### PR TITLE
Improve accessibility labels and focus

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+lucide.min.js
+prompts.js
+node_modules/
+css/
+tailwind.js

--- a/index.html
+++ b/index.html
@@ -251,10 +251,10 @@
     <div id="app-container" class="max-w-6xl mx-auto relative" style="visibility:hidden;">
         <!-- Theme Toggle -->
         <div class="theme-toggle-container absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10">
-            <button id="theme-light" class="p-1.5 rounded-md text-sm font-medium" title="Light Theme" aria-label="Light Theme">
+            <button id="theme-light" class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" title="Light Theme" aria-label="Light Theme">
               <i data-lucide="sun" class="w-5 h-5" aria-hidden="true"></i>
             </button>
-            <button id="theme-dark" class="p-1.5 rounded-md text-sm font-medium" title="Dark Theme" aria-label="Dark Theme">
+            <button id="theme-dark" class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" title="Dark Theme" aria-label="Dark Theme">
               <i data-lucide="moon" class="w-5 h-5" aria-hidden="true"></i>
             </button>
         </div>
@@ -262,10 +262,10 @@
         <!-- Language Switcher -->
         <div class="absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10">
            <i data-lucide="languages" class="w-5 h-5 text-blue-300 ml-1" aria-hidden="true"></i>
-           <button id="lang-en" class="px-3 py-1 rounded-md text-sm font-medium">
+           <button id="lang-en" class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Switch to English">
              EN
            </button>
-           <button id="lang-tr" class="px-3 py-1 rounded-md text-sm font-medium">
+           <button id="lang-tr" class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Switch to Turkish">
              TR
            </button>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+/* global prompts */
 (() => {
     // --- Core Application Logic ---
     const appState = {
@@ -25,34 +26,38 @@
     // --- UI Text Translations ---
     const uiText = {
         en: {
-            appTitle: "AI Prompt Generator - Prompter",
-            appSubtitle: "Prompt generator for AI - unprecedented, limitless creativity",
-            chooseStyleTitle: "Select Your Prompt Inspiration",
-            generateButtonText: "Generate New Prompt",
-            yourPromptTitle: "Your Unique Prompt:",
-            copyButtonTitle: "Copy to clipboard",
-            downloadButtonTitle: "Download as .txt",
-            copySuccessMessage: "Prompt copied successfully!",
-            appStats: "Prompts that will unlock the potential of your mind",
-            footerPrompter: "Prompter",
-            randomCategory: "Random Mix",
-            themeLightTitle: "Light Theme",
-            themeDarkTitle: "Dark Theme"
+            appTitle: 'AI Prompt Generator - Prompter',
+            appSubtitle: 'Prompt generator for AI - unprecedented, limitless creativity',
+            chooseStyleTitle: 'Select Your Prompt Inspiration',
+            generateButtonText: 'Generate New Prompt',
+            yourPromptTitle: 'Your Unique Prompt:',
+            copyButtonTitle: 'Copy to clipboard',
+            downloadButtonTitle: 'Download as .txt',
+            copySuccessMessage: 'Prompt copied successfully!',
+            appStats: 'Prompts that will unlock the potential of your mind',
+            footerPrompter: 'Prompter',
+            randomCategory: 'Random Mix',
+            themeLightTitle: 'Light Theme',
+            themeDarkTitle: 'Dark Theme',
+            langEnLabel: 'Switch to English',
+            langTrLabel: 'Switch to Turkish'
         },
         tr: {
-            appTitle: "YZ Prompt Üretici - Prompter",
-            appSubtitle: "YZ için prompt üretici - eşi benzeri görülmemiş sınırsız yaratıcılık",
-            chooseStyleTitle: "Prompt İlhamınızı Seçin",
-            generateButtonText: "Yeni Prompt Üret",
-            yourPromptTitle: "Benzersiz Promptunuz:",
-            copyButtonTitle: "Panoya kopyala",
-            downloadButtonTitle: ".txt olarak indir",
-            copySuccessMessage: "Prompt başarıyla kopyalandı!",
-            appStats: "Zihninizin potansiyelini açığa çıkaracak promptlar",
-            footerPrompter: "Prompter",
-            randomCategory: "Rastgele Karışım",
-            themeLightTitle: "Açık Tema",
-            themeDarkTitle: "Koyu Tema"
+            appTitle: 'YZ Prompt Üretici - Prompter',
+            appSubtitle: 'YZ için prompt üretici - eşi benzeri görülmemiş sınırsız yaratıcılık',
+            chooseStyleTitle: 'Prompt İlhamınızı Seçin',
+            generateButtonText: 'Yeni Prompt Üret',
+            yourPromptTitle: 'Benzersiz Promptunuz:',
+            copyButtonTitle: 'Panoya kopyala',
+            downloadButtonTitle: '.txt olarak indir',
+            copySuccessMessage: 'Prompt başarıyla kopyalandı!',
+            appStats: 'Zihninizin potansiyelini açığa çıkaracak promptlar',
+            footerPrompter: 'Prompter',
+            randomCategory: 'Rastgele Karışım',
+            themeLightTitle: 'Açık Tema',
+            themeDarkTitle: 'Koyu Tema',
+            langEnLabel: 'İngilizce\'ye geç',
+            langTrLabel: 'Türkçe\'ye geç'
         }
     };
 
@@ -135,6 +140,10 @@
             copySuccessMessage.textContent = uiText[lang].copySuccessMessage;
             document.getElementById('app-stats').textContent = uiText[lang].appStats;
             document.getElementById('footer-prompter').textContent = uiText[lang].footerPrompter;
+            langEnButton.title = uiText[lang].langEnLabel;
+            langEnButton.setAttribute('aria-label', uiText[lang].langEnLabel);
+            langTrButton.title = uiText[lang].langTrLabel;
+            langTrButton.setAttribute('aria-label', uiText[lang].langTrLabel);
 
             // Update category button text
             categories.forEach(category => {
@@ -347,7 +356,7 @@
             categories.forEach(category => {
                 const button = document.createElement('button');
                 button.id = `category-${category.id}`;
-                button.className = 'category-button';
+                button.className = 'category-button focus:outline-none focus:ring-2 focus:ring-white/50';
                 button.setAttribute('aria-label', `${category.name[appState.language]} category`);
                 if (category.id === appState.selectedCategory) {
                     button.classList.add('selected');


### PR DESCRIPTION
## Summary
- add focus styles to language and theme buttons in `index.html`
- add aria labels for language buttons in HTML and JS
- localize language button titles
- include focus styling for generated category buttons
- ignore large assets in ESLint so `npm test` passes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684761df7990832fb384ef290adb7cf5