### PR TITLE
Add Turkish index to service worker assets

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "theme_color": "#000000",
   "background_color": "#000000",
   "display": "standalone",
-  "version": "15",
+  "version": "16",
   "start_url": "./",
   "icons": [
     {

--- a/scripts/build-prompts.js
+++ b/scripts/build-prompts.js
@@ -74,6 +74,7 @@ function updateServiceWorker(promptFiles) {
   const baseAssets = [
     './',
     './index.html',
+    './tr/index.html',
     './tailwind.js',
     './lucide.min.js',
     './src/main.js',

--- a/sw.js
+++ b/sw.js
@@ -14,6 +14,7 @@ async function updateCacheName() {
 const ASSETS = [
   './',
   './index.html',
+  './tr/index.html',
   './tailwind.js',
   './lucide.min.js',
   './src/main.js',


### PR DESCRIPTION
## Summary
- cache `tr/index.html` in service worker
- bump manifest version via build script

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c9ac46314832fb2296e850d33c353