### PR TITLE
Move inline theme styles to separate CSS files

### DIFF
--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -1,0 +1,24 @@
+body { background-image: linear-gradient(to bottom right, #581c87, #1e3a8a, #312e81) !important; color: white !important; }
+.bg-white\/10 { background-color: rgba(255, 255, 255, 0.1) !important; border-color: rgba(255, 255, 255, 0.2) !important; }
+.bg-black\/30 { background-color: rgba(0, 0, 0, 0.3) !important; color: white !important; }
+.text-blue-200 { color: #bfdbfe !important; }
+.text-blue-300 { color: #93c5fd !important; }
+.border-white\/20 { border-color: rgba(255, 255, 255, 0.2) !important; }
+.bg-black\/20 { background-color: rgba(0, 0, 0, 0.2) !important; }
+.hover\:bg-white\/10:hover { background-color: rgba(255, 255, 255, 0.1) !important; }
+.bg-white\/30 { background-color: rgba(255, 255, 255, 0.3) !important; }
+.hover\:bg-white\/30:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
+.focus\:ring-white\/50:focus { --tw-ring-color: rgba(255, 255, 255, 0.5) !important; }
+.category-button { background-color: rgba(255, 255, 255, 0.2) !important; color: white !important; border: 1px solid rgba(255, 255, 255, 0.1) !important; }
+.category-button:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
+.category-button.selected { background-image: linear-gradient(to right, #a855f7, #ec4899) !important; color: white !important; border-color: transparent !important; }
+.category-button .lucide { color: white !important; display: none; }
+.category-button .emoji-icon { color: white !important; }
+#app-title { background-image: linear-gradient(to right, #22d3ee, #c084fc) !important; }
+#choose-style-title, #your-prompt-title { color: white !important; }
+#lang-en, #lang-tr { color: #bfdbfe !important; }
+#lang-en.active, #lang-tr.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
+.theme-toggle-container i { color: #bfdbfe !important; }
+.theme-toggle-container button { color: #bfdbfe !important; }
+.theme-toggle-container button.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
+.absolute.top-4.right-4 i { color: #93c5fd !important; }

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -1,0 +1,26 @@
+body { background-image: linear-gradient(to bottom right, #f0f4ff, #d9e2ff, #c4d1ff) !important; color: #1a1a2e !important; }
+.bg-white\/10 { background-color: rgba(255, 255, 255, 0.8) !important; border-color: rgba(0, 0, 0, 0.1) !important; }
+.bg-black\/30 { background-color: rgba(0, 0, 0, 0.05) !important; color: #1e293b !important; }
+.text-blue-200 { color: #4338ca !important; }
+.text-blue-300 { color: #3730a3 !important; }
+.border-white\/20 { border-color: rgba(0, 0, 0, 0.1) !important; }
+.bg-black\/20 { background-color: rgba(0, 0, 0, 0.05) !important; }
+.hover\:bg-white\/10:hover { background-color: rgba(0, 0, 0, 0.1) !important; }
+.bg-white\/30 { background-color: rgba(0, 0, 0, 0.2) !important; }
+.hover\:bg-white\/30:hover { background-color: rgba(0, 0, 0, 0.3) !important; }
+.focus\:ring-white\/50:focus { --tw-ring-color: rgba(0, 0, 0, 0.3) !important; }
+.category-button { background-color: rgba(0, 0, 0, 0.08) !important; color: #1a1a2e !important; border: 1px solid rgba(0, 0, 0, 0.1) !important; }
+.category-button:hover { background-color: rgba(0, 0, 0, 0.15) !important; }
+.category-button.selected { background-image: linear-gradient(to right, #6366f1, #8b5cf6) !important; color: white !important; border-color: transparent !important; }
+.category-button .lucide { color: #4f46e5 !important; display: none; }
+.category-button.selected .lucide { color: white !important; }
+.category-button .emoji-icon { color: #4f46e5 !important; }
+.category-button.selected .emoji-icon { color: white !important; }
+#app-title { background-image: linear-gradient(to right, #4f46e5, #7c3aed) !important; }
+#choose-style-title, #your-prompt-title { color: #1e293b !important; }
+#lang-en, #lang-tr { color: #4338ca !important; }
+#lang-en.active, #lang-tr.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
+.theme-toggle-container i { color: #4338ca !important; }
+.theme-toggle-container button { color: #4338ca !important; }
+.theme-toggle-container button.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
+.absolute.top-4.right-4 i { color: #4338ca !important; }

--- a/index.html
+++ b/index.html
@@ -221,141 +221,14 @@
             transition: background-color 0.2s ease, color 0.2s ease;
         }
     </style>
-    <style id="theme-styles">
-        /* Default Dark Theme Styles (will be overridden by JS) */
-        body {
-            background-image: linear-gradient(to bottom right, #581c87, #1e3a8a, #312e81) !important;
-            color: white !important;
-        }
-        .bg-white\/10 {
-            background-color: rgba(255, 255, 255, 0.1) !important;
-        }
-        .bg-black\/30 {
-            background-color: rgba(0, 0, 0, 0.3) !important;
-        }
-        .text-blue-200 {
-            color: #bfdbfe !important; /* Tailwind blue-200 */
-        }
-        .text-blue-300 {
-            color: #93c5fd !important; /* Tailwind blue-300 */
-        }
-        .border-white\/20 {
-             border-color: rgba(255, 255, 255, 0.2) !important;
-        }
-        .bg-black\/20 {
-             background-color: rgba(0, 0, 0, 0.2) !important;
-        }
-        .hover\:bg-white\/10:hover {
-             background-color: rgba(255, 255, 255, 0.1) !important;
-        }
-        .bg-white\/30 {
-             background-color: rgba(255, 255, 255, 0.3) !important;
-        }
-        .hover\:bg-white\/30:hover {
-             background-color: rgba(255, 255, 255, 0.3) !important;
-        }
-        .focus\:ring-white\/50:focus {
-             --tw-ring-color: rgba(255, 255, 255, 0.5) !important;
-        }
-        .category-button {
-            background-color: rgba(255, 255, 255, 0.2) !important;
-            color: white !important;
-            border: 1px solid rgba(255, 255, 255, 0.1) !important;
-        }
-        .category-button:hover {
-            background-color: rgba(255, 255, 255, 0.3) !important;
-        }
-        .category-button.selected {
-            background-image: linear-gradient(to right, #a855f7, #ec4899) !important;
-            color: white !important;
-        }
-        .category-button .lucide {
-            color: white !important;
-            display: none;
-        }
-        #app-title {
-            background-image: linear-gradient(to right, #22d3ee, #c084fc) !important;
-            line-height: 1.3;
-            padding-bottom: 5px;
-        }
-        #choose-style-title, #your-prompt-title {
-            color: white !important;
-        }
-        #lang-en, #lang-tr {
-            color: #bfdbfe !important; /* text-blue-200 */
-        }
-        #lang-en.active, #lang-tr.active {
-            background-color: rgba(255, 255, 255, 0.3) !important;
-            color: white !important;
-        }
-        .theme-toggle-container i {
-            color: #bfdbfe !important; /* text-blue-200 */
-        }
-    </style>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css">
     <script>
       (function() {
         const savedTheme = localStorage.getItem('theme');
         if (!savedTheme) return;
-        const styleEl = document.getElementById('theme-styles');
-        if (!styleEl) return;
-        const earlyStyles = {
-          light: `
-                body { background-image: linear-gradient(to bottom right, #f0f4ff, #d9e2ff, #c4d1ff) !important; color: #1a1a2e !important; }
-                .bg-white\/10 { background-color: rgba(255, 255, 255, 0.8) !important; border-color: rgba(0, 0, 0, 0.1) !important; }
-                .bg-black\/30 { background-color: rgba(0, 0, 0, 0.05) !important; color: #1e293b !important; }
-                .text-blue-200 { color: #4338ca !important; }
-                .text-blue-300 { color: #3730a3 !important; }
-                .border-white\/20 { border-color: rgba(0, 0, 0, 0.1) !important; }
-                .bg-black\/20 { background-color: rgba(0, 0, 0, 0.05) !important; }
-                .hover\:bg-white\/10:hover { background-color: rgba(0, 0, 0, 0.1) !important; }
-                .bg-white\/30 { background-color: rgba(0, 0, 0, 0.2) !important; }
-                .hover\:bg-white\/30:hover { background-color: rgba(0, 0, 0, 0.3) !important; }
-                .focus\:ring-white\/50:focus { --tw-ring-color: rgba(0, 0, 0, 0.3) !important; }
-                .category-button { background-color: rgba(0, 0, 0, 0.08) !important; color: #1a1a2e !important; border: 1px solid rgba(0, 0, 0, 0.1) !important; }
-                .category-button:hover { background-color: rgba(0, 0, 0, 0.15) !important; }
-                .category-button.selected { background-image: linear-gradient(to right, #6366f1, #8b5cf6) !important; color: white !important; border-color: transparent !important; }
-                .category-button .lucide { color: #4f46e5 !important; display: none; }
-                .category-button.selected .lucide { color: white !important; }
-                .category-button .emoji-icon { color: #4f46e5 !important; }
-                .category-button.selected .emoji-icon { color: white !important; }
-                #app-title { background-image: linear-gradient(to right, #4f46e5, #7c3aed) !important; }
-                #choose-style-title, #your-prompt-title { color: #1e293b !important; }
-                #lang-en, #lang-tr { color: #4338ca !important; }
-                #lang-en.active, #lang-tr.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
-                .theme-toggle-container i { color: #4338ca !important; }
-                .theme-toggle-container button { color: #4338ca !important; }
-                .theme-toggle-container button.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
-                .absolute.top-4.right-4 i { color: #4338ca !important; }
-          `,
-          dark: `
-                body { background-image: linear-gradient(to bottom right, #581c87, #1e3a8a, #312e81) !important; color: white !important; }
-                .bg-white\/10 { background-color: rgba(255, 255, 255, 0.1) !important; border-color: rgba(255, 255, 255, 0.2) !important; }
-                .bg-black\/30 { background-color: rgba(0, 0, 0, 0.3) !important; color: white !important; }
-                .text-blue-200 { color: #bfdbfe !important; }
-                .text-blue-300 { color: #93c5fd !important; }
-                .border-white\/20 { border-color: rgba(255, 255, 255, 0.2) !important; }
-                .bg-black\/20 { background-color: rgba(0, 0, 0, 0.2) !important; }
-                .hover\:bg-white\/10:hover { background-color: rgba(255, 255, 255, 0.1) !important; }
-                .bg-white\/30 { background-color: rgba(255, 255, 255, 0.3) !important; }
-                .hover\:bg-white\/30:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
-                .focus\:ring-white\/50:focus { --tw-ring-color: rgba(255, 255, 255, 0.5) !important; }
-                .category-button { background-color: rgba(255, 255, 255, 0.2) !important; color: white !important; border: 1px solid rgba(255, 255, 255, 0.1) !important; }
-                .category-button:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
-                .category-button.selected { background-image: linear-gradient(to right, #a855f7, #ec4899) !important; color: white !important; border-color: transparent !important; }
-                .category-button .lucide { color: white !important; display: none; }
-                .category-button .emoji-icon { color: white !important; }
-                #app-title { background-image: linear-gradient(to right, #22d3ee, #c084fc) !important; }
-                #choose-style-title, #your-prompt-title { color: white !important; }
-                #lang-en, #lang-tr { color: #bfdbfe !important; }
-                #lang-en.active, #lang-tr.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
-                .theme-toggle-container i { color: #bfdbfe !important; }
-                .theme-toggle-container button { color: #bfdbfe !important; }
-                .theme-toggle-container button.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
-                .absolute.top-4.right-4 i { color: #93c5fd !important; }
-          `
-        };
-        if (earlyStyles[savedTheme]) {
-          styleEl.textContent = earlyStyles[savedTheme];
+        const linkEl = document.getElementById('theme-css');
+        if (linkEl) {
+          linkEl.href = `css/theme-${savedTheme}.css`;
         }
       })();
     </script>
@@ -546,70 +419,16 @@
         const langTrButton = document.getElementById('lang-tr');
         const themeLightButton = document.getElementById('theme-light');
         const themeDarkButton = document.getElementById('theme-dark');
-        const themeStyleElement = document.getElementById('theme-styles');
+        const themeLinkElement = document.getElementById('theme-css');
 
         // --- Theme Toggle Logic ---
         const THEMES = { LIGHT: 'light', DARK: 'dark' };
-        const themeStyles = {
-            [THEMES.LIGHT]: `
-                body { background-image: linear-gradient(to bottom right, #f0f4ff, #d9e2ff, #c4d1ff) !important; color: #1a1a2e !important; }
-                .bg-white\/10 { background-color: rgba(255, 255, 255, 0.8) !important; border-color: rgba(0, 0, 0, 0.1) !important; }
-                .bg-black\/30 { background-color: rgba(0, 0, 0, 0.05) !important; color: #1e293b !important; }
-                .text-blue-200 { color: #4338ca !important; }
-                .text-blue-300 { color: #3730a3 !important; }
-                .border-white\/20 { border-color: rgba(0, 0, 0, 0.1) !important; }
-                .bg-black\/20 { background-color: rgba(0, 0, 0, 0.05) !important; }
-                .hover\:bg-white\/10:hover { background-color: rgba(0, 0, 0, 0.1) !important; }
-                .bg-white\/30 { background-color: rgba(0, 0, 0, 0.2) !important; }
-                .hover\:bg-white\/30:hover { background-color: rgba(0, 0, 0, 0.3) !important; }
-                .focus\:ring-white\/50:focus { --tw-ring-color: rgba(0, 0, 0, 0.3) !important; }
-                .category-button { background-color: rgba(0, 0, 0, 0.08) !important; color: #1a1a2e !important; border: 1px solid rgba(0, 0, 0, 0.1) !important; }
-                .category-button:hover { background-color: rgba(0, 0, 0, 0.15) !important; }
-                .category-button.selected { background-image: linear-gradient(to right, #6366f1, #8b5cf6) !important; color: white !important; border-color: transparent !important; }
-                .category-button .lucide { color: #4f46e5 !important; display: none; }
-                .category-button.selected .lucide { color: white !important; }
-                .category-button .emoji-icon { color: #4f46e5 !important; }
-                .category-button.selected .emoji-icon { color: white !important; }
-                #app-title { background-image: linear-gradient(to right, #4f46e5, #7c3aed) !important; }
-                #choose-style-title, #your-prompt-title { color: #1e293b !important; }
-                #lang-en, #lang-tr { color: #4338ca !important; }
-                #lang-en.active, #lang-tr.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
-                .theme-toggle-container i { color: #4338ca !important; }
-                .theme-toggle-container button { color: #4338ca !important; }
-                .theme-toggle-container button.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
-                .absolute.top-4.right-4 i { color: #4338ca !important; }
-            `,
-            [THEMES.DARK]: `
-                body { background-image: linear-gradient(to bottom right, #581c87, #1e3a8a, #312e81) !important; color: white !important; }
-                .bg-white\/10 { background-color: rgba(255, 255, 255, 0.1) !important; border-color: rgba(255, 255, 255, 0.2) !important; }
-                .bg-black\/30 { background-color: rgba(0, 0, 0, 0.3) !important; color: white !important; }
-                .text-blue-200 { color: #bfdbfe !important; }
-                .text-blue-300 { color: #93c5fd !important; }
-                .border-white\/20 { border-color: rgba(255, 255, 255, 0.2) !important; }
-                .bg-black\/20 { background-color: rgba(0, 0, 0, 0.2) !important; }
-                .hover\:bg-white\/10:hover { background-color: rgba(255, 255, 255, 0.1) !important; }
-                .bg-white\/30 { background-color: rgba(255, 255, 255, 0.3) !important; }
-                .hover\:bg-white\/30:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
-                .focus\:ring-white\/50:focus { --tw-ring-color: rgba(255, 255, 255, 0.5) !important; }
-                .category-button { background-color: rgba(255, 255, 255, 0.2) !important; color: white !important; border: 1px solid rgba(255, 255, 255, 0.1) !important; }
-                .category-button:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
-                .category-button.selected { background-image: linear-gradient(to right, #a855f7, #ec4899) !important; color: white !important; border-color: transparent !important; }
-                .category-button .lucide { color: white !important; display: none; }
-                .category-button .emoji-icon { color: white !important; }
-                #app-title { background-image: linear-gradient(to right, #22d3ee, #c084fc) !important; }
-                #choose-style-title, #your-prompt-title { color: white !important; }
-                #lang-en, #lang-tr { color: #bfdbfe !important; }
-                #lang-en.active, #lang-tr.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
-                .theme-toggle-container i { color: #bfdbfe !important; }
-                .theme-toggle-container button { color: #bfdbfe !important; }
-                .theme-toggle-container button.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
-                .absolute.top-4.right-4 i { color: #93c5fd !important; }
-            `
-        };
 
         const setTheme = (theme) => {
             appState.theme = theme;
-            themeStyleElement.textContent = themeStyles[theme];
+            if (themeLinkElement) {
+                themeLinkElement.href = `css/theme-${theme}.css`;
+            }
             if (theme === THEMES.LIGHT) {
                 themeLightButton.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
                 themeLightButton.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,9 @@ const ASSETS = [
   './tailwind.js',
   './prompts.js',
   './lucide.min.js',
-  './icons/logo.svg'
+  './icons/logo.svg',
+  './css/theme-dark.css',
+  './css/theme-light.css'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- create `css/theme-dark.css` and `css/theme-light.css`
- link the proper theme stylesheet in `index.html`
- swap the theme stylesheet via JavaScript rather than inline styles
- cache the new CSS files in the service worker

## Testing
- `node --check prompts.js`
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68474e2490bc832fb1f4facc171c6221