### PR TITLE
Add meta theme color and keywords

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <meta name="twitter:title" content="AI Prompt Generator - Prompter">
     <meta name="twitter:description" content="Creative AI prompt generator that works offline.">
     <meta name="twitter:image" content="assets/screenshot.png">
+    <meta name="theme-color" content="#000000">
+    <meta name="keywords" content="prompt generator, ai prompts, creative prompts">
 <script>
   (function() {
     function addScript(src, onLoad) {


### PR DESCRIPTION
## Summary
- set black theme color for mobile browser UIs
- add a keywords meta tag for SEO

## Testing
- `npm test` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684761d6cc28832fbad6d709f0c66b4f