### PR TITLE
Add prompts validation script and integrate with tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ lucide.min.js
 node_modules/
 css/
 tailwind.js
+prompts.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,json,md,css,html}\"",
-    "test": "npm run lint",
+    "test": "npm run lint && node scripts/validate-prompts.js",
     "build": "node scripts/build.js"
   },
   "devDependencies": {

--- a/prompts/en/educational.json
+++ b/prompts/en/educational.json
@@ -66,7 +66,7 @@
       "with fun analogies",
       "with hands-on examples",
       "highlighting key discoveries",
-      "through engaging stories",
+      "with fun stories",
       "using step-by-step explanations",
       "including quick exercises",
       "with approachable metaphors",

--- a/prompts/en/video.json
+++ b/prompts/en/video.json
@@ -84,7 +84,7 @@
       "Include a surprising twist.",
       "End with a call to action.",
       "Shareable on social media.",
-      "Shareable on social media.",
+      "Perfect for social sharing.",
       "Leave room for sequels.",
       "Keep scenes brief.",
       "Use dynamic music.",

--- a/scripts/validate-prompts.js
+++ b/scripts/validate-prompts.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const path = require('path');
+
+const promptsDir = path.join(__dirname, '..', 'prompts');
+
+function readJSON(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function flatten(parts) {
+  return parts.reduce((acc, arr) => acc.concat(arr), []);
+}
+
+function validate() {
+  const languages = fs
+    .readdirSync(promptsDir)
+    .filter((p) => fs.statSync(path.join(promptsDir, p)).isDirectory());
+
+  const categories = new Set();
+  languages.forEach((lang) => {
+    const langDir = path.join(promptsDir, lang);
+    fs.readdirSync(langDir)
+      .filter((f) => f.endsWith('.json'))
+      .forEach((f) => categories.add(f));
+  });
+
+  let valid = true;
+
+  categories.forEach((cat) => {
+    const partsByLang = {};
+
+    languages.forEach((lang) => {
+      const filePath = path.join(promptsDir, lang, cat);
+      if (!fs.existsSync(filePath)) {
+        console.error(`Missing file ${lang}/${cat}`);
+        valid = false;
+        return;
+      }
+
+      const json = readJSON(filePath);
+      if (!Array.isArray(json.parts)) {
+        console.error(`Invalid or missing parts in ${lang}/${cat}`);
+        valid = false;
+        return;
+      }
+      partsByLang[lang] = json.parts;
+
+      const flat = flatten(json.parts);
+      const seen = new Set();
+      const dups = new Set();
+      flat.forEach((p) => {
+        if (seen.has(p)) dups.add(p);
+        seen.add(p);
+      });
+      if (dups.size > 0) {
+        console.error(`Duplicate entries in ${lang}/${cat}: ${Array.from(dups).join(', ')}`);
+        valid = false;
+      }
+    });
+
+    const counts = Object.fromEntries(
+      Object.entries(partsByLang).map(([lang, parts]) => [lang, parts.length])
+    );
+    const uniqueCounts = new Set(Object.values(counts));
+    if (uniqueCounts.size > 1) {
+      console.error(
+        `Part count mismatch for ${cat}: ${Object.entries(counts)
+          .map(([l, c]) => `${l}=${c}`)
+          .join(', ')}`
+      );
+      valid = false;
+    }
+  });
+
+  if (!valid) {
+    console.error('Prompt validation failed.');
+    process.exit(1);
+  } else {
+    console.log('All prompt files validated.');
+  }
+}
+
+if (require.main === module) {
+  validate();
+}
+
+module.exports = validate;


### PR DESCRIPTION
## Summary
- add new `scripts/validate-prompts.js` which checks prompt pairs for duplicate entries and mismatched part counts
- ignore generated `prompts.js` for ESLint
- fix duplicate entries in English prompts
- run the validation script as part of `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480aa8c6b8832fac4c49f557a011fb