### PR TITLE
Fix Turkish prompts punctuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,16 +1122,16 @@ return { cdn: cdnScript, local: null };
         "productivity": {
             "parts": [
                 [
-                    "Şöyle bir sistem geliştir:",
-                    "Şöyle bir plan oluştur:",
-                    "Şöyle bir rutin tasarla:",
-                    "Şöyle bir strateji yaz:",
-                    "Şöyle bir zaman çizelgesi hazırla:",
-                    "Şöyle bir araç seti oluştur:",
-                    "Şöyle bir iş akışı düzenle:",
-                    "Şu alışkanlıkları belirle:",
-                    "Şöyle bir çerçeve kur:",
-                    "Şu kontrol listesini yaz:"
+                    "Şöyle bir sistem geliştir",
+                    "Şöyle bir plan oluştur",
+                    "Şöyle bir rutin tasarla",
+                    "Şöyle bir strateji yaz",
+                    "Şöyle bir zaman çizelgesi hazırla",
+                    "Şöyle bir araç seti oluştur",
+                    "Şöyle bir iş akışı düzenle",
+                    "Şu alışkanlıkları belirle",
+                    "Şöyle bir çerçeve kur",
+                    "Şu kontrol listesini yaz"
                 ],
                 [
                     "dikkat dağıtıcıları önlemek",
@@ -1174,16 +1174,16 @@ return { cdn: cdnScript, local: null };
         "educational": {
             "parts": [
                 [
-                    "Şunu açıkla:",
-                    "Şunu öğret:",
-                    "Şunu basitleştir:",
-                    "Şunu özetle:",
-                    "Şunu göster:",
-                    "Şunun genelini anlat:",
-                    "Şu konuda ders ver:",
-                    "Şunu netleştir:",
-                    "Şunu sıralandır:",
-                    "Şunu sun:"
+                    "Şunu açıkla",
+                    "Şunu öğret",
+                    "Şunu basitleştir",
+                    "Şunu özetle",
+                    "Şunu göster",
+                    "Şunun genelini anlat",
+                    "Şu konuda ders ver",
+                    "Şunu netleştir",
+                    "Şunu sıralandır",
+                    "Şunu sun"
                 ],
                 [
                     "kuantum fiziği",
@@ -1226,16 +1226,16 @@ return { cdn: cdnScript, local: null };
         "crazy": {
             "parts": [
                 [
-                    "Şöyle bir sahne yaz:",
-                    "Şu durumu düşün:",
-                    "Şöyle bir dünya anlat:",
-                    "Şu hikayeyi kur:",
-                    "Şöyle bir gerçeklik tasvir et:",
-                    "Şu kurguyu yarat:",
-                    "Şöyle bir senaryo icat et:",
-                    "Şöyle bir ortam hayal et:",
-                    "Şu masalı tasarla:",
-                    "Şöyle bir öykü oluştur:"
+                    "Şöyle bir sahne yaz",
+                    "Şu durumu düşün",
+                    "Şöyle bir dünya anlat",
+                    "Şu hikayeyi kur",
+                    "Şöyle bir gerçeklik tasvir et",
+                    "Şu kurguyu yarat",
+                    "Şöyle bir senaryo icat et",
+                    "Şöyle bir ortam hayal et",
+                    "Şu masalı tasarla",
+                    "Şöyle bir öykü oluştur"
                 ],
                 [
                     "kediler dünyayı yönetse",
@@ -1330,16 +1330,16 @@ return { cdn: cdnScript, local: null };
         "ai": {
             "parts": [
                 [
-                    "Şöyle bir YZ tasarla:",
-                    "Şöyle bir yapay zeka düşün:",
-                    "Şu robot hakkında yaz:",
-                    "Şöyle bir makine öner:",
-                    "Şu yazılımı tarif et:",
-                    "Şöyle bir teknolojiyi hayal et:",
+                    "Şöyle bir YZ tasarla",
+                    "Şöyle bir yapay zeka düşün",
+                    "Şu robot hakkında yaz",
+                    "Şöyle bir makine öner",
+                    "Şu yazılımı tarif et",
+                    "Şöyle bir teknolojiyi hayal et",
                     "Şu geleceği çiz ki YZ",
-                    "Şöyle bir bot konsepti geliştir:",
-                    "Şu algoritmayı özetle:",
-                    "Şöyle bir sistem kur:"
+                    "Şöyle bir bot konsepti geliştir",
+                    "Şu algoritmayı özetle",
+                    "Şöyle bir sistem kur"
                 ],
                 [
                     "dünyadaki açlığı çözen",
@@ -1382,16 +1382,16 @@ return { cdn: cdnScript, local: null };
         "ideas": {
             "parts": [
                 [
-                    "Şu alan için bir iş fikri üret:",
-                    "Şöyle bir proje beyin fırtınası yap:",
-                    "Şu ürüne dayalı bir öneri sun:",
-                    "Şu konuda bir girişim öner:",
-                    "Şöyle bir hizmet tasarla:",
-                    "Şu uygulamayı icat et:",
-                    "Şu kampanyayı tasarla:",
-                    "Şu konuda bir atölye geliştir:",
-                    "Şu kitap üzerine bir taslak çiz:",
-                    "Şu eğitimi öğreten bir kurs hazırla:"
+                    "Şu alan için bir iş fikri üret",
+                    "Şöyle bir proje beyin fırtınası yap",
+                    "Şu ürüne dayalı bir öneri sun",
+                    "Şu konuda bir girişim öner",
+                    "Şöyle bir hizmet tasarla",
+                    "Şu uygulamayı icat et",
+                    "Şu kampanyayı tasarla",
+                    "Şu konuda bir atölye geliştir",
+                    "Şu kitap üzerine bir taslak çiz",
+                    "Şu eğitimi öğreten bir kurs hazırla"
                 ],
                 [
                     "yenilenebilir enerji",
@@ -1434,16 +1434,16 @@ return { cdn: cdnScript, local: null };
         "video": {
             "parts": [
                 [
-                    "Viral olacak bir video fikri ver:",
-                    "Şuna odaklanan kısa film konsepti oluştur:",
-                    "Şunu keşfeden bir belgesel tasla:",
-                    "Şöyle bir skeç yaz:",
-                    "Şunu tasvir eden bir animasyon anlat:",
-                    "Şu konuda komik bir sahne düşün:",
-                    "Şunu öğreten bir eğitim videosu planla:",
-                    "Şunu gösteren aksiyon dolu bir sekans hayal et:",
-                    "Şu konu için motive edici bir konuşma hazırla:",
-                    "Şu anları yakalayan klipler dizisi tasarla:"
+                    "Viral olacak bir video fikri ver",
+                    "Şuna odaklanan kısa film konsepti oluştur",
+                    "Şunu keşfeden bir belgesel tasla",
+                    "Şöyle bir skeç yaz",
+                    "Şunu tasvir eden bir animasyon anlat",
+                    "Şu konuda komik bir sahne düşün",
+                    "Şunu öğreten bir eğitim videosu planla",
+                    "Şunu gösteren aksiyon dolu bir sekans hayal et",
+                    "Şu konu için motive edici bir konuşma hazırla",
+                    "Şu anları yakalayan klipler dizisi tasarla"
                 ],
                 [
                     "günlük yaşamı değiştiren geleceğin teknolojisi",
@@ -1486,16 +1486,16 @@ return { cdn: cdnScript, local: null };
         "image": {
             "parts": [
                 [
-                    "Şunun görselini oluştur:",
-                    "Detaylı bir çizimini yap:",
-                    "Şu unsurları içeren sürreal bir resim üret:",
-                    "Şuna dayalı minimal bir logo tasarla:",
-                    "Şu fantastik sahneyi çiz:",
-                    "Şunun futuristik bir yorumunu hayal et:",
-                    "Şunun portresini boya:",
-                    "Şu manzarayı tasvir et:",
-                    "Şu konu hakkında bir çizgi roman karesi oluştur:",
-                    "Şunu tanıtan bir afiş tasla:"
+                    "Şunun görselini oluştur",
+                    "Detaylı bir çizimini yap",
+                    "Şu unsurları içeren sürreal bir resim üret",
+                    "Şuna dayalı minimal bir logo tasarla",
+                    "Şu fantastik sahneyi çiz",
+                    "Şunun futuristik bir yorumunu hayal et",
+                    "Şunun portresini boya",
+                    "Şu manzarayı tasvir et",
+                    "Şu konu hakkında bir çizgi roman karesi oluştur",
+                    "Şunu tanıtan bir afiş tasla"
                 ],
                 [
                     "bisiklete binen efsanevi bir yaratık",
@@ -1538,9 +1538,9 @@ return { cdn: cdnScript, local: null };
         "hellprompts": {
             "parts": [
                 [
-                    "Şu anı tarif et:",
-                    "Şu korkuyu hayal et:",
-                    "Şu anı yaz:",
+                    "Şu anı tarif et",
+                    "Şu korkuyu hayal et",
+                    "Şu anı yaz",
                     "Kabusu anlat",
                     "O zamanı fısılda",
                     "Dehşeti betimle",


### PR DESCRIPTION
## Summary
- remove trailing colons from Turkish prompt templates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68458708eee8832fbd85653833c3c22d