### PR TITLE
Add sharing support with Web Share API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Prompt templates are now loaded from a separate `prompts.js` file for faster pag
 - Light and dark themes
 - English and Turkish interface
 - Twelve prompt categories with over 1.7M combinations
+- Share prompts via the Web Share API or copy link fallback
 This **AI prompt generator** delivers **creative prompt ideas** in a lightweight **offline web app** that runs directly in your browser.
 
 
@@ -18,7 +19,7 @@ This **AI prompt generator** delivers **creative prompt ideas** in a lightweight
 
 Simply open `index.html` in any modern web browser. You can double‑click the file or use your browser's **Open File** option. No server setup is required.
 
-When served from a local web server (for example `python3 -m http.server`) the app installs a small service worker that caches `index.html`, `tailwind.js`, `lucide.min.js`, `prompts.js` and the logo in `icons/logo.svg`. After an initial visit you can disconnect from the network and the generator will still load and function normally.
+When served from a local web server (for example `python3 -m http.server`) the app installs a small service worker that caches `index.html`, `tailwind.js`, `lucide.min.js`, `prompts.js`, both theme CSS files and the logo in `icons/logo.svg`. After an initial visit you can disconnect from the network and the generator will still load and function normally.
 
 ## Customization
 

--- a/index.html
+++ b/index.html
@@ -313,6 +313,9 @@
                 <button id="download-button" class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50" title="Download as .txt" aria-label="Download as .txt">
                   <i data-lucide="download" class="w-4 h-4" aria-hidden="true"></i>
                 </button>
+                <button id="share-button" class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50" title="Share" aria-label="Share">
+                  <i data-lucide="share-2" class="w-4 h-4" aria-hidden="true"></i>
+                </button>
               </div>
             </div>
             <div id="generated-prompt-text" class="bg-black/30 rounded-xl p-3 leading-relaxed whitespace-pre-wrap text-base font-mono selection:bg-purple-500 selection:text-white">
@@ -369,6 +372,8 @@
             yourPromptTitle: "Your Unique Prompt:",
             copyButtonTitle: "Copy to clipboard",
             downloadButtonTitle: "Download as .txt",
+            shareButtonTitle: "Share",
+            shareButtonFallback: "Prompt copied to clipboard!",
             copySuccessMessage: "Prompt copied successfully!",
             appStats: "Prompts that will unlock the potential of your mind",
             footerPrompter: "Prompter",
@@ -384,6 +389,8 @@
             yourPromptTitle: "Benzersiz Promptunuz:",
             copyButtonTitle: "Panoya kopyala",
             downloadButtonTitle: ".txt olarak indir",
+            shareButtonTitle: "Paylaş",
+            shareButtonFallback: "Prompt panoya kopyalandı!",
             copySuccessMessage: "Prompt başarıyla kopyalandı!",
             appStats: "Zihninizin potansiyelini açığa çıkaracak promptlar",
             footerPrompter: "Prompter",
@@ -423,6 +430,7 @@
         const generatedPromptText = document.getElementById('generated-prompt-text');
         const copyButton = document.getElementById('copy-button');
         const downloadButton = document.getElementById('download-button');
+        const shareButton = document.getElementById('share-button');
         const copySuccessMessage = document.getElementById('copy-success-message');
         const langEnButton = document.getElementById('lang-en');
         const langTrButton = document.getElementById('lang-tr');
@@ -469,6 +477,8 @@
             copyButton.setAttribute('aria-label', uiText[lang].copyButtonTitle);
             downloadButton.title = uiText[lang].downloadButtonTitle;
             downloadButton.setAttribute('aria-label', uiText[lang].downloadButtonTitle);
+            shareButton.title = uiText[lang].shareButtonTitle;
+            shareButton.setAttribute('aria-label', uiText[lang].shareButtonTitle);
             copySuccessMessage.textContent = uiText[lang].copySuccessMessage;
             document.getElementById('app-stats').textContent = uiText[lang].appStats;
             document.getElementById('footer-prompter').textContent = uiText[lang].footerPrompter;
@@ -623,6 +633,31 @@
                 a.click();
                 document.body.removeChild(a);
                 URL.revokeObjectURL(url);
+            });
+
+            // Share button
+            shareButton.addEventListener('click', async () => {
+                if (!appState.generatedPrompt) return;
+                const shareData = {
+                    title: 'Prompter',
+                    text: appState.generatedPrompt,
+                    url: window.location.href
+                };
+                if (navigator.share) {
+                    try {
+                        await navigator.share(shareData);
+                    } catch (err) {
+                        console.error('Share failed:', err);
+                    }
+                } else if (navigator.clipboard) {
+                    try {
+                        await navigator.clipboard.writeText(`${shareData.text}\n\n${shareData.url}`);
+                        alert(uiText[appState.language].shareButtonFallback);
+                    } catch (err) {
+                        console.error('Fallback share failed:', err);
+                        alert('Failed to share prompt. Please try again.');
+                    }
+                }
             });
 
             // Language buttons

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'prompter-v3';
+const CACHE_NAME = 'prompter-v4';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- implement a share button using the Web Share API with a clipboard fallback
- localize share button labels
- bump service worker cache version
- mention share feature and updated cache list in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68475df83178832f8604543778cd661d