### PR TITLE
Add sitemap generation script

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,8 @@ jobs:
         run: npm install
       - name: Generate prompts.js
         run: npm run build
+      - name: Generate sitemap
+        run: npm run build:sitemap
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ request workflow.
 
 The site is published automatically using GitHub Pages. The workflow
 [`pages.yml`](.github/workflows/pages.yml) installs dependencies, runs
-`npm run build` (which executes `scripts/build-prompts.js`) to generate `prompts.js`, update `sw.js`, bump the version in `manifest.json` and then uploads the artifact to GitHub Pages using
+`npm run build` (which executes `scripts/build-prompts.js`) and `npm run build:sitemap` to generate `prompts.js`, update `sw.js`, bump the version in `manifest.json`, create `sitemap.xml` and then upload the artifact using
 `actions/upload-pages-artifact` and `actions/deploy-pages`. Pushes to the
 `main` branch trigger a new deployment and the site becomes available at
 the repository's Pages URL.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "npm run lint && npm run lint:prompts",
     "lint:prompts": "node scripts/check-prompts.js",
     "build": "node scripts/build-prompts.js",
+    "build:sitemap": "node scripts/generate-sitemap.js",
     "start": "http-server -c-1"
   },
   "devDependencies": {

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const BASE_URL = 'https://example.com';
+
+const urls = [`${BASE_URL}/`, `${BASE_URL}/tr/`];
+
+const xml =
+  '<?xml version="1.0" encoding="UTF-8"?>\n' +
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+  urls.map((u) => `  <url><loc>${u}</loc></url>`).join('\n') +
+  '\n</urlset>\n';
+
+fs.writeFileSync(path.join(__dirname, '..', 'sitemap.xml'), xml);
+console.log('Wrote sitemap.xml');

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/tr/</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- generate a simple sitemap.xml via `generate-sitemap.js`
- add `build:sitemap` npm script
- run sitemap build step in GitHub Pages workflow
- mention sitemap generation in README
- include generated sitemap.xml

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8c5aa8bc832fb749fed3fd9c56a8