### PR TITLE
Fix Lucide init timing and cache logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Prompt templates are now loaded from a separate `prompts.js` file for faster pag
 
 Simply open `index.html` in any modern web browser. You can double‑click the file or use your browser's **Open File** option. No server setup is required.
 
-When served from a local web server (for example `python3 -m http.server`) the app installs a small service worker that caches `index.html`, `tailwind.js` and `lucide.min.js`, `prompts.js`. After an initial visit you can disconnect from the network and the generator will still load and function normally.
+When served from a local web server (for example `python3 -m http.server`) the app installs a small service worker that caches `index.html`, `tailwind.js`, `lucide.min.js`, `prompts.js` and the logo in `icons/logo.svg`. After an initial visit you can disconnect from the network and the generator will still load and function normally.
 
 ## Customization
 

--- a/index.html
+++ b/index.html
@@ -7,10 +7,13 @@
     <link rel="icon" type="image/svg+xml" href="icons/logo.svg">
 <script>
   (function() {
-    function addScript(src) {
+    function addScript(src, onLoad) {
       const s = document.createElement('script');
       s.src = src;
       s.async = true;
+      if (onLoad) {
+        s.addEventListener('load', onLoad, { once: true });
+      }
       document.head.appendChild(s);
       return s;
     }
@@ -25,18 +28,23 @@
     function loadWithFallback(primary, local) {
       let cdnScript = null;
       let localScript = null;
+      let resolveLoad;
+      const loadPromise = new Promise(resolve => { resolveLoad = resolve; });
 
       const addLocal = () => {
-        localScript = document.createElement('script');
-        localScript.src = local;
-        localScript.async = true;
-        document.head.appendChild(localScript);
+        if (!localScript) {
+          localScript = document.createElement('script');
+          localScript.src = local;
+          localScript.async = true;
+          localScript.addEventListener('load', resolveLoad, { once: true });
+          document.head.appendChild(localScript);
+        }
       };
 
       // If offline, load local immediately
       if (!navigator.onLine) {
         addLocal();
-        return { cdn: null, local: localScript };
+        return { cdn: null, local: localScript, loadPromise };
       }
 
       // Online: Try CDN with fallback
@@ -58,15 +66,13 @@
       });
 
       // Add CDN script
-      cdnScript = addScript(primary);
-
-      // Handle CDN script events
-      cdnScript.onload = () => {
+      cdnScript = addScript(primary, () => {
         if (fallbackTimer) {
           clearTimeout(fallbackTimer);
           fallbackTimer = null;
         }
-      };
+        resolveLoad();
+      });
 
       cdnScript.onerror = () => {
         if (fallbackTimer) {
@@ -76,7 +82,7 @@
         addLocal();
       };
 
-      return { cdn: cdnScript, local: localScript };
+      return { cdn: cdnScript, local: localScript, loadPromise };
     }
 
     loadWithFallback('https://cdn.tailwindcss.com', 'tailwind.js');
@@ -714,8 +720,6 @@
             const savedTheme = localStorage.getItem('theme') || THEMES.DARK;
             setTheme(savedTheme);
 
-            const hasLucide = runLucide();
-
             categoryButtonsContainer.innerHTML = '';
             categories.forEach(category => {
                 const button = document.createElement('button');
@@ -731,14 +735,10 @@
                     <span>${category.name[appState.language]}</span>`;
                 categoryButtonsContainer.appendChild(button);
             });
-            runLucide();
-
-            if (!hasLucide && window.lucideScripts) {
-                const { cdn, local } = window.lucideScripts;
-                [cdn, local].forEach(script => {
-                    script && script.addEventListener('load', runLucide, { once: true });
-                });
+            if (window.lucideScripts && window.lucideScripts.loadPromise) {
+                window.lucideScripts.loadPromise.then(runLucide);
             }
+
 
             // Setup event listeners
             setupEventListeners();

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,8 @@ const ASSETS = [
   './index.html',
   './tailwind.js',
   './prompts.js',
-  './lucide.min.js'
+  './lucide.min.js',
+  './icons/logo.svg'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- load Lucide icons only after the script's `load` event
- add a promise from `loadWithFallback()` so `runLucide()` runs once the script is ready
- cache the logo in the service worker
- document the added cached asset

## Testing
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68459737accc832f975cc4fa680de9fd