### PR TITLE
Fix punctuation for generated prompts

### DIFF
--- a/src/prompts.js
+++ b/src/prompts.js
@@ -20,18 +20,21 @@ const join = (arr) =>
 const punctuate = (str) => (/[.!?]$/.test(str) ? str : str + '.');
 
 const structures = {
-  singleSentence: (parts) => join(parts),
+  singleSentence: (parts) => punctuate(join(parts)),
   twoSentence: (parts) => {
     const first = punctuate(join(parts.slice(0, 3)));
-    return `${first} ${parts[3].trim()}`;
+    const second = punctuate(parts[3].trim());
+    return `${first} ${second}`;
   },
   questionThenInstruction: (parts) => {
     const first = punctuate(join(parts.slice(0, 2)));
-    return `${first} ${parts[2].trim()} ${parts[3].trim()}`;
+    const rest = `${parts[2].trim()} ${parts[3].trim()}`;
+    return `${first} ${punctuate(rest)}`;
   },
   imageStructure: (parts) => {
     const first = punctuate(join(parts.slice(0, 2)));
-    return `${first} ${parts[2].trim()} ${parts[3].trim()}`;
+    const rest = `${parts[2].trim()} ${parts[3].trim()}`;
+    return `${first} ${punctuate(rest)}`;
   },
 };
 


### PR DESCRIPTION
## Summary
- ensure generated prompts always end with punctuation
- add fallback punctuation to all structure functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a97a7aa24832fb88a8a8a61e0a0d4