### PR TITLE
Fix educational category start line

### DIFF
--- a/index.html
+++ b/index.html
@@ -1171,7 +1171,6 @@
         "educational": {
             "parts": [
                 [
-
                     "Şunu açıkla:",
                     "Şunu öğret:",
                     "Şunu basitleştir:",


### PR DESCRIPTION
## Summary
- remove blank line before first Turkish educational prompt

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68458b8365d0832f82da0888232c257e