### PR TITLE
docs: emphasize installing deps before tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ This guide explains how to set up the project, run tests, lint and format the co
    ```
    This project uses **ESLint v8.57.0**, which is installed as a dev
    dependency. Make sure your editor uses this version for linting.
+   Run this command before executing `npm test` so the linter can run correctly.
 4. (Optional) Start a local web server to use the app:
    ```bash
    python3 -m http.server
@@ -29,6 +30,9 @@ The project uses **ESLint** as its test suite. Run:
 ```bash
 npm test
 ```
+
+Make sure you have run `npm install` at least once before running the tests so
+that all required packages are available.
 
 This will lint the codebase and report any issues.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ of strings. These arrays represent the beginning, topic, continuation and ending
 ## Development
 
 This repository uses ESLint and Prettier for code quality. After cloning the
-project, run `npm install` to install the dependencies.
+project, run `npm install` to install the dependencies. Always run this command
+before executing `npm test` so the required tooling is available.
 
 Before committing changes run:
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,json,md,css,html}\"",
+    "pretest": "node scripts/check-node-modules.js",
     "test": "npm run lint && npm run lint:prompts",
     "lint:prompts": "node scripts/check-prompts.js",
     "build": "node scripts/build-prompts.js",

--- a/scripts/check-node-modules.js
+++ b/scripts/check-node-modules.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const modulesDir = path.join(__dirname, '..', 'node_modules');
+
+if (!fs.existsSync(modulesDir)) {
+  console.error('Dependencies missing. Run "npm install" before "npm test".');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- clarify in README that `npm install` must run before `npm test`
- note the same in CONTRIBUTING
- add a `pretest` script that checks for a `node_modules` directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad6b3d780832f8acbec1eee32ccef