### PR TITLE
Add service worker for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Prompter is a small web application that generates creative prompts for AI model
 
 Simply open `index.html` in any modern web browser. You can double‑click the file or use your browser's **Open File** option. No server setup is required.
 
-If you open the page offline, the UI falls back to the bundled Tailwind file and emoji icons, so its appearance may differ slightly.
+When served from a local web server (for example `python3 -m http.server`) the app installs a small service worker that caches `index.html`, `tailwind.js` and `lucide.min.js`. After an initial visit you can disconnect from the network and the generator will still load and function normally.
 
 ## Customization
 

--- a/index.html
+++ b/index.html
@@ -1846,6 +1846,12 @@
         // --- Run Initialization ---
         document.addEventListener('DOMContentLoaded', initializeApp);
 
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('sw.js').catch(console.error);
+            });
+        }
+
     </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'prompter-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/tailwind.js',
+  '/lucide.min.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- implement a caching service worker
- register the worker on load
- document offline usage in the README

## Testing
- `python3 -m http.server 8080` to serve the files
- `curl -I http://localhost:8080/sw.js`
- `curl -I http://localhost:8080/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68457cc9c950832f82df9af48914e83f