### PR TITLE
Update URLs for production

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,14 @@
     <meta name="twitter:title" content="PROMPTER">
     <meta name="twitter:description" content="Creative AI prompt generator that works offline.">
     <meta name="twitter:image" content="icons/logo.svg">
-    <link rel="canonical" href="https://example.com/">
-    <link rel="alternate" href="https://example.com/" hreflang="en">
-    <link rel="alternate" href="https://example.com/tr/" hreflang="tr">
+    <link rel="canonical" href="https://muratcangencturk.github.io/prompter/">
+    <link rel="alternate" href="https://muratcangencturk.github.io/prompter/" hreflang="en">
+    <link rel="alternate" href="https://muratcangencturk.github.io/prompter/tr/" hreflang="tr">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "url": "https://example.com/",
+        "url": "https://muratcangencturk.github.io/prompter/",
         "name": "Prompter",
         "alternateName": "Prompter",
         "inLanguage": ["en", "tr"],

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://example.com/sitemap.xml
+Sitemap: https://muratcangencturk.github.io/prompter/sitemap.xml

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const BASE_URL = 'https://example.com';
+const BASE_URL = 'https://muratcangencturk.github.io/prompter';
 
 const urls = [`${BASE_URL}/`, `${BASE_URL}/tr/`];
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://example.com/</loc></url>
-  <url><loc>https://example.com/tr/</loc></url>
+  <url><loc>https://muratcangencturk.github.io/prompter/</loc></url>
+  <url><loc>https://muratcangencturk.github.io/prompter/tr/</loc></url>
 </urlset>

--- a/tr/index.html
+++ b/tr/index.html
@@ -20,14 +20,14 @@
     <meta name="twitter:title" content="PROMPTER">
     <meta name="twitter:description" content="Creative AI prompt generator that works offline.">
     <meta name="twitter:image" content="../icons/logo.svg">
-    <link rel="canonical" href="https://example.com/tr/">
-    <link rel="alternate" href="https://example.com/" hreflang="en">
-    <link rel="alternate" href="https://example.com/tr/" hreflang="tr">
+    <link rel="canonical" href="https://muratcangencturk.github.io/prompter/tr/">
+    <link rel="alternate" href="https://muratcangencturk.github.io/prompter/" hreflang="en">
+    <link rel="alternate" href="https://muratcangencturk.github.io/prompter/tr/" hreflang="tr">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "url": "https://example.com/tr/",
+        "url": "https://muratcangencturk.github.io/prompter/tr/",
         "name": "Prompter",
         "alternateName": "Prompter",
         "inLanguage": ["tr", "en"],


### PR DESCRIPTION
## Summary
- swap placeholder example.com with production URL for canonical links, sitemap, and robots.txt
- regenerate sitemap

## Testing
- `npm test`
- `npm run build:sitemap`

------
https://chatgpt.com/codex/tasks/task_e_684c9986f678832fbad8b39de18ee5ee