### PR TITLE
Improve loading experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,11 +88,36 @@
     const tailwindScripts = loadWithFallback('https://cdn.tailwindcss.com', 'tailwind.js');
     window.lucideScripts = loadWithFallback('https://unpkg.com/lucide@latest/dist/umd/lucide.min.js', 'lucide.min.js');
     Promise.all([tailwindScripts.loadPromise, window.lucideScripts.loadPromise])
-      .finally(() => { document.body.style.visibility = 'visible'; });
+      .finally(() => {
+        const appContainer = document.getElementById('app-container');
+        const loadingScreen = document.getElementById('loading-screen');
+        if (appContainer) appContainer.style.visibility = 'visible';
+        if (loadingScreen) loadingScreen.classList.add('hidden');
+      });
   })();
 </script>
     <style>
         /* Custom styles */
+        #loading-screen {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #000;
+            color: white;
+            z-index: 9999;
+            transition: opacity 0.3s ease;
+        }
+        #loading-screen.hidden { opacity: 0; pointer-events: none; }
+        #loading-screen .spinner {
+            width: 2rem;
+            height: 2rem;
+            border: 4px solid currentColor;
+            border-top-color: transparent;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
         body {
             font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             transition: background-color 0.3s ease, color 0.3s ease;
@@ -335,9 +360,13 @@
       })();
     </script>
 </head>
-<body class="min-h-screen p-4" style="visibility:hidden;">
+<body class="min-h-screen p-4">
 
-    <div id="app-container" class="max-w-6xl mx-auto relative">
+    <div id="loading-screen">
+      <div class="spinner" aria-label="Loading"></div>
+    </div>
+
+    <div id="app-container" class="max-w-6xl mx-auto relative" style="visibility:hidden;">
         <!-- Theme Toggle -->
         <div class="theme-toggle-container absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10">
             <button id="theme-light" class="p-1.5 rounded-md text-sm font-medium" title="Light Theme" aria-label="Light Theme">


### PR DESCRIPTION
## Summary
- add a simple loading screen so users see a spinner while scripts load
- show the main container once scripts are ready and fade out the loading overlay

## Testing
- `node -e "console.log('Node version', process.version)"`

------
https://chatgpt.com/codex/tasks/task_e_684728304c50832f98d5495c93e5b427