### PR TITLE
Add cache versioning from manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Simply open `index.html` in any modern web browser. You can double‑click the f
 
 When served from a local web server (for example `python3 -m http.server`) the app installs a small service worker that caches `index.html`, `tailwind.js`, `lucide.min.js`, `prompts.js` and the logo in `icons/logo.svg`. After an initial visit you can disconnect from the network and the generator will still load and function normally.
 
+### Versioning
+
+The service worker reads the `version` field from `manifest.json` and names its cache accordingly (for example `prompter-v3`). When the version changes, any old caches are removed automatically during activation so users receive the latest files.
+
 ## Customization
 
 ### Theme

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "name": "Prompter",
   "short_name": "Prompter",
   "theme_color": "#000000",
+  "version": "3",
   "start_url": "./",
   "icons": [
     {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,16 @@
-const CACHE_NAME = 'prompter-v3';
+let CACHE_NAME = 'prompter-v1';
+
+async function updateCacheName() {
+  try {
+    const res = await fetch('./manifest.json', {cache: 'no-cache'});
+    const manifest = await res.json();
+    if (manifest.version) {
+      CACHE_NAME = `prompter-v${manifest.version}`;
+    }
+  } catch (e) {
+    // ignore and use default
+  }
+}
 const ASSETS = [
   './',
   './index.html',
@@ -12,17 +24,23 @@ const ASSETS = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+    (async () => {
+      await updateCacheName();
+      const cache = await caches.open(CACHE_NAME);
+      await cache.addAll(ASSETS);
+    })()
   );
 });
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
+    (async () => {
+      await updateCacheName();
+      const keys = await caches.keys();
+      await Promise.all(
         keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      )
-    )
+      );
+    })()
   );
 });
 


### PR DESCRIPTION
## Summary
- read a version field from `manifest.json`
- update `sw.js` to use that version in its cache name and clear old caches
- document the versioning approach in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68475d9f9438832faf36fc7945717abe