### PR TITLE
Fix duplicate phrase in educational prompts

### DIFF
--- a/prompts/en/educational.json
+++ b/prompts/en/educational.json
@@ -66,7 +66,7 @@
       "with fun analogies",
       "with hands-on examples",
       "highlighting key discoveries",
-      "through engaging stories",
+      "through immersive narratives",
       "using step-by-step explanations",
       "including quick exercises",
       "with approachable metaphors",


### PR DESCRIPTION
## Summary
- replace a duplicate "through engaging stories" entry in `educational.json` with "through immersive narratives"

## Testing
- `npm test` *(fails: ESLint couldn't find a configuration file)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68481190ae64832fbe7e6c8200e16a68