### PR TITLE
Improve prompt punctuation

### DIFF
--- a/prompts.js
+++ b/prompts.js
@@ -1327,3 +1327,48 @@ window.prompts = {
         }
     }
 };
+
+(function attachStructureFunctions(prompts) {
+    const join = arr => arr.join(' ').replace(/\s+([,.!?])/g, '$1').replace(/\s+/g, ' ').trim();
+    const punctuate = str => /[.!?]$/.test(str) ? str : str + '.';
+
+    const structures = {
+        singleSentence: parts => join(parts),
+        twoSentence: parts => {
+            const first = punctuate(join(parts.slice(0, 3)));
+            return `${first} ${parts[3].trim()}`;
+        },
+        questionThenInstruction: parts => {
+            const first = punctuate(join(parts.slice(0, 2)));
+            return `${first} ${parts[2].trim()} ${parts[3].trim()}`;
+        },
+        imageStructure: parts => {
+            const first = punctuate(join(parts.slice(0, 2)));
+            return `${first} ${parts[2].trim()} ${parts[3].trim()}`;
+        }
+    };
+
+    const catMap = {
+        inspiring: 'singleSentence',
+        mindBlowing: 'questionThenInstruction',
+        productivity: 'twoSentence',
+        educational: 'twoSentence',
+        crazy: 'twoSentence',
+        perspective: 'twoSentence',
+        ai: 'twoSentence',
+        ideas: 'twoSentence',
+        video: 'questionThenInstruction',
+        image: 'imageStructure',
+        hellprompts: 'twoSentence'
+    };
+
+    ['en', 'tr'].forEach(lang => {
+        const langPrompts = prompts[lang];
+        if (!langPrompts) return;
+        Object.keys(catMap).forEach(cat => {
+            if (langPrompts[cat]) {
+                langPrompts[cat].structure = structures[catMap[cat]];
+            }
+        });
+    });
+})(window.prompts);


### PR DESCRIPTION
## Summary
- ensure prompts display with natural punctuation in both languages
- add structure helpers for each category so sentences flow smoothly

## Testing
- `node -e "global.window={};require('./prompts.js');console.log(Object.keys(window.prompts.en).length);"`
- `node - <<'NODE'
window={};require('./prompts.js');
console.log(window.prompts.en.mindBlowing.structure(['Imagine if','humans could teleport','How would society react?','Explore the consequences.']));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68471c2e4a0c832fbbb829dd6241e3d6