### PR TITLE
Improve translation workflow and dynamic language detection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "env": {
     "browser": true,
-    "es2021": true
+    "es2021": true,
+    "node": true
   },
   "extends": "eslint:recommended",
   "parserOptions": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,14 @@ This guide explains how to set up the project, run tests, lint and format the co
    ```
    Then open `http://localhost:8000` in your browser or simply open `index.html` directly.
 
+## Translations
+
+We welcome new language contributions.
+
+1. Create a folder under `prompts/<lang>` with JSON files for each category.
+2. Add the interface text and category names for the language in `src/main.js`.
+3. Run `npm run build` to regenerate `prompts.js` before opening a pull request.
+
 ## Running tests
 
 The project uses **ESLint** as its test suite. Run:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,22 @@ The service worker reads the `version` field from `manifest.json` and names its 
 
 ### Language
 
-- Prompter currently supports **English** (`EN`) and **Turkish** (`TR`).
-- Use the language switcher in the top‑right corner to choose your interface language. The setting persists in your browser.
+- Available languages are detected from folders under `prompts`. Add a directory
+  like `prompts/es` and the switcher will offer Spanish once the JSON files are
+  in place.
+- Use the language switcher in the top‑right corner to choose your interface
+  language. The setting persists in your browser.
+
+#### Adding a new language
+
+1. Create a folder `prompts/<lang>` where `<lang>` is the language code (e.g.
+   `prompts/es`).
+2. Copy the files from `prompts/en` as a starting point and translate the prompt
+   parts.
+3. Add UI text and category labels in `src/main.js` within the `uiText` object
+   and `categories` array.
+4. Run `npm run build` to regenerate `prompts.js` if you include the bundled
+   prompts file.
 
 ## Categories
 

--- a/index.html
+++ b/index.html
@@ -260,14 +260,8 @@
         </div>
 
         <!-- Language Switcher -->
-        <div class="absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10">
+        <div id="language-switcher" class="absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10">
            <i data-lucide="languages" class="w-5 h-5 text-blue-300 ml-1" aria-hidden="true"></i>
-           <button id="lang-en" class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Switch to English">
-             EN
-           </button>
-           <button id="lang-tr" class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Switch to Turkish">
-             TR
-           </button>
         </div>
 
         <!-- Header -->
@@ -334,6 +328,7 @@
         </div>
     </div>
 
+<script src="prompts.js"></script>
 <script src="src/main.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-/* global prompts */
+
 (() => {
     // --- Core Application Logic ---
     const appState = {
@@ -104,7 +104,9 @@
             randomCategory: 'Rastgele Karışım',
             themeLightTitle: 'Açık Tema',
             themeDarkTitle: 'Koyu Tema',
+            // prettier-ignore
             langEnLabel: 'İngilizce\'ye geç',
+            // prettier-ignore
             langTrLabel: 'Türkçe\'ye geç'
         }
     };
@@ -140,8 +142,9 @@
         const copyButton = document.getElementById('copy-button');
         const downloadButton = document.getElementById('download-button');
         const copySuccessMessage = document.getElementById('copy-success-message');
-        const langEnButton = document.getElementById('lang-en');
-        const langTrButton = document.getElementById('lang-tr');
+        const languageSwitcher = document.getElementById('language-switcher');
+        const langButtons = {};
+        let availableLanguages = [];
         const themeLightButton = document.getElementById('theme-light');
         const themeDarkButton = document.getElementById('theme-dark');
         const themeLinkElement = document.getElementById('theme-css');
@@ -188,10 +191,14 @@
             copySuccessMessage.textContent = uiText[lang].copySuccessMessage;
             document.getElementById('app-stats').textContent = uiText[lang].appStats;
             document.getElementById('footer-prompter').textContent = uiText[lang].footerPrompter;
-            langEnButton.title = uiText[lang].langEnLabel;
-            langEnButton.setAttribute('aria-label', uiText[lang].langEnLabel);
-            langTrButton.title = uiText[lang].langTrLabel;
-            langTrButton.setAttribute('aria-label', uiText[lang].langTrLabel);
+            if (langButtons.en && uiText[lang].langEnLabel) {
+                langButtons.en.title = uiText[lang].langEnLabel;
+                langButtons.en.setAttribute('aria-label', uiText[lang].langEnLabel);
+            }
+            if (langButtons.tr && uiText[lang].langTrLabel) {
+                langButtons.tr.title = uiText[lang].langTrLabel;
+                langButtons.tr.setAttribute('aria-label', uiText[lang].langTrLabel);
+            }
 
             // Update category button text
             categories.forEach(category => {
@@ -206,17 +213,17 @@
             });
 
             // Update language button styles
-            if (lang === 'en') {
-                langEnButton.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
-                langEnButton.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-                langTrButton.classList.remove('active', 'bg-white/30', 'text-white', 'shadow-md');
-                langTrButton.classList.add('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-            } else {
-                langTrButton.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
-                langTrButton.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-                langEnButton.classList.remove('active', 'bg-white/30', 'text-white', 'shadow-md');
-                langEnButton.classList.add('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-            }
+            availableLanguages.forEach(code => {
+                const btn = langButtons[code];
+                if (!btn) return;
+                if (code === lang) {
+                    btn.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
+                    btn.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
+                } else {
+                    btn.classList.remove('active', 'bg-white/30', 'text-white', 'shadow-md');
+                    btn.classList.add('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
+                }
+            });
             localStorage.setItem('language', lang);
             // Update theme button titles based on language
             updateButtonTitles();
@@ -348,8 +355,9 @@
             });
 
             // Language buttons
-            langEnButton.addEventListener('click', () => setLanguage('en'));
-            langTrButton.addEventListener('click', () => setLanguage('tr'));
+            Object.keys(langButtons).forEach(code => {
+                langButtons[code].addEventListener('click', () => setLanguage(code));
+            });
 
             // Theme buttons
             themeLightButton.addEventListener('click', () => setTheme(THEMES.LIGHT));
@@ -394,8 +402,24 @@
                 return false;
             };
 
-            // Load saved language or default to 'en'
-            const savedLanguage = localStorage.getItem('language') || 'en';
+            // Determine available languages
+            if (window.prompts) {
+                availableLanguages = Object.keys(window.prompts);
+            } else {
+                availableLanguages = Object.keys(uiText);
+            }
+
+            languageSwitcher.innerHTML = '';
+            availableLanguages.forEach(code => {
+                const btn = document.createElement('button');
+                btn.id = `lang-${code}`;
+                btn.className = 'px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50';
+                btn.textContent = code.toUpperCase();
+                languageSwitcher.appendChild(btn);
+                langButtons[code] = btn;
+            });
+
+            const savedLanguage = localStorage.getItem('language') || availableLanguages[0] || 'en';
             setLanguage(savedLanguage);
 
             // Load saved theme or default to 'dark'

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ async function updateCacheName() {
     if (manifest.version) {
       CACHE_NAME = `prompter-v${manifest.version}`;
     }
-  } catch (e) {
+  } catch {
     // ignore and use default
   }
 }


### PR DESCRIPTION
## Summary
- document how to add prompt folders for new languages
- invite translators in `CONTRIBUTING.md`
- autodetect available languages from folders in `src/main.js`
- wire up dynamic language buttons in `index.html`
- load bundled `prompts.js`
- minor ESLint config tweak and service worker cleanup

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e6397f74832f86b68a56ce86995b