### PR TITLE
Increase prompt variety

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Prompter offers a variety of prompt themes. Select a category by clicking its ic
 - **Image** – descriptions for unique visuals or logos
 - **Hellprompts** – unsettling horror themes
 
+With at least four parts and ten choices per part, each category now provides around 10,000 unique prompts. Across all categories this adds up to more than **110,000** possible combinations.
+
 If icon fonts fail to load, the app falls back to emoji symbols so the buttons remain visible.
 
 If the TailwindCSS CDN is unreachable, a local copy bundled with the app is loaded automatically so the interface still looks correct.

--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
         theme: 'dark', // Default theme
         history: [],        // overall prompt history
         partHistory: [],    // per-part history
-        HISTORY_SIZE: 50    // Increased history size
+        HISTORY_SIZE: 100    // Increased history size
     };
 
     // --- Utility Functions ---
@@ -361,187 +361,1155 @@
 
         // --- Prompt Templates ---
         const prompts = {
-            en: {
-                inspiring: {
-                    parts: [
-                        ["Imagine", "Describe", "Write about"],
-                        ["overcoming a challenge", "finding unexpected hope", "joining together for change"],
-                        ["to inspire others.", "for a brighter future.", "and transform lives."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                mindBlowing: {
-                    parts: [
-                        ["Consider a world where", "Imagine if", "What if"],
-                        ["gravity reversed", "humans could teleport", "time flowed backwards"],
-                        ["How would society react?", "What would change?", "Would we adapt?"]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]}. ${p[2]}`
-                },
-                productivity: {
-                    parts: [
-                        ["Develop a system to", "Create a plan to", "Design a routine that"],
-                        ["avoid distractions", "maximize focus", "boost efficiency"],
-                        ["for sustained results.", "without burnout.", "each day."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                educational: {
-                    parts: [
-                        ["Explain", "Teach", "Break down"],
-                        ["quantum physics", "the human brain", "machine learning"],
-                        ["in simple terms.", "for beginners.", "with real-world examples."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                crazy: {
-                    parts: [
-                        ["Write a scene where", "Imagine a situation where", "Describe a world where"],
-                        ["cats rule the earth", "bananas are sentient", "gravity is optional"],
-                        ["resulting in chaos.", "with hilarious outcomes.", "confusing everyone."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                perspective: {
-                    parts: [
-                        ["From a different point of view,", "Looking from space,", "Through the eyes of a child,"],
-                        ["consider love", "see the daily routine", "understand conflict"],
-                        ["to gain new insight.", "and feel small.", "in a fresh way."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                ai: {
-                    parts: [
-                        ["Design an AI that", "Imagine artificial intelligence that", "Write about a robot that"],
-                        ["solves world hunger", "creates art autonomously", "learns emotions"],
-                        ["and benefits humanity.", "challenging ethics.", "changing our future."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                ideas: {
-                    parts: [
-                        ["Come up with a business idea for", "Brainstorm a project involving", "Propose a product based on"],
-                        ["renewable energy", "virtual reality", "smart home tech"],
-                        ["that stands out.", "for mass adoption.", "with minimal cost."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                video: {
-                    parts: [
-                        ["Pitch a viral video idea about", "Create a short film concept focusing on", "Outline a documentary exploring", "Write a sketch where", "Describe an animation that depicts", "Come up with a comedic scene about", "Plan a tutorial video demonstrating", "Imagine a high-action sequence showing", "Design a motivational speech for", "Sketch a series of clips capturing"],
-                        ["future technology disrupting everyday life", "unexpected encounters between historical figures", "a day in the life of a forgotten hero", "fun science experiments with household items", "an epic quest in a miniature world", "interviews with people from parallel universes", "exploring abandoned places with drones", "DIY inventions that solve silly problems", "a competition between famous internet memes", "a behind-the-scenes look at a blockbuster movie"],
-                        ["Which camera angles or editing tricks would keep viewers hooked?", "How should the soundtrack enhance the mood?", "What plot twist would make it unforgettable?", "Which visual effects will add wow factor?", "How can the pacing maximize suspense?", "What narration style best fits the concept?", "How would you structure the climax for impact?", "What theme ties all the scenes together?", "How could you involve audience participation?", "What surprising cameo could top it off?"]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]}, ${p[2]}`
-                },
-                image: {
-                    parts: [
-                        ["Create an image of", "Draw a detailed illustration of", "Generate a surreal picture featuring", "Design a minimalistic logo based on", "Sketch a fantasy scene portraying", "Imagine a futuristic concept of", "Paint a portrait of", "Compose a landscape showing", "Develop a comic panel about", "Draft a poster that advertises"],
-                        ["a mythical creature riding a bicycle", "a city floating in the clouds", "a robot chef cooking breakfast", "an ancient tree with glowing runes", "a clash between superheroes and villains", "a tranquil village at dusk", "a festival on another planet", "a famous musician as a cartoon hero", "a historical event reimagined in cyberpunk style", "a friendly AI assisting humans"],
-                        ["Use vibrant neon colors.", "Make it black and white with strong contrast.", "Use a watercolor texture for a soft look.", "Employ a retro 80s aesthetic.", "Apply a dark gothic mood.", "Add whimsical elements for humor.", "Make it appear photorealistic.", "Use a geometric abstract style.", "Give it a steampunk flair.", "Blend in glitch art effects."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                hellprompts: {
-                    parts: [
-                        ["Describe the feeling when", "Imagine the horror of", "Write about the moment"],
-                        ["shadows whisper", "time stops", "your reflection moves"],
-                        ["driving you insane.", "beyond comprehension.", "and nothing feels real."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                }
-            },
-            tr: {
-                inspiring: {
-                    parts: [
-                        ["Şunu hayal et:", "Şunu anlat:", "Bunu yaz:"],
-                        ["zorluğun üstesinden gelmek", "beklenmedik umut bulmak", "değişim için bir araya gelmek"],
-                        ["başkalarına ilham vermek için.", "daha parlak bir gelecek için.", "ve hayatları dönüştürmek için."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                mindBlowing: {
-                    parts: [
-                        ["Şöyle bir dünya düşün:", "Ya şöyle olsaydı:", "Şu olasılığı hayal et:"],
-                        ["yerçekimi tersine dönse", "insanlar ışınlansa", "zaman geriye aksa"],
-                        ["Toplum nasıl tepki verir?", "Neler değişirdi?", "Uyum sağlayabilir miydik?"]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]}. ${p[2]}`
-                },
-                productivity: {
-                    parts: [
-                        ["Bir sistem geliştir:", "Bir plan oluştur:", "Bir rutin tasarla:"],
-                        ["dikkat dağıtıcıları önlemek", "odaklanmayı artırmak", "verimliliği yükseltmek"],
-                        ["kalıcı sonuçlar için.", "yorulmadan.", "her gün."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                educational: {
-                    parts: [
-                        ["Şunu açıkla:", "Şunu öğret:", "Şunu basitleştir:"],
-                        ["kuantum fiziği", "insan beyni", "makine öğrenimi"],
-                        ["basit terimlerle.", "yeni başlayanlara.", "gerçek örneklerle."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                crazy: {
-                    parts: [
-                        ["Şöyle bir sahne yaz:", "Şu durumu düşün:", "Şöyle bir dünya anlat:"],
-                        ["kediler dünyayı yönetse", "muzlar bilinçli olsa", "yerçekimi isteğe bağlı olsa"],
-                        ["tam bir kaos olur.", "komik sonuçlarla.", "herkes şaşırır."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                perspective: {
-                    parts: [
-                        ["Farklı bir bakış açısıyla,", "Uzaydan bakıldığında,", "Bir çocuğun gözünden,"],
-                        ["aşkı düşün", "günlük rutine bak", "çatışmayı anla"],
-                        ["yeni bir anlayış için.", "ve kendini küçük hisset.", "farklı bir şekilde."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                ai: {
-                    parts: [
-                        ["Şöyle bir YZ tasarla:", "Şöyle bir yapay zeka düşün:", "Bir robot hakkında yaz:"],
-                        ["dünyadaki açlığı çözen", "kendi başına sanat üreten", "duyguları öğrenen"],
-                        ["ve insanlığa faydalı olan.", "etik tartışmalara yol açan.", "geleceğimizi değiştiren."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                ideas: {
-                    parts: [
-                        ["Şu alan için bir iş fikri:", "Şöyle bir proje öner:", "Şu ürünü tasarla:"],
-                        ["yenilenebilir enerji", "sanal gerçeklik", "akıllı ev teknolojisi"],
-                        ["fark yaratacak.", "geniş kitlelere hitap eden.", "düşük maliyetli."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                video: {
-                    parts: [
-                        ["Viral olacak bir video fikri ver:", "Şuna odaklanan kısa film konsepti oluştur:", "Şunu keşfeden bir belgesel tasla:", "Şöyle bir skeç yaz:", "Şunu tasvir eden bir animasyon anlat:", "Şu konuda komik bir sahne düşün:", "Şunu öğreten bir eğitim videosu planla:", "Şunu gösteren aksiyon dolu bir sekans hayal et:", "Şu konu için motive edici bir konuşma hazırla:", "Şu anları yakalayan klipler dizisi tasarla:"],
-                        ["günlük yaşamı değiştiren geleceğin teknolojisi", "tarihî kişilerin beklenmedik karşılaşmaları", "unutulmuş bir kahramanın bir günü", "evde yapılacak eğlenceli bilim deneyleri", "minyatür bir dünyada destansı bir macera", "paralel evrenlerden insanlarla röportajlar", "dronlarla terk edilmiş yerlerin keşfi", "saçma sorunlara çözüm bulan icatlar", "ünlü internet memeleri arasında bir yarışma", "bir gişe rekortmeni filmin kamera arkası"],
-                        ["İzleyiciyi ekranda tutacak kamera açıları neler olmalı?", "Müzik atmosferi nasıl güçlendirmeli?", "Hangi sürpriz son unutulmaz kılar?", "Hangi görsel efektler şaşırtıcı olur?", "Gerilimi artırmak için tempo nasıl olmalı?", "Hangi anlatım tarzı en uygun olur?", "Finali etkileyici kılmak için nasıl kurgularsın?", "Tüm sahneleri birleştiren tema ne?", "Seyircinin katılımı nasıl sağlanır?", "Hangi beklenmedik cameo işi taçlandırır?"]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]}, ${p[2]}`
-                },
-                image: {
-                    parts: [
-                        ["Şunun görselini oluştur:", "Detaylı bir çizimini yap:", "Şu unsurları içeren sürreal bir resim üret:", "Şuna dayalı minimal bir logo tasarla:", "Şu fantastik sahneyi çiz:", "Şunun futuristik bir yorumunu hayal et:", "Şunun portresini boya:", "Şu manzarayı tasvir et:", "Şu konu hakkında bir çizgi roman karesi oluştur:", "Şunu tanıtan bir afiş tasla:"],
-                        ["bisiklete binen efsanevi bir yaratık", "bulutların üzerinde yüzen bir şehir", "kahvaltı pişiren robot bir aşçı", "parlayan rünlerle süslü kadim bir ağaç", "süper kahramanlar ile kötülerin çarpışması", "alacakaranlıkta huzurlu bir köy", "başka bir gezegende festival", "çizgi film kahramanı olarak ünlü bir müzisyen", "siberpunk tarzında yeniden tasarlanmış tarihî bir olay", "insanlara yardımcı olan sevimli bir yapay zeka"],
-                        ["Canlı neon renkler kullan.", "Siyah beyaz ve yüksek kontrast olsun.", "Yumuşak bir görünüm için sulu boya dokusu kullan.", "Retro 80'ler estetiği uygula.", "Karanlık gotik bir hava ver.", "Eğlenceli detaylar ekle.", "Fotoğraf gerçekçiliğinde olsun.", "Geometrik soyut bir stil kullan.", "Steampunk dokunuşları ekle.", "Glitch efektleriyle harmanla."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                },
-                hellprompts: {
-                    parts: [
-                        ["Şu anı tarif et:", "Şu korkuyu hayal et:", "Şu anı yaz:"],
-                        ["gölgeler fısıldadığında", "zaman durduğunda", "yansıman hareket ettiğinde"],
-                        ["akıl sağlığını yitirirsin.", "anlamanın ötesinde.", "ve gerçeklik kaybolur."]
-                    ],
-                    structure: (p) => `${p[0]} ${p[1]} ${p[2]}`
-                }
-            }
-        };
+    "en": {
+        "inspiring": {
+            "parts": [
+                [
+                    "Imagine",
+                    "Describe",
+                    "Write about",
+                    "Tell a story where",
+                    "Visualize",
+                    "Explain how",
+                    "Compose a poem about",
+                    "Share an anecdote about",
+                    "Outline steps to",
+                    "Give advice on"
+                ],
+                [
+                    "overcoming a challenge",
+                    "discovering hidden strength",
+                    "finding unexpected hope",
+                    "helping others succeed",
+                    "standing up for what's right",
+                    "uniting different cultures",
+                    "embracing change",
+                    "creating opportunities",
+                    "following a dream",
+                    "turning fear into courage"
+                ],
+                [
+                    "that sparks motivation",
+                    "leading to personal growth",
+                    "that inspires a community",
+                    "that transforms lives",
+                    "that spreads positivity",
+                    "that brings people together",
+                    "that opens new horizons",
+                    "that encourages creativity",
+                    "that shifts perspectives",
+                    "that moves hearts"
+                ],
+                [
+                    "for the next generation.",
+                    "with lasting results.",
+                    "in your everyday life.",
+                    "to share with friends.",
+                    "that resonates globally.",
+                    "for a brighter future.",
+                    "in your local community.",
+                    "to spark social change.",
+                    "as a lifelong habit.",
+                    "for anyone seeking progress."
+                ]
+            ]
+        },
+        "mindBlowing": {
+            "parts": [
+                [
+                    "Consider a world where",
+                    "Imagine if",
+                    "What if",
+                    "Suppose we discovered",
+                    "Envision a reality where",
+                    "Think about a time when",
+                    "Picture a universe where",
+                    "Assume technology enabled",
+                    "Dream of a scenario where",
+                    "Pretend that"
+                ],
+                [
+                    "gravity reversed",
+                    "humans could teleport",
+                    "time flowed backwards",
+                    "everyone shared thoughts",
+                    "aliens lived among us",
+                    "dreams predicted the future",
+                    "we controlled the weather",
+                    "life existed on Mars",
+                    "machines ruled society",
+                    "history kept repeating"
+                ],
+                [
+                    "How would society react?",
+                    "What would change?",
+                    "Would we adapt?",
+                    "Could humanity survive?",
+                    "Would ethics evolve?",
+                    "How would governments respond?",
+                    "Would art flourish or die?",
+                    "How would culture shift?",
+                    "Could chaos be avoided?",
+                    "Would new rules emerge?"
+                ],
+                [
+                    "Explore the consequences.",
+                    "Debate the possibilities.",
+                    "Describe the first reactions.",
+                    "Predict long-term effects.",
+                    "Explain potential benefits.",
+                    "Consider moral dilemmas.",
+                    "Discuss scientific hurdles.",
+                    "Outline the social impact.",
+                    "Reflect on personal freedoms.",
+                    "Analyze economic changes."
+                ]
+            ]
+        },
+        "productivity": {
+            "parts": [
+                [
+                    "Develop a system to",
+                    "Create a plan to",
+                    "Design a routine that",
+                    "Draft a strategy for",
+                    "Map out a schedule to",
+                    "Build a toolkit that",
+                    "Organize a workflow to",
+                    "Formulate habits that",
+                    "Set up a framework to",
+                    "Write a checklist to"
+                ],
+                [
+                    "avoid distractions",
+                    "maximize focus",
+                    "boost efficiency",
+                    "balance work and life",
+                    "achieve daily goals",
+                    "reduce procrastination",
+                    "manage time wisely",
+                    "increase motivation",
+                    "maintain consistency",
+                    "streamline tasks"
+                ],
+                [
+                    "for sustained results",
+                    "without burnout",
+                    "each day",
+                    "over the long term",
+                    "while keeping energy high",
+                    "with measurable milestones",
+                    "for a team environment",
+                    "while staying flexible",
+                    "to track progress",
+                    "for continuous improvement"
+                ],
+                [
+                    "Use practical examples.",
+                    "Include helpful tools.",
+                    "Mention common pitfalls.",
+                    "Add motivational tips.",
+                    "Highlight real success stories.",
+                    "Break it into simple steps.",
+                    "Suggest useful apps.",
+                    "Explain how to measure success.",
+                    "Emphasize mindset shifts.",
+                    "Keep instructions concise."
+                ]
+            ]
+        },
+        "educational": {
+            "parts": [
+                [
+                    "Explain",
+                    "Teach",
+                    "Break down",
+                    "Summarize",
+                    "Demonstrate",
+                    "Provide an overview of",
+                    "Give a lesson on",
+                    "Clarify",
+                    "Outline",
+                    "Present"
+                ],
+                [
+                    "quantum physics",
+                    "the human brain",
+                    "machine learning",
+                    "ancient history",
+                    "the solar system",
+                    "genetic engineering",
+                    "economics basics",
+                    "environmental science",
+                    "philosophical theories",
+                    "modern art movements"
+                ],
+                [
+                    "in simple terms",
+                    "for beginners",
+                    "with real-world examples",
+                    "using everyday language",
+                    "with engaging activities",
+                    "highlighting key figures",
+                    "showing step-by-step methods",
+                    "including common mistakes",
+                    "with interactive exercises",
+                    "to spark curiosity"
+                ],
+                [
+                    "Keep it short.",
+                    "Add diagrams if needed.",
+                    "Use analogies.",
+                    "Make it conversational.",
+                    "Provide links for further reading.",
+                    "Emphasize why it matters.",
+                    "Include a quick quiz.",
+                    "Suggest follow-up projects.",
+                    "Share interesting trivia.",
+                    "Relate it to daily life."
+                ]
+            ]
+        },
+        "crazy": {
+            "parts": [
+                [
+                    "Write a scene where",
+                    "Imagine a situation where",
+                    "Describe a world where",
+                    "Tell a story about",
+                    "Picture a reality where",
+                    "Concoct a plot in which",
+                    "Invent a scenario where",
+                    "Dream up a setting where",
+                    "Design a tale in which",
+                    "Create a narrative where"
+                ],
+                [
+                    "cats rule the earth",
+                    "bananas are sentient",
+                    "gravity is optional",
+                    "everyone speaks in rhyme",
+                    "vegetables have superpowers",
+                    "people trade memories",
+                    "robots tell jokes",
+                    "rivers flow upward",
+                    "books fly like birds",
+                    "phones have feelings"
+                ],
+                [
+                    "resulting in chaos",
+                    "with hilarious outcomes",
+                    "confusing everyone",
+                    "turning logic upside down",
+                    "causing endless laughter",
+                    "leading to epic adventures",
+                    "that nobody can predict",
+                    "sparking strange friendships",
+                    "changing the laws of physics",
+                    "that rewrite history"
+                ],
+                [
+                    "Make it witty.",
+                    "Keep the tone light.",
+                    "Add unexpected twists.",
+                    "Use vivid imagery.",
+                    "Blend humor with suspense.",
+                    "Include quirky characters.",
+                    "Let imagination run wild.",
+                    "Set an outrageous pace.",
+                    "End on a surprising note.",
+                    "Leave readers wanting more."
+                ]
+            ]
+        },
+        "perspective": {
+            "parts": [
+                [
+                    "From a different point of view,",
+                    "Looking from space,",
+                    "Through the eyes of a child,",
+                    "As an ancient philosopher,",
+                    "From a future historian,",
+                    "Through a photographer's lens,",
+                    "As a time traveler,",
+                    "From the viewpoint of nature,",
+                    "Through the mind of an AI,",
+                    "From an outsider's perspective,"
+                ],
+                [
+                    "consider love",
+                    "see the daily routine",
+                    "understand conflict",
+                    "explore technology",
+                    "question society",
+                    "reflect on art",
+                    "observe human habits",
+                    "analyze language",
+                    "study emotions",
+                    "review history"
+                ],
+                [
+                    "to gain new insight",
+                    "and feel small",
+                    "in a fresh way",
+                    "and spark debate",
+                    "for deeper meaning",
+                    "and challenge beliefs",
+                    "to inspire change",
+                    "and appreciate diversity",
+                    "for unexpected humor",
+                    "to imagine possibilities"
+                ],
+                [
+                    "Keep it reflective.",
+                    "Use sensory details.",
+                    "Invite empathy.",
+                    "Ask thought-provoking questions.",
+                    "Reveal hidden angles.",
+                    "Encourage open-mindedness.",
+                    "Highlight contrasts.",
+                    "Finish with a takeaway.",
+                    "Balance optimism and realism.",
+                    "Connect back to the reader."
+                ]
+            ]
+        },
+        "ai": {
+            "parts": [
+                [
+                    "Design an AI that",
+                    "Imagine artificial intelligence that",
+                    "Write about a robot that",
+                    "Propose a machine that",
+                    "Describe software that",
+                    "Envision technology that",
+                    "Sketch a future where AI",
+                    "Draft a concept for a bot that",
+                    "Outline an algorithm that",
+                    "Create a system that"
+                ],
+                [
+                    "solves world hunger",
+                    "creates art autonomously",
+                    "learns emotions",
+                    "protects the environment",
+                    "teaches any language",
+                    "optimizes city traffic",
+                    "cures diseases",
+                    "enhances human memory",
+                    "predicts natural disasters",
+                    "personalizes education"
+                ],
+                [
+                    "and benefits humanity",
+                    "challenging ethics",
+                    "changing our future",
+                    "raising new questions",
+                    "earning global praise",
+                    "sparking controversy",
+                    "reshaping industries",
+                    "leading to cooperation",
+                    "outpacing regulations",
+                    "inspiring creativity"
+                ],
+                [
+                    "Focus on possibilities.",
+                    "Consider safety issues.",
+                    "Explore moral implications.",
+                    "Describe user interactions.",
+                    "Highlight potential risks.",
+                    "Offer real-world examples.",
+                    "Examine social impact.",
+                    "Predict next steps.",
+                    "Address privacy concerns.",
+                    "Keep tone optimistic."
+                ]
+            ]
+        },
+        "ideas": {
+            "parts": [
+                [
+                    "Come up with a business idea for",
+                    "Brainstorm a project involving",
+                    "Propose a product based on",
+                    "Suggest a startup around",
+                    "Create a service that uses",
+                    "Invent an app for",
+                    "Design a campaign promoting",
+                    "Develop a workshop about",
+                    "Sketch a book centered on",
+                    "Draft a course teaching"
+                ],
+                [
+                    "renewable energy",
+                    "virtual reality",
+                    "smart home tech",
+                    "healthy living",
+                    "local tourism",
+                    "artisanal crafts",
+                    "mobile gaming",
+                    "remote work solutions",
+                    "financial literacy",
+                    "sustainable fashion"
+                ],
+                [
+                    "that stands out",
+                    "for mass adoption",
+                    "with minimal cost",
+                    "targeting young adults",
+                    "with global reach",
+                    "that sparks community",
+                    "using modern tools",
+                    "leveraging social media",
+                    "with scalable growth",
+                    "appealing to investors"
+                ],
+                [
+                    "Outline key features.",
+                    "Explain the target market.",
+                    "Mention potential partners.",
+                    "Describe revenue streams.",
+                    "Highlight unique selling points.",
+                    "Suggest marketing tactics.",
+                    "Estimate startup costs.",
+                    "Point out challenges.",
+                    "Show long-term vision.",
+                    "Add why it excites you."
+                ]
+            ]
+        },
+        "video": {
+            "parts": [
+                [
+                    "Pitch a viral video idea about",
+                    "Create a short film concept focusing on",
+                    "Outline a documentary exploring",
+                    "Write a sketch where",
+                    "Describe an animation that depicts",
+                    "Come up with a comedic scene about",
+                    "Plan a tutorial video demonstrating",
+                    "Imagine a high-action sequence showing",
+                    "Design a motivational speech for",
+                    "Sketch a series of clips capturing"
+                ],
+                [
+                    "future technology disrupting everyday life",
+                    "unexpected encounters between historical figures",
+                    "a day in the life of a forgotten hero",
+                    "fun science experiments with household items",
+                    "an epic quest in a miniature world",
+                    "interviews with people from parallel universes",
+                    "exploring abandoned places with drones",
+                    "DIY inventions that solve silly problems",
+                    "a competition between famous internet memes",
+                    "a behind-the-scenes look at a blockbuster movie"
+                ],
+                [
+                    "Which camera angles or editing tricks would keep viewers hooked?",
+                    "How should the soundtrack enhance the mood?",
+                    "What plot twist would make it unforgettable?",
+                    "Which visual effects will add wow factor?",
+                    "How can the pacing maximize suspense?",
+                    "What narration style best fits the concept?",
+                    "How would you structure the climax for impact?",
+                    "What theme ties all the scenes together?",
+                    "How could you involve audience participation?",
+                    "What surprising cameo could top it off?"
+                ],
+                [
+                    "Keep it short and snappy.",
+                    "Consider using humor.",
+                    "Focus on strong visuals.",
+                    "Add dramatic narration.",
+                    "Shoot in interesting locations.",
+                    "Use creative transitions.",
+                    "Incorporate audience participation.",
+                    "Match music to the mood.",
+                    "Include a surprising twist.",
+                    "End with a call to action."
+                ]
+            ]
+        },
+        "image": {
+            "parts": [
+                [
+                    "Create an image of",
+                    "Draw a detailed illustration of",
+                    "Generate a surreal picture featuring",
+                    "Design a minimalistic logo based on",
+                    "Sketch a fantasy scene portraying",
+                    "Imagine a futuristic concept of",
+                    "Paint a portrait of",
+                    "Compose a landscape showing",
+                    "Develop a comic panel about",
+                    "Draft a poster that advertises"
+                ],
+                [
+                    "a mythical creature riding a bicycle",
+                    "a city floating in the clouds",
+                    "a robot chef cooking breakfast",
+                    "an ancient tree with glowing runes",
+                    "a clash between superheroes and villains",
+                    "a tranquil village at dusk",
+                    "a festival on another planet",
+                    "a famous musician as a cartoon hero",
+                    "a historical event reimagined in cyberpunk style",
+                    "a friendly AI assisting humans"
+                ],
+                [
+                    "Use vibrant neon colors.",
+                    "Make it black and white with strong contrast.",
+                    "Use a watercolor texture for a soft look.",
+                    "Employ a retro 80s aesthetic.",
+                    "Apply a dark gothic mood.",
+                    "Add whimsical elements for humor.",
+                    "Make it appear photorealistic.",
+                    "Use a geometric abstract style.",
+                    "Give it a steampunk flair.",
+                    "Blend in glitch art effects."
+                ],
+                [
+                    "Use bold colors.",
+                    "Keep composition balanced.",
+                    "Experiment with lighting.",
+                    "Add a touch of surrealism.",
+                    "Blend realistic and abstract elements.",
+                    "Focus on texture.",
+                    "Try an unusual perspective.",
+                    "Incorporate hidden symbols.",
+                    "Emphasize contrast.",
+                    "Leave room for imagination."
+                ]
+            ]
+        },
+        "hellprompts": {
+            "parts": [
+                [
+                    "Describe the feeling when",
+                    "Imagine the horror of",
+                    "Write about the moment",
+                    "Detail the nightmare where",
+                    "Whisper about the time",
+                    "Depict the terror as",
+                    "Recall the scene when",
+                    "Explain the dread of",
+                    "Share the vision where",
+                    "Reveal the instant when"
+                ],
+                [
+                    "shadows whisper",
+                    "time stops",
+                    "your reflection moves",
+                    "voices echo from the dark",
+                    "light fades away",
+                    "the ground melts",
+                    "a cold breath follows you",
+                    "every door disappears",
+                    "blood rains from the sky",
+                    "eyes watch from the walls"
+                ],
+                [
+                    "driving you insane",
+                    "beyond comprehension",
+                    "and nothing feels real",
+                    "until screams fade",
+                    "as reality cracks",
+                    "while sanity slips",
+                    "until hope dies",
+                    "as nightmares awaken",
+                    "while terror consumes all",
+                    "until time collapses"
+                ],
+                [
+                    "Make it unsettling.",
+                    "Keep details visceral.",
+                    "Emphasize suspense.",
+                    "Use disturbing imagery.",
+                    "Let fear build slowly.",
+                    "Leave some mystery.",
+                    "Avoid clichés.",
+                    "Heighten the tension.",
+                    "End with a lingering chill.",
+                    "Write in first person."
+                ]
+            ]
+        }
+    },
+    "tr": {
+        "inspiring": {
+            "parts": [
+                [
+                    "Hayal et",
+                    "Tasvir et",
+                    "Şunu yaz",
+                    "Bir hikaye anlat",
+                    "Gözünde canlandır",
+                    "Nasıl olduğunu açıkla",
+                    "Bu konuda bir şiir yaz",
+                    "Bu konuda bir anı paylaş",
+                    "Adımları özetle",
+                    "Şu konuda tavsiye ver"
+                ],
+                [
+                    "bir zorluğu aşmayı",
+                    "gizli gücü keşfetmeyi",
+                    "beklenmedik umudu bulmayı",
+                    "başkalarının başarısına yardım etmeyi",
+                    "doğru olan için ayağa kalkmayı",
+                    "farklı kültürleri birleştirmeyi",
+                    "değişimi kucaklamayı",
+                    "fırsatlar yaratmayı",
+                    "bir hayalin peşinden gitmeyi",
+                    "korkuyu cesarete dönüştürmeyi"
+                ],
+                [
+                    "motive eden",
+                    "kişisel gelişime yol açan",
+                    "topluma ilham veren",
+                    "hayatları dönüştüren",
+                    "pozitifliği yayan",
+                    "insanları bir araya getiren",
+                    "yeni ufuklar açan",
+                    "yaratıcılığı teşvik eden",
+                    "bakış açısını değiştiren",
+                    "kalpleri hareketlendiren"
+                ],
+                [
+                    "gelecek nesil için.",
+                    "kalıcı sonuçlarla.",
+                    "günlük hayatında.",
+                    "arkadaşlarınla paylaşmak için.",
+                    "tüm dünyaya hitap eden.",
+                    "daha parlak bir gelecek için.",
+                    "yerel topluluğunda.",
+                    "toplumsal değişim için.",
+                    "ömür boyu sürecek bir alışkanlık olarak.",
+                    "ilerleme arayan herkes için."
+                ]
+            ]
+        },
+        "mindBlowing": {
+            "parts": [
+                [
+                    "Şöyle bir dünya düşün ki",
+                    "Ya şöyle olsaydı",
+                    "Varsay ki",
+                    "Keşfettiğimizi düşün ki",
+                    "Şu gerçeği hayal et ki",
+                    "Şöyle bir zaman düşün ki",
+                    "Şöyle bir evren düşün ki",
+                    "Teknolojinin sağladığını varsayalım ki",
+                    "Şu senaryoyu hayal et ki",
+                    "Diyelim ki"
+                ],
+                [
+                    "yerçekimi ters dönüyor",
+                    "insanlar ışınlanabiliyor",
+                    "zaman geri akıyor",
+                    "herkes düşüncelerini paylaşıyor",
+                    "uzaylılar aramızda yaşıyor",
+                    "rüyalar geleceği haber veriyor",
+                    "hava durumunu kontrol ediyoruz",
+                    "Mars'ta yaşam var",
+                    "makineler toplumu yönetiyor",
+                    "tarih tekrar tekrar yaşanıyor"
+                ],
+                [
+                    "Toplum nasıl tepki verir?",
+                    "Neler değişirdi?",
+                    "Uyum sağlayabilir miydik?",
+                    "İnsanlık hayatta kalabilir mi?",
+                    "Etik nasıl evrilir?",
+                    "Hükümetler nasıl tepki verir?",
+                    "Sanat gelişir mi yok olur mu?",
+                    "Kültür nasıl değişir?",
+                    "Kaos önlenebilir mi?",
+                    "Yeni kurallar oluşur mu?"
+                ],
+                [
+                    "Sonuçlarını keşfet.",
+                    "Olasılıkları tartış.",
+                    "İlk tepkileri anlat.",
+                    "Uzun vadeli etkileri tahmin et.",
+                    "Olası faydaları açıkla.",
+                    "Ahlaki ikilemleri düşün.",
+                    "Bilimsel zorlukları ele al.",
+                    "Sosyal etkileri özetle.",
+                    "Kişisel özgürlükleri değerlendir.",
+                    "Ekonomik değişimi analiz et."
+                ]
+            ]
+        },
+        "productivity": {
+            "parts": [
+                [
+                    "Şöyle bir sistem geliştir:",
+                    "Şöyle bir plan oluştur:",
+                    "Şöyle bir rutin tasarla:",
+                    "Şöyle bir strateji yaz:",
+                    "Şöyle bir zaman çizelgesi hazırla:",
+                    "Şöyle bir araç seti oluştur:",
+                    "Şöyle bir iş akışı düzenle:",
+                    "Şu alışkanlıkları belirle:",
+                    "Şöyle bir çerçeve kur:",
+                    "Şu kontrol listesini yaz:"
+                ],
+                [
+                    "dikkat dağıtıcıları önlemek",
+                    "odaklanmayı en üst düzeye çıkarmak",
+                    "verimliliği artırmak",
+                    "iş ve yaşam dengesini kurmak",
+                    "günlük hedeflere ulaşmak",
+                    "erteleme alışkanlığını azaltmak",
+                    "zamanı akıllıca yönetmek",
+                    "motivasyonu artırmak",
+                    "istikrarı sürdürmek",
+                    "görevleri kolaylaştırmak"
+                ],
+                [
+                    "kalıcı sonuçlar için",
+                    "yorulmadan",
+                    "her gün",
+                    "uzun vadede",
+                    "enerjiyi yüksek tutarak",
+                    "ölçülebilir aşamalarla",
+                    "takım ortamında",
+                    "esnek kalarak",
+                    "ilerlemeyi takip ederek",
+                    "sürekli iyileştirme için"
+                ],
+                [
+                    "Pratik örnekler kullan.",
+                    "Faydalı araçlar ekle.",
+                    "Yaygın tuzaklardan bahset.",
+                    "Motivasyon ipuçları ver.",
+                    "Gerçek başarı hikayeleri ekle.",
+                    "Adımları basitleştir.",
+                    "Kullanışlı uygulamalar öner.",
+                    "Başarıyı nasıl ölçeceğini açıkla.",
+                    "Zihniyet değişimine vurgu yap.",
+                    "Talimatları kısa tut."
+                ]
+            ]
+        },
+        "educational": {
+            "parts": [
+                [
+                    "Şunu açıkla:",
+                    "Şunu öğret:",
+                    "Şunu basitleştir:",
+                    "Şunu özetle:",
+                    "Şunu göster:",
+                    "Şunun genelini anlat:",
+                    "Şu konuda ders ver:",
+                    "Şunu netleştir:",
+                    "Şunu sıralandır:",
+                    "Şunu sun:"
+                ],
+                [
+                    "kuantum fiziği",
+                    "insan beyni",
+                    "makine öğrenimi",
+                    "antik tarih",
+                    "güneş sistemi",
+                    "genetik mühendisliği",
+                    "ekonomi temelleri",
+                    "çevre bilimi",
+                    "felsefi teoriler",
+                    "modern sanat akımları"
+                ],
+                [
+                    "basit terimlerle",
+                    "yeni başlayanlar için",
+                    "gerçek örneklerle",
+                    "günlük dil kullanarak",
+                    "etkileyici aktivitelerle",
+                    "önemli kişiler vurgulanarak",
+                    "adım adım yöntemlerle",
+                    "yaygın hataları dahil ederek",
+                    "etkileşimli alıştırmalarla",
+                    "merak uyandırmak için"
+                ],
+                [
+                    "Kısa tut.",
+                    "Gerekirse şemalar ekle.",
+                    "Benzetmeler kullan.",
+                    "Sohbet havasında olsun.",
+                    "Daha fazla okuma için bağlantı ver.",
+                    "Neden önemli olduğunu belirt.",
+                    "Hızlı bir test ekle.",
+                    "Devam projeleri öner.",
+                    "İlginç bilgiler paylaş.",
+                    "Günlük hayatla ilişkilendir."
+                ]
+            ]
+        },
+        "crazy": {
+            "parts": [
+                [
+                    "Şöyle bir sahne yaz:",
+                    "Şu durumu düşün:",
+                    "Şöyle bir dünya anlat:",
+                    "Şu hikayeyi kur:",
+                    "Şöyle bir gerçeklik tasvir et:",
+                    "Şu kurguyu yarat:",
+                    "Şöyle bir senaryo icat et:",
+                    "Şöyle bir ortam hayal et:",
+                    "Şu masalı tasarla:",
+                    "Şöyle bir öykü oluştur:"
+                ],
+                [
+                    "kediler dünyayı yönetse",
+                    "muzlar bilinçli olsa",
+                    "yerçekimi isteğe bağlı olsa",
+                    "herkes kafiyeli konuşsa",
+                    "sebzeler süper güçlere sahip olsa",
+                    "insanlar anılarını takas etse",
+                    "robotlar fıkra anlatsa",
+                    "nehirler yukarı aksa",
+                    "kitaplar kuş gibi uçsa",
+                    "telefonların duyguları olsa"
+                ],
+                [
+                    "tam bir kaos olur",
+                    "komik sonuçlarla",
+                    "herkes şaşırır",
+                    "mantık başaşağı olur",
+                    "sonsuz kahkahalara yol açar",
+                    "epik maceralara sürükler",
+                    "kimse tahmin edemez",
+                    "garip dostluklar doğar",
+                    "fizik kuralları değişir",
+                    "tarih yeniden yazılır"
+                ],
+                [
+                    "Mizahi olsun.",
+                    "Hafif bir ton kullan.",
+                    "Beklenmedik dönüşler ekle.",
+                    "Canlı betimlemeler yap.",
+                    "Humor ve gerilimi harmanla.",
+                    "Tuhaf karakterler kat.",
+                    "Hayal gücünü serbest bırak.",
+                    "Hızlı bir tempoda ilerle.",
+                    "Şaşırtıcı bir sonla bitir.",
+                    "Okuru merakta bırak."
+                ]
+            ]
+        },
+        "perspective": {
+            "parts": [
+                [
+                    "Farklı bir bakış açısıyla,",
+                    "Uzaydan bakıldığında,",
+                    "Bir çocuğun gözünden,",
+                    "Antik bir filozof olarak,",
+                    "Gelecekteki bir tarihçi olarak,",
+                    "Bir fotoğrafçının objektifinden,",
+                    "Bir zaman yolcusu olarak,",
+                    "Doğanın bakış açısından,",
+                    "Bir yapay zekânın zihninden,",
+                    "Dışarıdan bir gözle,"
+                ],
+                [
+                    "aşkı düşün",
+                    "günlük rutine bak",
+                    "çatışmayı anla",
+                    "teknolojiyi incele",
+                    "toplumu sorgula",
+                    "sanatı değerlendir",
+                    "insan alışkanlıklarını gözlemle",
+                    "dili analiz et",
+                    "duyguları incele",
+                    "tarihi gözden geçir"
+                ],
+                [
+                    "yeni bir anlayış için",
+                    "ve kendini küçük hisset",
+                    "farklı bir şekilde",
+                    "ve tartışma yarat",
+                    "daha derin anlamlar için",
+                    "ve inançları sorgula",
+                    "değişime ilham vermek için",
+                    "ve çeşitliliği takdir et",
+                    "beklenmedik espriler için",
+                    "olasılıkları hayal etmek için"
+                ],
+                [
+                    "Düşündürücü olsun.",
+                    "Duyusal ayrıntılar kullan.",
+                    "Empati kurmaya çağır.",
+                    "Soru sordur.",
+                    "Gizli yönleri açığa çıkar.",
+                    "Açık fikirliliği teşvik et.",
+                    "Karşıtlıkları vurgula.",
+                    "Bir çıkarımla bitir.",
+                    "İyimserlik ve gerçekçiliği dengede tut.",
+                    "Okuyucuya bağla."
+                ]
+            ]
+        },
+        "ai": {
+            "parts": [
+                [
+                    "Şöyle bir YZ tasarla:",
+                    "Şöyle bir yapay zeka düşün:",
+                    "Şu robot hakkında yaz:",
+                    "Şöyle bir makine öner:",
+                    "Şu yazılımı tarif et:",
+                    "Şöyle bir teknolojiyi hayal et:",
+                    "Şu geleceği çiz ki YZ",
+                    "Şöyle bir bot konsepti geliştir:",
+                    "Şu algoritmayı özetle:",
+                    "Şöyle bir sistem kur:"
+                ],
+                [
+                    "dünyadaki açlığı çözen",
+                    "kendi başına sanat üreten",
+                    "duyguları öğrenen",
+                    "çevreyi koruyan",
+                    "her dili öğreten",
+                    "şehir trafiğini optimize eden",
+                    "hastalıkları iyileştiren",
+                    "insan hafızasını güçlendiren",
+                    "doğal afetleri öngören",
+                    "eğitimi kişiselleştiren"
+                ],
+                [
+                    "ve insanlığa faydalı olan",
+                    "etik sorunlar yaratan",
+                    "geleceğimizi değiştiren",
+                    "yeni sorular doğuran",
+                    "dünya çapında övgü toplayan",
+                    "tartışmalara yol açan",
+                    "sektörleri yeniden şekillendiren",
+                    "iş birliğine yol açan",
+                    "yasal düzenlemelerin önüne geçen",
+                    "yaratıcılığı teşvik eden"
+                ],
+                [
+                    "Olasılıkları vurgula.",
+                    "Güvenlik konularını düşün.",
+                    "Ahlaki etkileri incele.",
+                    "Kullanıcı etkileşimini anlat.",
+                    "Potansiyel riskleri belirt.",
+                    "Gerçek örnekler ver.",
+                    "Sosyal etkileri tartış.",
+                    "Sonraki adımları öngör.",
+                    "Gizlilik endişelerini ele al.",
+                    "İyimser bir ton kullan."
+                ]
+            ]
+        },
+        "ideas": {
+            "parts": [
+                [
+                    "Şu alan için bir iş fikri üret:",
+                    "Şöyle bir proje beyin fırtınası yap:",
+                    "Şu ürüne dayalı bir öneri sun:",
+                    "Şu konuda bir girişim öner:",
+                    "Şöyle bir hizmet tasarla:",
+                    "Şu uygulamayı icat et:",
+                    "Şu kampanyayı tasarla:",
+                    "Şu konuda bir atölye geliştir:",
+                    "Şu kitap üzerine bir taslak çiz:",
+                    "Şu eğitimi öğreten bir kurs hazırla:"
+                ],
+                [
+                    "yenilenebilir enerji",
+                    "sanal gerçeklik",
+                    "akıllı ev teknolojisi",
+                    "sağlıklı yaşam",
+                    "yerel turizm",
+                    "el yapımı ürünler",
+                    "mobil oyunlar",
+                    "uzaktan çalışma çözümleri",
+                    "finansal okuryazarlık",
+                    "sürdürülebilir moda"
+                ],
+                [
+                    "fark yaratacak",
+                    "geniş kitlelere hitap eden",
+                    "düşük maliyetli",
+                    "genç yetişkinleri hedefleyen",
+                    "küresel erişimli",
+                    "topluluk oluşturacak",
+                    "modern araçlar kullanarak",
+                    "sosyal medyayı kullanarak",
+                    "ölçeklenebilir büyüme ile",
+                    "yatırımcıları cezbeden"
+                ],
+                [
+                    "Temel özellikleri özetle.",
+                    "Hedef pazarı açıkla.",
+                    "Olası ortakları belirt.",
+                    "Gelir kaynaklarını tanımla.",
+                    "Benzersiz yönlerini vurgula.",
+                    "Pazarlama taktikleri öner.",
+                    "Başlangıç maliyetini hesapla.",
+                    "Zorlukları belirt.",
+                    "Uzun vadeli vizyonu göster.",
+                    "Neden heyecan verici olduğunu söyle."
+                ]
+            ]
+        },
+        "video": {
+            "parts": [
+                [
+                    "Viral olacak bir video fikri ver:",
+                    "Şuna odaklanan kısa film konsepti oluştur:",
+                    "Şunu keşfeden bir belgesel tasla:",
+                    "Şöyle bir skeç yaz:",
+                    "Şunu tasvir eden bir animasyon anlat:",
+                    "Şu konuda komik bir sahne düşün:",
+                    "Şunu öğreten bir eğitim videosu planla:",
+                    "Şunu gösteren aksiyon dolu bir sekans hayal et:",
+                    "Şu konu için motive edici bir konuşma hazırla:",
+                    "Şu anları yakalayan klipler dizisi tasarla:"
+                ],
+                [
+                    "günlük yaşamı değiştiren geleceğin teknolojisi",
+                    "tarihî kişilerin beklenmedik karşılaşmaları",
+                    "unutulmuş bir kahramanın bir günü",
+                    "evde yapılacak eğlenceli bilim deneyleri",
+                    "minyatür bir dünyada destansı bir macera",
+                    "paralel evrenlerden insanlarla röportajlar",
+                    "dronlarla terk edilmiş yerlerin keşfi",
+                    "saçma sorunlara çözüm bulan icatlar",
+                    "ünlü internet memeleri arasında bir yarışma",
+                    "bir gişe rekortmeni filmin kamera arkası"
+                ],
+                [
+                    "İzleyiciyi ekranda tutacak kamera açıları neler olmalı?",
+                    "Müzik atmosferi nasıl güçlendirmeli?",
+                    "Hangi sürpriz son unutulmaz kılar?",
+                    "Hangi görsel efektler şaşırtıcı olur?",
+                    "Gerilimi artırmak için tempo nasıl olmalı?",
+                    "Hangi anlatım tarzı en uygun olur?",
+                    "Finali etkileyici kılmak için nasıl kurgularsın?",
+                    "Tüm sahneleri birleştiren tema ne?",
+                    "Seyircinin katılımı nasıl sağlanır?",
+                    "Hangi beklenmedik cameo işi taçlandırır?"
+                ],
+                [
+                    "Kısa ve akıcı tut.",
+                    "Mizah katmayı düşün.",
+                    "Güçlü görsellere odaklan.",
+                    "Dramatik anlatım ekle.",
+                    "İlginç mekânlar kullan.",
+                    "Yaratıcı geçişler kullan.",
+                    "İzleyiciyi dahil et.",
+                    "Müzği atmosfere uydur.",
+                    "Sürpriz bir dönemeç ekle.",
+                    "Eylem çağrısıyla bitir."
+                ]
+            ]
+        },
+        "image": {
+            "parts": [
+                [
+                    "Şunun görselini oluştur:",
+                    "Detaylı bir çizimini yap:",
+                    "Şu unsurları içeren sürreal bir resim üret:",
+                    "Şuna dayalı minimal bir logo tasarla:",
+                    "Şu fantastik sahneyi çiz:",
+                    "Şunun futuristik bir yorumunu hayal et:",
+                    "Şunun portresini boya:",
+                    "Şu manzarayı tasvir et:",
+                    "Şu konu hakkında bir çizgi roman karesi oluştur:",
+                    "Şunu tanıtan bir afiş tasla:"
+                ],
+                [
+                    "bisiklete binen efsanevi bir yaratık",
+                    "bulutların üzerinde yüzen bir şehir",
+                    "kahvaltı pişiren robot bir aşçı",
+                    "parlayan rünlerle süslü kadim bir ağaç",
+                    "süper kahramanlar ile kötülerin çarpışması",
+                    "alacakaranlıkta huzurlu bir köy",
+                    "başka bir gezegende festival",
+                    "çizgi film kahramanı olarak ünlü bir müzisyen",
+                    "siberpunk tarzında yeniden tasarlanmış tarihî bir olay",
+                    "insanlara yardımcı olan sevimli bir yapay zeka"
+                ],
+                [
+                    "Canlı neon renkler kullan.",
+                    "Siyah beyaz ve yüksek kontrast olsun.",
+                    "Yumuşak bir görünüm için sulu boya dokusu kullan.",
+                    "Retro 80'ler estetiği uygula.",
+                    "Karanlık gotik bir hava ver.",
+                    "Eğlenceli detaylar ekle.",
+                    "Fotoğraf gerçekçiliğinde olsun.",
+                    "Geometrik soyut bir stil kullan.",
+                    "Steampunk dokunuşları ekle.",
+                    "Glitch efektleriyle harmanla."
+                ],
+                [
+                    "Canlı renkler kullan.",
+                    "Kompozisyonu dengede tut.",
+                    "Işıkla denemeler yap.",
+                    "Biraz sürrealizm kat.",
+                    "Gerçekçi ve soyut öğeleri harmanla.",
+                    "Dokuya odaklan.",
+                    "Sıra dışı bir açı dene.",
+                    "Gizli semboller ekle.",
+                    "Kontrastı vurgula.",
+                    "Hayal gücüne yer bırak."
+                ]
+            ]
+        },
+        "hellprompts": {
+            "parts": [
+                [
+                    "Şu anı tarif et:",
+                    "Şu korkuyu hayal et:",
+                    "Şu anı yaz:",
+                    "Kabusu anlat ki",
+                    "O zamanı fısılda ki",
+                    "Dehşeti betimle ki",
+                    "Şu sahneyi hatırla ki",
+                    "Şu dehşetin nedenini açıkla ki",
+                    "Bu vizyonu paylaş ki",
+                    "O anı ortaya çıkar ki"
+                ],
+                [
+                    "gölgeler fısıldadığında",
+                    "zaman durduğunda",
+                    "yansıman hareket ettiğinde",
+                    "karanlıktan sesler geldiğinde",
+                    "ışık yok olduğunda",
+                    "yer eridiğinde",
+                    "soğuk nefes seni takip ettiğinde",
+                    "her kapı kaybolduğunda",
+                    "gökten kan yağdığında",
+                    "duvarlardan gözler seni izlediğinde"
+                ],
+                [
+                    "aklını kaçırırsın",
+                    "anlamanın ötesinde",
+                    "ve gerçeklik kaybolur",
+                    "çığlıklar dinene kadar",
+                    "gerçeklik çatlayana dek",
+                    "akıl yavaşça kayarken",
+                    "umut ölünceye kadar",
+                    "kâbuslar uyanırken",
+                    "dehşet herkesi tüketirken",
+                    "zaman çökene dek"
+                ],
+                [
+                    "Rahatsız edici olsun.",
+                    "Detayları canlı tut.",
+                    "Gerginliği vurgula.",
+                    "Sarsıcı imgeler kullan.",
+                    "Korkuyu yavaş yavaş artır.",
+                    "Biraz gizem bırak.",
+                    "Klişelerden kaçın.",
+                    "Gerilimi yükselt.",
+                    "Sonunda ürpertici bir his bırak.",
+                    "Birinci şahıs anlat."
+                ]
+            ]
+        }
+    }
+};
 
         // --- DOM Elements ---
         const categoryButtonsContainer = document.getElementById('category-buttons');
@@ -721,7 +1689,9 @@
                     }
                     return element;
                 });
-                const newPrompt = categoryData.structure(promptParts);
+                const newPrompt = categoryData.structure
+                    ? categoryData.structure(promptParts)
+                    : promptParts.join(' ');
 
                 // Update history for each part (FIFO queue)
                 promptParts.forEach((part, idx) => {


### PR DESCRIPTION
## Summary
- expand each prompt template to four parts with 10 options each
- support variable-length templates when generating prompts
- raise history size to avoid quick repeats
- document that the app now offers over 110k combinations

## Testing
- `node - <<'NODE'
const fs=require('fs');
const html=fs.readFileSync('index.html','utf8');
const m=html.match(/const prompts = (\{[\s\S]*?\});/);let code=m[0]+"\nglobalThis.prompts=prompts;";eval(code);let total=0;for(const cat of Object.values(prompts.en)){total+=cat.parts.reduce((a,b)=>a*b.length,1);}console.log('combo',total);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68456fd97370832fbfcd825de0012ea9