### PR TITLE
Fix stray word in prompt generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,7 +668,6 @@
                     }
                     return element;
                 });
- main
                 const newPrompt = categoryData.structure(promptParts);
 
                 // Update history for each part (FIFO queue)


### PR DESCRIPTION
## Summary
- remove stray word `main` from prompt generation section

## Testing
- `node --check bottom_script.js`

------
https://chatgpt.com/codex/tasks/task_e_68456a5f8844832fa1fcc337f29d10ab