### PR TITLE
Improve CDN fallback timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,17 +14,30 @@
       return s;
     }
 
+    function fetchWithTimeout(url, timeout = 500) {
+      return Promise.race([
+        fetch(url, { method: 'HEAD', mode: 'no-cors' }),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeout))
+      ]);
+    }
+
     function loadWithFallback(primary, local) {
+      const addLocal = () => addScript(local);
       if (!navigator.onLine) {
-        addScript(local);
+        addLocal();
         return;
       }
+      let fallbackTimer = setTimeout(addLocal, 750);
+      fetchWithTimeout(primary).catch(() => {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+        addLocal();
+      });
       const cdn = addScript(primary);
-      const timer = setTimeout(() => addScript(local), 3000);
-      cdn.onload = () => clearTimeout(timer);
+      cdn.onload = () => fallbackTimer && clearTimeout(fallbackTimer);
       cdn.onerror = () => {
-        clearTimeout(timer);
-        addScript(local);
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+        addLocal();
       };
     }
 


### PR DESCRIPTION
## Summary
- shorten the fallback delay for CDN scripts
- attempt a quick HEAD request to skip unreachable CDN servers

## Testing
- `node test_offline.js`

------
https://chatgpt.com/codex/tasks/task_e_68457cc45bf8832fb46d76472a51b25d