### PR TITLE
Add lucide safety check on prompt generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1663,7 +1663,9 @@
             appState.isGenerating = true;
             generateButton.disabled = true;
             generatedPromptText.innerHTML = '<div class="flex justify-center items-center h-20"><i data-lucide="loader-2" class="w-6 h-6 animate-spin"></i></div>';
-            lucide.createIcons(); // Render spinner icon
+            if (window.lucide && typeof window.lucide.createIcons === 'function') {
+                window.lucide.createIcons();
+            }
             promptDisplayArea.classList.remove('hidden');
             promptDisplayArea.classList.add('animate-fadeIn');
 


### PR DESCRIPTION
## Summary
- avoid errors when lucide is unavailable by checking for `window.lucide.createIcons` before calling it

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68457a1e7ef8832fa6aff2992d7103d9