### PR TITLE
Add prompt lint checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,json,md,css,html}\"",
-    "test": "npm run lint",
+    "test": "npm run lint && npm run lint:prompts",
+    "lint:prompts": "node scripts/check-prompts.js",
     "build": "node scripts/build-prompts.js",
     "start": "http-server -c-1"
   },

--- a/scripts/check-prompts.js
+++ b/scripts/check-prompts.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const promptsDir = path.join(__dirname, '..', 'prompts');
+
+function listPromptFiles() {
+  const files = [];
+  for (const lang of fs.readdirSync(promptsDir)) {
+    const langDir = path.join(promptsDir, lang);
+    if (!fs.statSync(langDir).isDirectory()) continue;
+    for (const file of fs.readdirSync(langDir)) {
+      if (file.endsWith('.json')) {
+        files.push(path.join(langDir, file));
+      }
+    }
+  }
+  return files;
+}
+
+function checkFile(file) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const errors = [];
+  if (!Array.isArray(data.parts)) return errors;
+  data.parts.slice(0, 3).forEach((arr, partIdx) => {
+    if (!Array.isArray(arr)) return;
+    arr.forEach((str, idx) => {
+      if (typeof str !== 'string') return;
+      const hasSpace = str.trim() !== str;
+      const hasPunct = /[.!?]$/.test(str);
+      if (hasSpace || hasPunct) {
+        errors.push(`${path.relative(process.cwd(), file)} [${partIdx}:${idx}] "${str}"`);
+      }
+    });
+  });
+  return errors;
+}
+
+let allErrors = [];
+for (const file of listPromptFiles()) {
+  allErrors = allErrors.concat(checkFile(file));
+}
+
+if (allErrors.length) {
+  console.error('Prompt format issues found:');
+  for (const err of allErrors) {
+    console.error(' -', err);
+  }
+  process.exitCode = 1;
+} else {
+  console.log('All prompts look good.');
+}


### PR DESCRIPTION
## Summary
- add `scripts/check-prompts.js` to validate prompt JSON files
- wire new `lint:prompts` script into `npm test`

## Testing
- `npm test > /tmp/test.log 2>&1; tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_684aab6fdc7c832f91f6c5ada7286778