### PR TITLE
Add emoji fallback for categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ Simply open `index.html` in any modern web browser. You can double‑click the f
 - Prompter currently supports **English** (`EN`) and **Turkish** (`TR`).
 - Use the language switcher in the top‑right corner to choose your interface language. The setting persists in your browser.
 
+## Categories
+Prompter offers a variety of prompt themes. Select a category by clicking its icon in the **Select Your Prompt Inspiration** area.
+
+- **Random Mix** – picks from all categories
+- **Inspiring** – motivational or uplifting scenarios
+- **Mind-blowing** – speculative or reality‑bending ideas
+- **Productivity** – business and money-making strategies
+- **Educational** – quick lessons and knowledge tests
+- **Crazy** – absurd, darkly humorous situations
+- **Perspective** – rethink a situation from another angle
+- **AI** – prompts about artificial intelligence and the future
+- **Ideas** – pitches for apps, movies, books, and more
+- **Video** – concepts for short films or viral clips
+- **Image** – descriptions for unique visuals or logos
+- **Hellprompts** – unsettling horror themes
+
+If icon fonts fail to load, the app falls back to emoji symbols so the buttons remain visible.
+
+Example: click the **Video** icon, then press **Generate New Prompt** to create a video-related idea.
+
 ## License
 
 This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for the full text.


### PR DESCRIPTION
## Summary
- add emoji fallback icons so categories show without Lucide
- document icon fallback in README

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68449a2e0550832f889a2e54871b6d4e