### PR TITLE
Fix loadWithFallback logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,60 +22,57 @@
     }
 
     function loadWithFallback(primary, local) {
-const addLocal = () => {
-  const localScript = document.createElement('script');
-  localScript.src = local;
-  localScript.async = true;
-  document.head.appendChild(localScript);
-  return localScript;
-};
+      let cdnScript = null;
+      let localScript = null;
 
-// If offline, load local immediately
-if (!navigator.onLine) {
-  const localScript = addLocal();
-  return { cdn: null, local: localScript };
-}
+      const addLocal = () => {
+        localScript = document.createElement('script');
+        localScript.src = local;
+        localScript.async = true;
+        document.head.appendChild(localScript);
+      };
 
-// Online: Try CDN with fallback
-let cdnScript = null;
-let fallbackTimer = null;
+      // If offline, load local immediately
+      if (!navigator.onLine) {
+        addLocal();
+        return { cdn: null, local: localScript };
+      }
 
-// Set up fallback timer (3 seconds seems more reasonable than 750ms)
-fallbackTimer = setTimeout(() => {
-  addLocal();
-  fallbackTimer = null;
-}, 3000);
+      // Online: Try CDN with fallback
+      let fallbackTimer = null;
 
-// Try to fetch from CDN first
-fetchWithTimeout(primary).catch(() => {
-  if (fallbackTimer) {
-    clearTimeout(fallbackTimer);
-    fallbackTimer = null;
-  }
-  addLocal();
-});
+      // Set up fallback timer (3 seconds seems more reasonable than 750ms)
+      fallbackTimer = setTimeout(() => {
+        addLocal();
+        fallbackTimer = null;
+      }, 3000);
 
-// Add CDN script
-cdnScript = addScript(primary);
+      // Try to fetch from CDN first
+      fetchWithTimeout(primary).catch(() => {
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer);
+          fallbackTimer = null;
+        }
+        addLocal();
+      });
 
-// Handle CDN script events
-cdnScript.onload = () => {
-  if (fallbackTimer) {
-    clearTimeout(fallbackTimer);
-    fallbackTimer = null;
-  }
-};
+      // Add CDN script
+      cdnScript = addScript(primary);
 
-cdnScript.onerror = () => {
-  if (fallbackTimer) {
-    clearTimeout(fallbackTimer);
-    fallbackTimer = null;
-  }
-  addLocal();
-};
+      // Handle CDN script events
+      cdnScript.onload = () => {
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer);
+          fallbackTimer = null;
+        }
+      };
 
-// Return both script elements for reference
-return { cdn: cdnScript, local: null };
+      cdnScript.onerror = () => {
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer);
+          fallbackTimer = null;
+        }
+        addLocal();
       };
 
       return { cdn: cdnScript, local: localScript };


### PR DESCRIPTION
## Summary
- rewrite `loadWithFallback` to properly expose both cdn/local script elements

## Testing
- `node <puppeteer>` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_6845883114f8832f926287b5696fc763