### PR TITLE
Fix punctuation when using preloaded prompts

### DIFF
--- a/src/prompts.js
+++ b/src/prompts.js
@@ -74,13 +74,14 @@ export const ICON_FALLBACKS = {
 export const loadCategory = async (lang, cat) => {
   loadedPrompts[lang] = loadedPrompts[lang] || {};
   if (loadedPrompts[lang][cat]) return loadedPrompts[lang][cat];
+  let data;
   if (window.prompts && window.prompts[lang] && window.prompts[lang][cat]) {
-    loadedPrompts[lang][cat] = window.prompts[lang][cat];
-    return loadedPrompts[lang][cat];
+    data = { ...window.prompts[lang][cat] };
+  } else {
+    const res = await fetch(`prompts/${lang}/${cat}.json`);
+    data = await res.json();
   }
-  const res = await fetch(`prompts/${lang}/${cat}.json`);
-  const data = await res.json();
-  data.structure = structures[catMap[cat]];
+  data = { ...data, structure: structures[catMap[cat]] };
   loadedPrompts[lang][cat] = data;
   return data;
 };


### PR DESCRIPTION
## Summary
- include `structure` on prompts loaded from `window.prompts`
- avoid mutating global prompt data when loading categories

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684a9aced108832fa12620243637ebdc