### PR TITLE
Fix Turkish subtitle spelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,7 +467,7 @@
         },
         tr: {
             appTitle: "YZ Prompt Üretici - Prompter",
-            appSubtitle: "YZ için prompt üretici - eşi benzeri görülmemiş sınırsız yaraticilik",
+            appSubtitle: "YZ için prompt üretici - eşi benzeri görülmemiş sınırsız yaratıcılık",
             chooseStyleTitle: "Prompt İlhamınızı Seçin",
             generateButtonText: "Yeni Prompt Üret",
             yourPromptTitle: "Benzersiz Promptunuz:",


### PR DESCRIPTION
## Summary
- fix typo in Turkish translation for `appSubtitle`

## Testing
- `grep -n "appSubtitle" -n index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_68471c2c0d5c832f92acf2cece2082d6