### PR TITLE
Run lucide after button render

### DIFF
--- a/index.html
+++ b/index.html
@@ -725,6 +725,7 @@
                     : `<span class="emoji-icon mr-1">${fallbackIcons[category.id] || ''}</span><span>${category.name[appState.language]}</span>`;
                 categoryButtonsContainer.appendChild(button);
             });
+            runLucide();
 
             if (!hasLucide && window.lucideScripts) {
                 const { cdn, local } = window.lucideScripts;


### PR DESCRIPTION
## Summary
- call `runLucide()` after category buttons are inserted so lucide icons initialize properly
- keep the existing load listener for lucide scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68458ee0d4bc832f917900d4860361ee