### PR TITLE
Fix lucide CDN URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     }
 
     loadWithFallback('https://cdn.tailwindcss.com', 'tailwind.js');
-    window.lucideScripts = loadWithFallback('https://unpkg.com/lucide@latest', 'lucide.min.js');
+    window.lucideScripts = loadWithFallback('https://unpkg.com/lucide@latest/dist/umd/lucide.min.js', 'lucide.min.js');
   })();
 </script>
     <style>


### PR DESCRIPTION
## Summary
- fix Lucide CDN link in `index.html`

## Testing
- `curl -I https://unpkg.com/lucide@latest/dist/umd/lucide.min.js | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68458ee1e8fc832fa1dddda9659c6a81