### PR TITLE
Add prompt counting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The service worker reads the `version` field from `manifest.json` and names its 
 
 - Prompter currently supports **English** (`EN`) and **Turkish** (`TR`).
 - Use the language switcher in the top‑right corner to choose your interface language. The setting persists in your browser.
+
 ## Accessibility
 
 Colors for both light and dark themes meet WCAG AA contrast requirements. Gradients and button styles were tested with automated tools and adjusted so text has at least a 4.5:1 contrast ratio against its background.
@@ -94,6 +95,7 @@ of strings. These arrays represent the beginning, topic, continuation and ending
 2. Register the category in `src/main.js` with an icon, emoji and names.
 3. Provide corresponding files for other languages to offer translations.
 4. Run `npm run build` to regenerate `prompts.js`, update `sw.js`, and bump the version in `manifest.json` so deployments include your changes.
+5. Run `node scripts/count-prompts.js` to see how many unique prompts each category provides per language.
 
 ## Development
 

--- a/scripts/count-prompts.js
+++ b/scripts/count-prompts.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const promptsDir = path.join(__dirname, '..', 'prompts');
+
+function listLanguages() {
+  return fs.readdirSync(promptsDir).filter((p) => {
+    const full = path.join(promptsDir, p);
+    return fs.statSync(full).isDirectory();
+  });
+}
+
+function countForFile(file) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (!Array.isArray(data.parts)) return 0;
+  return data.parts.reduce(
+    (acc, arr) => acc * (Array.isArray(arr) ? arr.length : 0),
+    1
+  );
+}
+
+const results = {};
+for (const lang of listLanguages()) {
+  const langDir = path.join(promptsDir, lang);
+  results[lang] = {};
+  for (const file of fs.readdirSync(langDir)) {
+    if (!file.endsWith('.json')) continue;
+    const key = path.basename(file, '.json');
+    const filePath = path.join(langDir, file);
+    const count = countForFile(filePath);
+    results[lang][key] = count;
+  }
+}
+
+for (const lang of Object.keys(results)) {
+  console.log(`${lang}:`);
+  const categories = results[lang];
+  for (const key of Object.keys(categories)) {
+    const count = categories[key];
+    console.log(`  ${key}: ${count.toLocaleString()}`);
+  }
+}


### PR DESCRIPTION
## Summary
- create `scripts/count-prompts.js` for counting prompt combinations
- document how to use the script in the README

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ae75ce8c0832f926d4c1def94f341