### PR TITLE
Add JSON-LD site metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,20 @@
     <link rel="canonical" href="https://example.com/">
     <link rel="alternate" href="https://example.com/" hreflang="en">
     <link rel="alternate" href="https://example.com/tr/" hreflang="tr">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "url": "https://example.com/",
+        "name": "Prompter",
+        "alternateName": "Prompter",
+        "inLanguage": ["en", "tr"],
+        "publisher": {
+          "@type": "Organization",
+          "name": "Prompter"
+        }
+      }
+    </script>
 <script>
   (function() {
     function addScript(src, onLoad) {


### PR DESCRIPTION
## Summary
- enrich SEO metadata with a structured data block describing the web app

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8ed5b89c832fa000b019bc9d5af6