### PR TITLE
Add history panel

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,123 +1,203 @@
 /* Custom styles */
 #loading-screen {
-    position: fixed;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: #000;
-    color: white;
-    z-index: 9999;
-    transition: opacity 0.3s ease;
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  color: white;
+  z-index: 9999;
+  transition: opacity 0.3s ease;
 }
-#loading-screen.hidden { opacity: 0; pointer-events: none; }
+#loading-screen.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
 #loading-screen .spinner {
-    width: 2rem;
-    height: 2rem;
-    border: 4px solid currentColor;
-    border-top-color: transparent;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
+  width: 2rem;
+  height: 2rem;
+  border: 4px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
 }
 body {
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    transition: background-color 0.3s ease, color 0.3s ease;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
 }
 .bg-gradient-to-br {
-    background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
 }
-.from-purple-900 { --tw-gradient-from: #581c87; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(88, 28, 135, 0)); }
-.via-blue-900 { --tw-gradient-stops: var(--tw-gradient-from), #1e3a8a, var(--tw-gradient-to, rgba(30, 58, 138, 0)); }
-.to-indigo-900 { --tw-gradient-to: #312e81; }
-.bg-gradient-to-r { background-image: linear-gradient(to right, var(--tw-gradient-stops)); }
-.from-cyan-400 { --tw-gradient-from: #22d3ee; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(34, 211, 238, 0)); }
-.to-purple-400 { --tw-gradient-to: #c084fc; }
-.from-purple-500 { --tw-gradient-from: #a855f7; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(168, 85, 247, 0)); }
-.to-pink-500 { --tw-gradient-to: #ec4899; }
-.from-cyan-500 { --tw-gradient-from: #06b6d4; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 182, 212, 0)); }
-.to-purple-500 { --tw-gradient-to: #a855f7; }
-.hover\:from-cyan-600:hover { --tw-gradient-from: #0891b2; }
-.hover\:to-purple-600:hover { --tw-gradient-to: #9333ea; }
-.bg-clip-text { background-clip: text; -webkit-background-clip: text; }
-.text-transparent { color: transparent; }
-.backdrop-blur-md { backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); }
-.selection\:bg-purple-500::selection { background-color: #a855f7; }
-.selection\:text-white::selection { color: white; }
+.from-purple-900 {
+  --tw-gradient-from: #581c87;
+  --tw-gradient-stops:
+    var(--tw-gradient-from), var(--tw-gradient-to, rgba(88, 28, 135, 0));
+}
+.via-blue-900 {
+  --tw-gradient-stops:
+    var(--tw-gradient-from), #1e3a8a,
+    var(--tw-gradient-to, rgba(30, 58, 138, 0));
+}
+.to-indigo-900 {
+  --tw-gradient-to: #312e81;
+}
+.bg-gradient-to-r {
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+.from-cyan-400 {
+  --tw-gradient-from: #22d3ee;
+  --tw-gradient-stops:
+    var(--tw-gradient-from), var(--tw-gradient-to, rgba(34, 211, 238, 0));
+}
+.to-purple-400 {
+  --tw-gradient-to: #c084fc;
+}
+.from-purple-500 {
+  --tw-gradient-from: #a855f7;
+  --tw-gradient-stops:
+    var(--tw-gradient-from), var(--tw-gradient-to, rgba(168, 85, 247, 0));
+}
+.to-pink-500 {
+  --tw-gradient-to: #ec4899;
+}
+.from-cyan-500 {
+  --tw-gradient-from: #06b6d4;
+  --tw-gradient-stops:
+    var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 182, 212, 0));
+}
+.to-purple-500 {
+  --tw-gradient-to: #a855f7;
+}
+.hover\:from-cyan-600:hover {
+  --tw-gradient-from: #0891b2;
+}
+.hover\:to-purple-600:hover {
+  --tw-gradient-to: #9333ea;
+}
+.bg-clip-text {
+  background-clip: text;
+  -webkit-background-clip: text;
+}
+.text-transparent {
+  color: transparent;
+}
+.backdrop-blur-md {
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.selection\:bg-purple-500::selection {
+  background-color: #a855f7;
+}
+.selection\:text-white::selection {
+  color: white;
+}
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 .animate-fadeIn {
   animation: fadeIn 0.5s ease-in-out;
 }
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 .animate-spin {
   animation: spin 1s linear infinite;
 }
 @keyframes pulse {
-  50% { opacity: .5; }
+  50% {
+    opacity: 0.5;
+  }
 }
 .animate-pulse {
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 .lucide {
-    width: 1em;
-    height: 1em;
-    stroke-width: 2;
-    stroke: currentColor;
-    fill: none;
-    stroke-linecap: round;
-    stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+  stroke-width: 2;
+  stroke: currentColor;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 .category-button {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 0.5rem;
-    border-radius: 0.75rem;
-    text-align: center;
-    transition: all 0.2s ease-in-out;
-    height: 5rem;
-    background-color: rgba(255, 255, 255, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+  text-align: center;
+  transition: all 0.2s ease-in-out;
+  height: 5rem;
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 .category-button:hover {
-    background-color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(255, 255, 255, 0.3);
 }
 .category-button.selected {
-    background-image: linear-gradient(to right, var(--tw-gradient-stops));
-    --tw-gradient-from: #a855f7;
-    --tw-gradient-to: #ec4899;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    transform: scale(1.05);
-    --tw-ring-color: #f472b6;
-    box-shadow: 0 0 0 2px var(--tw-ring-color);
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  --tw-gradient-from: #a855f7;
+  --tw-gradient-to: #ec4899;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  transform: scale(1.05);
+  --tw-ring-color: #f472b6;
+  box-shadow: 0 0 0 2px var(--tw-ring-color);
 }
 .category-button .lucide {
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-bottom: 0.25rem;
-    display: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-bottom: 0.25rem;
+  display: none;
 }
 .emoji-icon {
-    font-size: 1.5rem;
-    display: inline-block;
-    color: currentColor;
+  font-size: 1.5rem;
+  display: inline-block;
+  color: currentColor;
 }
 .category-button .emoji-icon {
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-bottom: 0.25rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-bottom: 0.25rem;
 }
 .category-button span {
-    font-size: 0.75rem;
-    font-weight: 500;
-    line-height: 1.1;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.1;
 }
 /* Theme Toggle Styles */
 .theme-toggle-container button {
-    transition: background-color 0.2s ease, color 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+/* History panel */
+#history-panel {
+  max-height: 15rem;
+  overflow-y: auto;
+}
+.history-copy i {
+  pointer-events: none;
 }

--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -1,24 +1,91 @@
-body { background-image: linear-gradient(to bottom right, #581c87, #1e3a8a, #312e81) !important; color: white !important; }
-.bg-white\/10 { background-color: rgba(255, 255, 255, 0.1) !important; border-color: rgba(255, 255, 255, 0.2) !important; }
-.bg-black\/30 { background-color: rgba(0, 0, 0, 0.3) !important; color: white !important; }
-.text-blue-200 { color: #bfdbfe !important; }
-.text-blue-300 { color: #93c5fd !important; }
-.border-white\/20 { border-color: rgba(255, 255, 255, 0.2) !important; }
-.bg-black\/20 { background-color: rgba(0, 0, 0, 0.2) !important; }
-.hover\:bg-white\/10:hover { background-color: rgba(255, 255, 255, 0.1) !important; }
-.bg-white\/30 { background-color: rgba(255, 255, 255, 0.3) !important; }
-.hover\:bg-white\/30:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
-.focus\:ring-white\/50:focus { --tw-ring-color: rgba(255, 255, 255, 0.5) !important; }
-.category-button { background-color: rgba(255, 255, 255, 0.2) !important; color: white !important; border: 1px solid rgba(255, 255, 255, 0.1) !important; }
-.category-button:hover { background-color: rgba(255, 255, 255, 0.3) !important; }
-.category-button.selected { background-image: linear-gradient(to right, #7e22ce, #a21caf) !important; color: white !important; border-color: transparent !important; }
-.category-button .lucide { color: white !important; display: none; }
-.category-button .emoji-icon { color: white !important; }
-#app-title { background-image: linear-gradient(to right, #22d3ee, #c084fc) !important; }
-#choose-style-title, #your-prompt-title { color: white !important; }
-#lang-en, #lang-tr { color: #bfdbfe !important; }
-#lang-en.active, #lang-tr.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
-.theme-toggle-container i { color: #bfdbfe !important; }
-.theme-toggle-container button { color: #bfdbfe !important; }
-.theme-toggle-container button.active { background-color: rgba(255, 255, 255, 0.3) !important; color: white !important; }
-.absolute.top-4.right-4 i { color: #93c5fd !important; }
+body {
+  background-image: linear-gradient(
+    to bottom right,
+    #581c87,
+    #1e3a8a,
+    #312e81
+  ) !important;
+  color: white !important;
+}
+.bg-white\/10 {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  border-color: rgba(255, 255, 255, 0.2) !important;
+}
+.bg-black\/30 {
+  background-color: rgba(0, 0, 0, 0.3) !important;
+  color: white !important;
+}
+.text-blue-200 {
+  color: #bfdbfe !important;
+}
+.text-blue-300 {
+  color: #93c5fd !important;
+}
+.border-white\/20 {
+  border-color: rgba(255, 255, 255, 0.2) !important;
+}
+.bg-black\/20 {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+.hover\:bg-white\/10:hover {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+}
+.bg-white\/30 {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+.hover\:bg-white\/30:hover {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+.focus\:ring-white\/50:focus {
+  --tw-ring-color: rgba(255, 255, 255, 0.5) !important;
+}
+.category-button {
+  background-color: rgba(255, 255, 255, 0.2) !important;
+  color: white !important;
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+}
+.category-button:hover {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+}
+.category-button.selected {
+  background-image: linear-gradient(to right, #7e22ce, #a21caf) !important;
+  color: white !important;
+  border-color: transparent !important;
+}
+.category-button .lucide {
+  color: white !important;
+  display: none;
+}
+.category-button .emoji-icon {
+  color: white !important;
+}
+#app-title {
+  background-image: linear-gradient(to right, #22d3ee, #c084fc) !important;
+}
+#choose-style-title,
+#your-prompt-title,
+#history-title {
+  color: white !important;
+}
+#lang-en,
+#lang-tr {
+  color: #bfdbfe !important;
+}
+#lang-en.active,
+#lang-tr.active {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  color: white !important;
+}
+.theme-toggle-container i {
+  color: #bfdbfe !important;
+}
+.theme-toggle-container button {
+  color: #bfdbfe !important;
+}
+.theme-toggle-container button.active {
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  color: white !important;
+}
+.absolute.top-4.right-4 i {
+  color: #93c5fd !important;
+}

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -1,26 +1,97 @@
-body { background-image: linear-gradient(to bottom right, #f0f4ff, #d9e2ff, #c4d1ff) !important; color: #1a1a2e !important; }
-.bg-white\/10 { background-color: rgba(255, 255, 255, 0.8) !important; border-color: rgba(0, 0, 0, 0.1) !important; }
-.bg-black\/30 { background-color: rgba(0, 0, 0, 0.05) !important; color: #1e293b !important; }
-.text-blue-200 { color: #4338ca !important; }
-.text-blue-300 { color: #3730a3 !important; }
-.border-white\/20 { border-color: rgba(0, 0, 0, 0.1) !important; }
-.bg-black\/20 { background-color: rgba(0, 0, 0, 0.05) !important; }
-.hover\:bg-white\/10:hover { background-color: rgba(0, 0, 0, 0.1) !important; }
-.bg-white\/30 { background-color: rgba(0, 0, 0, 0.2) !important; }
-.hover\:bg-white\/30:hover { background-color: rgba(0, 0, 0, 0.3) !important; }
-.focus\:ring-white\/50:focus { --tw-ring-color: rgba(0, 0, 0, 0.3) !important; }
-.category-button { background-color: rgba(0, 0, 0, 0.08) !important; color: #1a1a2e !important; border: 1px solid rgba(0, 0, 0, 0.1) !important; }
-.category-button:hover { background-color: rgba(0, 0, 0, 0.15) !important; }
-.category-button.selected { background-image: linear-gradient(to right, #4f46e5, #4338ca) !important; color: white !important; border-color: transparent !important; }
-.category-button .lucide { color: #4f46e5 !important; display: none; }
-.category-button.selected .lucide { color: white !important; }
-.category-button .emoji-icon { color: #4f46e5 !important; }
-.category-button.selected .emoji-icon { color: white !important; }
-#app-title { background-image: linear-gradient(to right, #4f46e5, #7c3aed) !important; }
-#choose-style-title, #your-prompt-title { color: #1e293b !important; }
-#lang-en, #lang-tr { color: #4338ca !important; }
-#lang-en.active, #lang-tr.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
-.theme-toggle-container i { color: #4338ca !important; }
-.theme-toggle-container button { color: #4338ca !important; }
-.theme-toggle-container button.active { background-color: rgba(0, 0, 0, 0.2) !important; color: #1e293b !important; }
-.absolute.top-4.right-4 i { color: #4338ca !important; }
+body {
+  background-image: linear-gradient(
+    to bottom right,
+    #f0f4ff,
+    #d9e2ff,
+    #c4d1ff
+  ) !important;
+  color: #1a1a2e !important;
+}
+.bg-white\/10 {
+  background-color: rgba(255, 255, 255, 0.8) !important;
+  border-color: rgba(0, 0, 0, 0.1) !important;
+}
+.bg-black\/30 {
+  background-color: rgba(0, 0, 0, 0.05) !important;
+  color: #1e293b !important;
+}
+.text-blue-200 {
+  color: #4338ca !important;
+}
+.text-blue-300 {
+  color: #3730a3 !important;
+}
+.border-white\/20 {
+  border-color: rgba(0, 0, 0, 0.1) !important;
+}
+.bg-black\/20 {
+  background-color: rgba(0, 0, 0, 0.05) !important;
+}
+.hover\:bg-white\/10:hover {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+.bg-white\/30 {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+.hover\:bg-white\/30:hover {
+  background-color: rgba(0, 0, 0, 0.3) !important;
+}
+.focus\:ring-white\/50:focus {
+  --tw-ring-color: rgba(0, 0, 0, 0.3) !important;
+}
+.category-button {
+  background-color: rgba(0, 0, 0, 0.08) !important;
+  color: #1a1a2e !important;
+  border: 1px solid rgba(0, 0, 0, 0.1) !important;
+}
+.category-button:hover {
+  background-color: rgba(0, 0, 0, 0.15) !important;
+}
+.category-button.selected {
+  background-image: linear-gradient(to right, #4f46e5, #4338ca) !important;
+  color: white !important;
+  border-color: transparent !important;
+}
+.category-button .lucide {
+  color: #4f46e5 !important;
+  display: none;
+}
+.category-button.selected .lucide {
+  color: white !important;
+}
+.category-button .emoji-icon {
+  color: #4f46e5 !important;
+}
+.category-button.selected .emoji-icon {
+  color: white !important;
+}
+#app-title {
+  background-image: linear-gradient(to right, #4f46e5, #7c3aed) !important;
+}
+#choose-style-title,
+#your-prompt-title,
+#history-title {
+  color: #1e293b !important;
+}
+#lang-en,
+#lang-tr {
+  color: #4338ca !important;
+}
+#lang-en.active,
+#lang-tr.active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: #1e293b !important;
+}
+.theme-toggle-container i {
+  color: #4338ca !important;
+}
+.theme-toggle-container button {
+  color: #4338ca !important;
+}
+.theme-toggle-container button.active {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: #1e293b !important;
+}
+.absolute.top-4.right-4 i {
+  color: #4338ca !important;
+}

--- a/index.html
+++ b/index.html
@@ -1,28 +1,51 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests"
+    />
     <title>PROMPTER</title>
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg">
-    <link rel="preload" href="icons/logo.svg" as="image">
-    <link rel="manifest" href="manifest.json">
-    <meta name="theme-color" content="#000000">
-    <meta name="description" content="Creative AI prompt generator that works offline.">
-    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker, yapay zeka komutları, yaratıcı prompt üretici, prompt oluşturucu">
-    <meta name="robots" content="index,follow">
-    <meta property="og:title" content="PROMPTER">
-    <meta property="og:description" content="Creative AI prompt generator that works offline.">
-    <meta property="og:image" content="icons/logo.svg">
-    <meta property="og:type" content="website">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="PROMPTER">
-    <meta name="twitter:description" content="Creative AI prompt generator that works offline.">
-    <meta name="twitter:image" content="icons/logo.svg">
-    <link rel="canonical" href="https://muratcangencturk.github.io/prompter/">
-    <link rel="alternate" href="https://muratcangencturk.github.io/prompter/" hreflang="en">
-    <link rel="alternate" href="https://muratcangencturk.github.io/prompter/tr/" hreflang="tr">
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg" />
+    <link rel="preload" href="icons/logo.svg" as="image" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Creative AI prompt generator that works offline."
+    />
+    <meta
+      name="keywords"
+      content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker, yapay zeka komutları, yaratıcı prompt üretici, prompt oluşturucu"
+    />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="PROMPTER" />
+    <meta
+      property="og:description"
+      content="Creative AI prompt generator that works offline."
+    />
+    <meta property="og:image" content="icons/logo.svg" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="PROMPTER" />
+    <meta
+      name="twitter:description"
+      content="Creative AI prompt generator that works offline."
+    />
+    <meta name="twitter:image" content="icons/logo.svg" />
+    <link rel="canonical" href="https://muratcangencturk.github.io/prompter/" />
+    <link
+      rel="alternate"
+      href="https://muratcangencturk.github.io/prompter/"
+      hreflang="en"
+    />
+    <link
+      rel="alternate"
+      href="https://muratcangencturk.github.io/prompter/tr/"
+      hreflang="tr"
+    />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -53,101 +76,113 @@
         ]
       }
     </script>
-<script>
-  (function() {
-    function addScript(src, onLoad) {
-      const s = document.createElement('script');
-      s.src = src;
-      s.async = true;
-      if (onLoad) {
-        s.addEventListener('load', onLoad, { once: true });
-      }
-      document.head.appendChild(s);
-      return s;
-    }
-
-    function fetchWithTimeout(url, timeout = 500) {
-      return Promise.race([
-        fetch(url, { method: 'HEAD', mode: 'no-cors' }),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeout))
-      ]);
-    }
-
-    function loadWithFallback(primary, local) {
-      let cdnScript = null;
-      let localScript = null;
-      let resolveLoad;
-      const loadPromise = new Promise(resolve => { resolveLoad = resolve; });
-
-      const addLocal = () => {
-        if (!localScript) {
-          localScript = document.createElement('script');
-          localScript.src = local;
-          localScript.async = true;
-          localScript.addEventListener('load', resolveLoad, { once: true });
-          document.head.appendChild(localScript);
-        }
-      };
-
-      // If offline, load local immediately
-      if (!navigator.onLine) {
-        addLocal();
-        return { cdn: null, local: localScript, loadPromise };
-      }
-
-      // Online: Try CDN with fallback
-      let fallbackTimer = null;
-
-      // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
-      fallbackTimer = setTimeout(() => {
-        addLocal();
-        fallbackTimer = null;
-      }, 500);
-
-      // Try to fetch from CDN first
-      fetchWithTimeout(primary).catch(() => {
-        if (fallbackTimer) {
-          clearTimeout(fallbackTimer);
-          fallbackTimer = null;
-        }
-        addLocal();
-      });
-
-      // Add CDN script
-      cdnScript = addScript(primary, () => {
-        if (fallbackTimer) {
-          clearTimeout(fallbackTimer);
-          fallbackTimer = null;
-        }
-        resolveLoad();
-      });
-
-      cdnScript.onerror = () => {
-        if (fallbackTimer) {
-          clearTimeout(fallbackTimer);
-          fallbackTimer = null;
-        }
-        addLocal();
-      };
-
-      return { cdn: cdnScript, local: localScript, loadPromise };
-    }
-
-    const tailwindScripts = loadWithFallback('https://cdn.tailwindcss.com', 'tailwind.js');
-    window.lucideScripts = loadWithFallback('https://unpkg.com/lucide@latest/dist/umd/lucide.min.js', 'lucide.min.js');
-    Promise.all([tailwindScripts.loadPromise, window.lucideScripts.loadPromise])
-      .finally(() => {
-        const appContainer = document.getElementById('app-container');
-        const loadingScreen = document.getElementById('loading-screen');
-        if (appContainer) appContainer.style.visibility = 'visible';
-        if (loadingScreen) loadingScreen.classList.add('hidden');
-      });
-  })();
-</script>
-    <link rel="stylesheet" href="css/app.css">
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css">
     <script>
-      (function() {
+      (function () {
+        function addScript(src, onLoad) {
+          const s = document.createElement('script');
+          s.src = src;
+          s.async = true;
+          if (onLoad) {
+            s.addEventListener('load', onLoad, { once: true });
+          }
+          document.head.appendChild(s);
+          return s;
+        }
+
+        function fetchWithTimeout(url, timeout = 500) {
+          return Promise.race([
+            fetch(url, { method: 'HEAD', mode: 'no-cors' }),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('timeout')), timeout),
+            ),
+          ]);
+        }
+
+        function loadWithFallback(primary, local) {
+          let cdnScript = null;
+          let localScript = null;
+          let resolveLoad;
+          const loadPromise = new Promise((resolve) => {
+            resolveLoad = resolve;
+          });
+
+          const addLocal = () => {
+            if (!localScript) {
+              localScript = document.createElement('script');
+              localScript.src = local;
+              localScript.async = true;
+              localScript.addEventListener('load', resolveLoad, { once: true });
+              document.head.appendChild(localScript);
+            }
+          };
+
+          // If offline, load local immediately
+          if (!navigator.onLine) {
+            addLocal();
+            return { cdn: null, local: localScript, loadPromise };
+          }
+
+          // Online: Try CDN with fallback
+          let fallbackTimer = null;
+
+          // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
+          fallbackTimer = setTimeout(() => {
+            addLocal();
+            fallbackTimer = null;
+          }, 500);
+
+          // Try to fetch from CDN first
+          fetchWithTimeout(primary).catch(() => {
+            if (fallbackTimer) {
+              clearTimeout(fallbackTimer);
+              fallbackTimer = null;
+            }
+            addLocal();
+          });
+
+          // Add CDN script
+          cdnScript = addScript(primary, () => {
+            if (fallbackTimer) {
+              clearTimeout(fallbackTimer);
+              fallbackTimer = null;
+            }
+            resolveLoad();
+          });
+
+          cdnScript.onerror = () => {
+            if (fallbackTimer) {
+              clearTimeout(fallbackTimer);
+              fallbackTimer = null;
+            }
+            addLocal();
+          };
+
+          return { cdn: cdnScript, local: localScript, loadPromise };
+        }
+
+        const tailwindScripts = loadWithFallback(
+          'https://cdn.tailwindcss.com',
+          'tailwind.js',
+        );
+        window.lucideScripts = loadWithFallback(
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js',
+          'lucide.min.js',
+        );
+        Promise.all([
+          tailwindScripts.loadPromise,
+          window.lucideScripts.loadPromise,
+        ]).finally(() => {
+          const appContainer = document.getElementById('app-container');
+          const loadingScreen = document.getElementById('loading-screen');
+          if (appContainer) appContainer.style.visibility = 'visible';
+          if (loadingScreen) loadingScreen.classList.add('hidden');
+        });
+      })();
+    </script>
+    <link rel="stylesheet" href="css/app.css" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css" />
+    <script>
+      (function () {
         const savedTheme = localStorage.getItem('theme');
         if (!savedTheme) return;
         const linkEl = document.getElementById('theme-css');
@@ -156,102 +191,223 @@
         }
       })();
     </script>
-</head>
-<body class="min-h-screen p-4">
-
+  </head>
+  <body class="min-h-screen p-4">
     <div id="loading-screen">
       <div class="spinner" aria-label="Loading"></div>
     </div>
 
-    <div id="app-container" class="max-w-6xl mx-auto relative" style="visibility:hidden;">
-        <!-- Theme Toggle -->
-        <div class="theme-toggle-container absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10">
-            <button id="theme-light" class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" title="Light Theme" aria-label="Light Theme">
-              <i data-lucide="sun" class="w-5 h-5" role="img" aria-label="Sun icon"></i>
+    <div
+      id="app-container"
+      class="max-w-6xl mx-auto relative"
+      style="visibility: hidden"
+    >
+      <!-- Theme Toggle -->
+      <div
+        class="theme-toggle-container absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+      >
+        <button
+          id="theme-light"
+          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Light Theme"
+          aria-label="Light Theme"
+        >
+          <i
+            data-lucide="sun"
+            class="w-5 h-5"
+            role="img"
+            aria-label="Sun icon"
+          ></i>
+        </button>
+        <button
+          id="theme-dark"
+          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Dark Theme"
+          aria-label="Dark Theme"
+        >
+          <i
+            data-lucide="moon"
+            class="w-5 h-5"
+            role="img"
+            aria-label="Moon icon"
+          ></i>
+        </button>
+      </div>
+
+      <!-- Language Switcher -->
+      <div
+        class="absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+      >
+        <i
+          data-lucide="languages"
+          class="w-5 h-5 text-blue-300 ml-1"
+          role="img"
+          aria-label="Languages icon"
+        ></i>
+        <button
+          id="lang-en"
+          class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          aria-label="Switch to English"
+        >
+          EN
+        </button>
+        <button
+          id="lang-tr"
+          class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          aria-label="Switch to Turkish"
+        >
+          TR
+        </button>
+      </div>
+
+      <!-- Header -->
+      <div class="text-center mb-6 pt-16 md:pt-12">
+        <img
+          src="icons/logo.svg"
+          alt="Prompter logo"
+          class="mx-auto mb-4 w-16 h-16"
+          id="app-logo"
+          loading="lazy"
+          width="64"
+          height="64"
+        />
+        <h1
+          id="app-title"
+          class="text-4xl md:text-5xl font-bold mb-2 bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent"
+        >
+          PROMPTER
+        </h1>
+        <p id="app-subtitle" class="text-blue-200 text-lg md:text-xl px-2">
+          Prompt generator for AI - unprecedented, limitless creativity
+        </p>
+      </div>
+
+      <!-- Category Selection -->
+      <div
+        class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-4 border border-white/20 shadow-lg"
+      >
+        <h2 id="choose-style-title" class="text-lg font-semibold mb-3">
+          Select Your Prompt Inspiration
+        </h2>
+        <div
+          id="category-buttons"
+          class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-12 gap-2"
+        >
+          <!-- Category buttons load here -->
+        </div>
+      </div>
+
+      <!-- Generate Button -->
+      <div class="text-center mb-4">
+        <button
+          id="generate-button"
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 disabled:opacity-50 disabled:cursor-not-allowed font-bold py-3 px-6 rounded-xl text-base transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+          aria-label="Generate New Prompt"
+        >
+          <div class="flex items-center justify-center">
+            <i
+              data-lucide="sparkles"
+              class="w-4 h-4 mr-2"
+              role="img"
+              aria-label="Sparkles icon"
+            ></i>
+            <span id="generate-button-text">Generate New Prompt</span>
+          </div>
+        </button>
+      </div>
+
+      <!-- Generated Prompt Display -->
+      <div
+        id="prompt-display-area"
+        class="hidden bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg transition-opacity duration-500 ease-in-out"
+      >
+        <div class="flex justify-between items-center mb-3">
+          <h3 id="your-prompt-title" class="text-lg font-semibold">
+            Your Unique Prompt:
+          </h3>
+          <div class="flex gap-2">
+            <button
+              id="copy-button"
+              class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50"
+              title="Copy to clipboard"
+              aria-label="Copy to clipboard"
+            >
+              <i
+                data-lucide="copy"
+                class="w-4 h-4"
+                role="img"
+                aria-label="Copy icon"
+              ></i>
             </button>
-            <button id="theme-dark" class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" title="Dark Theme" aria-label="Dark Theme">
-              <i data-lucide="moon" class="w-5 h-5" role="img" aria-label="Moon icon"></i>
+            <button
+              id="download-button"
+              class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50"
+              title="Download as .txt"
+              aria-label="Download as .txt"
+            >
+              <i
+                data-lucide="download"
+                class="w-4 h-4"
+                role="img"
+                aria-label="Download icon"
+              ></i>
             </button>
-        </div>
-
-        <!-- Language Switcher -->
-        <div class="absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10">
-           <i data-lucide="languages" class="w-5 h-5 text-blue-300 ml-1" role="img" aria-label="Languages icon"></i>
-           <button id="lang-en" class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Switch to English">
-             EN
-           </button>
-           <button id="lang-tr" class="px-3 py-1 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Switch to Turkish">
-             TR
-           </button>
-        </div>
-
-        <!-- Header -->
-        <div class="text-center mb-6 pt-16 md:pt-12">
-          <img src="icons/logo.svg" alt="Prompter logo" class="mx-auto mb-4 w-16 h-16" id="app-logo" loading="lazy" width="64" height="64">
-          <h1 id="app-title" class="text-4xl md:text-5xl font-bold mb-2 bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent">
-            PROMPTER
-          </h1>
-          <p id="app-subtitle" class="text-blue-200 text-lg md:text-xl px-2">
-            Prompt generator for AI - unprecedented, limitless creativity
-          </p>
-        </div>
-
-        <!-- Category Selection -->
-        <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-4 border border-white/20 shadow-lg">
-          <h2 id="choose-style-title" class="text-lg font-semibold mb-3">
-            Select Your Prompt Inspiration
-          </h2>
-          <div id="category-buttons" class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-12 gap-2">
-            <!-- Category buttons load here -->
           </div>
         </div>
+        <div
+          id="generated-prompt-text"
+          class="bg-black/30 rounded-xl p-3 leading-relaxed whitespace-pre-wrap text-base font-mono selection:bg-purple-500 selection:text-white"
+          role="status"
+          aria-live="polite"
+        >
+          <!-- Generated prompt text loads here -->
+        </div>
+        <p
+          id="copy-success-message"
+          class="text-green-400 text-sm mt-2 animate-pulse hidden"
+        >
+          Prompt copied successfully!
+        </p>
+      </div>
 
-        <!-- Generate Button -->
-        <div class="text-center mb-4">
-          <button id="generate-button" class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 disabled:opacity-50 disabled:cursor-not-allowed font-bold py-3 px-6 rounded-xl text-base transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900" aria-label="Generate New Prompt">
-            <div class="flex items-center justify-center">
-              <i data-lucide="sparkles" class="w-4 h-4 mr-2" role="img" aria-label="Sparkles icon"></i>
-              <span id="generate-button-text">Generate New Prompt</span>
-            </div>
+      <!-- Prompt History -->
+      <div
+        id="history-panel"
+        class="hidden bg-white/10 backdrop-blur-md rounded-2xl p-4 mt-4 border border-white/20 shadow-lg"
+      >
+        <div class="flex justify-between items-center mb-3">
+          <h3 id="history-title" class="text-lg font-semibold">
+            Previous Prompts
+          </h3>
+          <button
+            id="clear-history"
+            class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Clear history"
+            aria-label="Clear history"
+          >
+            <i
+              data-lucide="trash"
+              class="w-4 h-4"
+              role="img"
+              aria-label="Trash icon"
+            ></i>
           </button>
         </div>
+        <ul id="history-list" class="space-y-2 text-sm"></ul>
+      </div>
 
-        <!-- Generated Prompt Display -->
-        <div id="prompt-display-area" class="hidden bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg transition-opacity duration-500 ease-in-out">
-            <div class="flex justify-between items-center mb-3">
-              <h3 id="your-prompt-title" class="text-lg font-semibold">
-                Your Unique Prompt:
-              </h3>
-              <div class="flex gap-2">
-                <button id="copy-button" class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50" title="Copy to clipboard" aria-label="Copy to clipboard">
-                  <i data-lucide="copy" class="w-4 h-4" role="img" aria-label="Copy icon"></i>
-                </button>
-                <button id="download-button" class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50" title="Download as .txt" aria-label="Download as .txt">
-                  <i data-lucide="download" class="w-4 h-4" role="img" aria-label="Download icon"></i>
-                </button>
-              </div>
-            </div>
-            <div id="generated-prompt-text" class="bg-black/30 rounded-xl p-3 leading-relaxed whitespace-pre-wrap text-base font-mono selection:bg-purple-500 selection:text-white" role="status" aria-live="polite">
-              <!-- Generated prompt text loads here -->
-            </div>
-            <p id="copy-success-message" class="text-green-400 text-sm mt-2 animate-pulse hidden">
-              Prompt copied successfully!
-            </p>
-        </div>
-
-        <!-- Footer/Stats -->
-        <div class="mt-8 text-center pb-4">
-          <p id="app-stats" class="text-blue-200 text-sm mb-1">
-            Prompts that will unlock the potential of your mind
-          </p>
-          <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
-            Prompter
-          </p>
-        </div>
+      <!-- Footer/Stats -->
+      <div class="mt-8 text-center pb-4">
+        <p id="app-stats" class="text-blue-200 text-sm mb-1">
+          Prompts that will unlock the potential of your mind
+        </p>
+        <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
+          Prompter
+        </p>
+      </div>
     </div>
 
-<script src="prompts.js"></script>
-<script type="module" src="src/main.js"></script>
-</body>
+    <script src="prompts.js"></script>
+    <script type="module" src="src/main.js"></script>
+  </body>
 </html>
-

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -53,18 +53,73 @@ const catMap = {
 };
 
 export const categories = [
-  { id: 'random', icon: 'shuffle', emoji: '🔀', name: { en: 'Random Mix', tr: 'Rastgele Karışım' } },
-  { id: 'inspiring', icon: 'sunrise', emoji: '🌅', name: { en: 'Inspiring', tr: 'İlham Verici' } },
-  { id: 'mindBlowing', icon: 'brain-circuit', emoji: '🤯', name: { en: 'Mind-blowing', tr: 'Ufuk Açıcı' } },
-  { id: 'productivity', icon: 'zap', emoji: '⚡', name: { en: 'Productivity', tr: 'Üretkenlik' } },
-  { id: 'educational', icon: 'graduation-cap', emoji: '🎓', name: { en: 'Educational', tr: 'Eğitici' } },
-  { id: 'crazy', icon: 'laugh', emoji: '😂', name: { en: 'Crazy', tr: 'Çılgın Fikirler' } },
-  { id: 'perspective', icon: 'glasses', emoji: '🕶️', name: { en: 'Perspective', tr: 'Bakış Açısı' } },
+  {
+    id: 'random',
+    icon: 'shuffle',
+    emoji: '🔀',
+    name: { en: 'Random Mix', tr: 'Rastgele Karışım' },
+  },
+  {
+    id: 'inspiring',
+    icon: 'sunrise',
+    emoji: '🌅',
+    name: { en: 'Inspiring', tr: 'İlham Verici' },
+  },
+  {
+    id: 'mindBlowing',
+    icon: 'brain-circuit',
+    emoji: '🤯',
+    name: { en: 'Mind-blowing', tr: 'Ufuk Açıcı' },
+  },
+  {
+    id: 'productivity',
+    icon: 'zap',
+    emoji: '⚡',
+    name: { en: 'Productivity', tr: 'Üretkenlik' },
+  },
+  {
+    id: 'educational',
+    icon: 'graduation-cap',
+    emoji: '🎓',
+    name: { en: 'Educational', tr: 'Eğitici' },
+  },
+  {
+    id: 'crazy',
+    icon: 'laugh',
+    emoji: '😂',
+    name: { en: 'Crazy', tr: 'Çılgın Fikirler' },
+  },
+  {
+    id: 'perspective',
+    icon: 'glasses',
+    emoji: '🕶️',
+    name: { en: 'Perspective', tr: 'Bakış Açısı' },
+  },
   { id: 'ai', icon: 'cpu', emoji: '🤖', name: { en: 'AI', tr: 'YZ' } },
-  { id: 'ideas', icon: 'lightbulb', emoji: '💡', name: { en: 'Ideas', tr: 'Fikirler' } },
-  { id: 'video', icon: 'video', emoji: '🎬', name: { en: 'Video', tr: 'Video' } },
-  { id: 'image', icon: 'image', emoji: '🖼️', name: { en: 'Image', tr: 'Görsel' } },
-  { id: 'hellprompts', icon: 'skull', emoji: '💀', name: { en: 'Hellprompts', tr: 'Cehennem Promptları' } },
+  {
+    id: 'ideas',
+    icon: 'lightbulb',
+    emoji: '💡',
+    name: { en: 'Ideas', tr: 'Fikirler' },
+  },
+  {
+    id: 'video',
+    icon: 'video',
+    emoji: '🎬',
+    name: { en: 'Video', tr: 'Video' },
+  },
+  {
+    id: 'image',
+    icon: 'image',
+    emoji: '🖼️',
+    name: { en: 'Image', tr: 'Görsel' },
+  },
+  {
+    id: 'hellprompts',
+    icon: 'skull',
+    emoji: '💀',
+    name: { en: 'Hellprompts', tr: 'Cehennem Promptları' },
+  },
 ];
 
 export const ICON_FALLBACKS = {
@@ -106,13 +161,18 @@ export const generatePrompt = async () => {
   if (selectedCatId === 'random') {
     const availableCategories = categories.filter((c) => c.id !== 'random');
     selectedCatId =
-      availableCategories[Math.floor(Math.random() * availableCategories.length)]
-        .id;
+      availableCategories[
+        Math.floor(Math.random() * availableCategories.length)
+      ].id;
   }
 
   const categoryData = await loadCategory(appState.language, selectedCatId);
 
-  if (!categoryData || !categoryData.parts || !Array.isArray(categoryData.parts)) {
+  if (
+    !categoryData ||
+    !categoryData.parts ||
+    !Array.isArray(categoryData.parts)
+  ) {
     appState.isGenerating = false;
     throw new Error('Invalid category data');
   }
@@ -121,9 +181,6 @@ export const generatePrompt = async () => {
     if (!appState.partHistory[idx]) {
       appState.partHistory[idx] = [];
     }
-    if (!appState.history[idx]) {
-      appState.history[idx] = [];
-    }
     const element = getRandomElement(partArray, appState.partHistory[idx]);
     appState.partHistory[idx].push(element);
     if (appState.partHistory[idx].length > appState.HISTORY_SIZE) {
@@ -131,18 +188,9 @@ export const generatePrompt = async () => {
     }
     return element;
   });
-  const newPrompt = categoryData.structure ? categoryData.structure(promptParts) : promptParts.join(' ');
-
-  promptParts.forEach((part, idx) => {
-    if (!appState.history[idx]) {
-      appState.history[idx] = [];
-    }
-    const hist = appState.history[idx];
-    hist.push(part);
-    if (hist.length > appState.HISTORY_SIZE) {
-      hist.shift();
-    }
-  });
+  const newPrompt = categoryData.structure
+    ? categoryData.structure(promptParts)
+    : promptParts.join(' ');
 
   appState.generatedPrompt = newPrompt;
   appState.isGenerating = false;

--- a/src/state.js
+++ b/src/state.js
@@ -7,7 +7,7 @@ export const appState = {
   copySuccess: false,
   language: 'en',
   theme: THEMES.DARK,
-  history: [],
+  history: [], // generated prompts
   partHistory: [],
   HISTORY_SIZE: 100,
 };

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,12 +4,15 @@ import { categories, ICON_FALLBACKS, generatePrompt } from './prompts.js';
 const uiText = {
   en: {
     appTitle: 'PROMPTER',
-    appSubtitle: 'Prompt generator for AI - unprecedented, limitless creativity',
+    appSubtitle:
+      'Prompt generator for AI - unprecedented, limitless creativity',
     chooseStyleTitle: 'Select Your Prompt Inspiration',
     generateButtonText: 'Generate New Prompt',
     yourPromptTitle: 'Your Unique Prompt:',
     copyButtonTitle: 'Copy to clipboard',
     downloadButtonTitle: 'Download as .txt',
+    historyTitle: 'Previous Prompts',
+    clearHistoryTitle: 'Clear history',
     copySuccessMessage: 'Prompt copied successfully!',
     appStats: 'Prompts that will unlock the potential of your mind',
     footerPrompter: 'Prompter',
@@ -22,20 +25,23 @@ const uiText = {
   },
   tr: {
     appTitle: 'PROMPTER',
-    appSubtitle: 'YZ için prompt üretici - eşi benzeri görülmemiş sınırsız yaratıcılık',
+    appSubtitle:
+      'YZ için prompt üretici - eşi benzeri görülmemiş sınırsız yaratıcılık',
     chooseStyleTitle: 'Prompt İlhamınızı Seçin',
     generateButtonText: 'Yeni Prompt Üret',
     yourPromptTitle: 'Benzersiz Promptunuz:',
     copyButtonTitle: 'Panoya kopyala',
     downloadButtonTitle: '.txt olarak indir',
+    historyTitle: 'Önceki Promptlar',
+    clearHistoryTitle: 'Geçmişi temizle',
     copySuccessMessage: 'Prompt başarıyla kopyalandı!',
     appStats: 'Zihninizin potansiyelini açığa çıkaracak promptlar',
     footerPrompter: 'Prompter',
     randomCategory: 'Rastgele Karışım',
     themeLightTitle: 'Açık Tema',
     themeDarkTitle: 'Koyu Tema',
-    langEnLabel: 'İngilizce\'ye geç',
-    langTrLabel: 'Türkçe\'ye geç',
+    langEnLabel: "İngilizce'ye geç",
+    langTrLabel: "Türkçe'ye geç",
     appLogoAlt: 'Prompter logosu',
   },
 };
@@ -53,6 +59,9 @@ let themeLightButton;
 let themeDarkButton;
 let themeLinkElement;
 let appLogo;
+let historyPanel;
+let historyList;
+let clearHistoryButton;
 let lastGeneratedCategoryId = appState.selectedCategory;
 
 const setTheme = (theme) => {
@@ -61,15 +70,51 @@ const setTheme = (theme) => {
     themeLinkElement.href = `css/theme-${theme}.css`;
   }
   if (theme === THEMES.LIGHT) {
-    themeLightButton.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
-    themeLightButton.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-    themeDarkButton.classList.remove('active', 'bg-white/30', 'text-white', 'shadow-md');
-    themeDarkButton.classList.add('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
+    themeLightButton.classList.add(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    themeLightButton.classList.remove(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
+    themeDarkButton.classList.remove(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    themeDarkButton.classList.add(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
   } else {
-    themeDarkButton.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
-    themeDarkButton.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-    themeLightButton.classList.remove('active', 'bg-white/30', 'text-white', 'shadow-md');
-    themeLightButton.classList.add('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
+    themeDarkButton.classList.add(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    themeDarkButton.classList.remove(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
+    themeLightButton.classList.remove(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    themeLightButton.classList.add(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
   }
   localStorage.setItem('theme', theme);
   updateButtonTitles();
@@ -79,11 +124,15 @@ const setLanguage = (lang) => {
   appState.language = lang;
   document.documentElement.lang = lang;
   document.getElementById('app-title').textContent = uiText[lang].appTitle;
-  document.getElementById('app-subtitle').textContent = uiText[lang].appSubtitle;
-  document.getElementById('choose-style-title').textContent = uiText[lang].chooseStyleTitle;
-  document.getElementById('generate-button-text').textContent = uiText[lang].generateButtonText;
+  document.getElementById('app-subtitle').textContent =
+    uiText[lang].appSubtitle;
+  document.getElementById('choose-style-title').textContent =
+    uiText[lang].chooseStyleTitle;
+  document.getElementById('generate-button-text').textContent =
+    uiText[lang].generateButtonText;
   generateButton.setAttribute('aria-label', uiText[lang].generateButtonText);
-  document.getElementById('your-prompt-title').textContent = uiText[lang].yourPromptTitle;
+  document.getElementById('your-prompt-title').textContent =
+    uiText[lang].yourPromptTitle;
   if (appLogo) {
     appLogo.alt = uiText[lang].appLogoAlt;
   }
@@ -92,8 +141,13 @@ const setLanguage = (lang) => {
   downloadButton.title = uiText[lang].downloadButtonTitle;
   downloadButton.setAttribute('aria-label', uiText[lang].downloadButtonTitle);
   copySuccessMessage.textContent = uiText[lang].copySuccessMessage;
+  document.getElementById('history-title').textContent =
+    uiText[lang].historyTitle;
+  clearHistoryButton.title = uiText[lang].clearHistoryTitle;
+  clearHistoryButton.setAttribute('aria-label', uiText[lang].clearHistoryTitle);
   document.getElementById('app-stats').textContent = uiText[lang].appStats;
-  document.getElementById('footer-prompter').textContent = uiText[lang].footerPrompter;
+  document.getElementById('footer-prompter').textContent =
+    uiText[lang].footerPrompter;
   langEnButton.title = uiText[lang].langEnLabel;
   langEnButton.setAttribute('aria-label', uiText[lang].langEnLabel);
   langTrButton.title = uiText[lang].langTrLabel;
@@ -111,25 +165,95 @@ const setLanguage = (lang) => {
   });
 
   if (lang === 'en') {
-    langEnButton.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
-    langEnButton.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-    langTrButton.classList.remove('active', 'bg-white/30', 'text-white', 'shadow-md');
-    langTrButton.classList.add('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
+    langEnButton.classList.add(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    langEnButton.classList.remove(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
+    langTrButton.classList.remove(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    langTrButton.classList.add(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
   } else {
-    langTrButton.classList.add('active', 'bg-white/30', 'text-white', 'shadow-md');
-    langTrButton.classList.remove('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
-    langEnButton.classList.remove('active', 'bg-white/30', 'text-white', 'shadow-md');
-    langEnButton.classList.add('bg-transparent', 'text-blue-200', 'hover:bg-white/10');
+    langTrButton.classList.add(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    langTrButton.classList.remove(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
+    langEnButton.classList.remove(
+      'active',
+      'bg-white/30',
+      'text-white',
+      'shadow-md',
+    );
+    langEnButton.classList.add(
+      'bg-transparent',
+      'text-blue-200',
+      'hover:bg-white/10',
+    );
   }
   localStorage.setItem('language', lang);
   updateButtonTitles();
+  renderHistory();
 };
 
 const updateButtonTitles = () => {
   themeLightButton.title = uiText[appState.language].themeLightTitle;
-  themeLightButton.setAttribute('aria-label', uiText[appState.language].themeLightTitle);
+  themeLightButton.setAttribute(
+    'aria-label',
+    uiText[appState.language].themeLightTitle,
+  );
   themeDarkButton.title = uiText[appState.language].themeDarkTitle;
-  themeDarkButton.setAttribute('aria-label', uiText[appState.language].themeDarkTitle);
+  themeDarkButton.setAttribute(
+    'aria-label',
+    uiText[appState.language].themeDarkTitle,
+  );
+};
+
+const renderHistory = () => {
+  if (!historyPanel || !historyList) return;
+  historyList.innerHTML = '';
+  appState.history.forEach((prompt, idx) => {
+    const li = document.createElement('li');
+    li.className = 'flex justify-between items-start gap-2';
+    const span = document.createElement('span');
+    span.className = 'flex-1 whitespace-pre-wrap font-mono';
+    span.textContent = prompt;
+    const btn = document.createElement('button');
+    btn.className =
+      'history-copy p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+    btn.title = uiText[appState.language].copyButtonTitle;
+    btn.setAttribute('aria-label', uiText[appState.language].copyButtonTitle);
+    btn.setAttribute('data-index', idx);
+    btn.innerHTML =
+      '<i data-lucide="copy" class="w-3 h-3" aria-hidden="true"></i>';
+    li.appendChild(span);
+    li.appendChild(btn);
+    historyList.appendChild(li);
+  });
+  historyPanel.classList.toggle('hidden', appState.history.length === 0);
+  if (window.lucide && typeof window.lucide.createIcons === 'function') {
+    window.lucide.createIcons();
+  }
 };
 
 const handleGenerate = async () => {
@@ -143,10 +267,16 @@ const handleGenerate = async () => {
   try {
     const { prompt, categoryId } = await generatePrompt();
     generatedPromptText.textContent = prompt;
+    appState.history.push(prompt);
+    if (appState.history.length > appState.HISTORY_SIZE) {
+      appState.history.shift();
+    }
+    renderHistory();
     lastGeneratedCategoryId = categoryId;
   } catch (err) {
     console.error(err);
-    generatedPromptText.textContent = 'Error generating prompt. Please try again.';
+    generatedPromptText.textContent =
+      'Error generating prompt. Please try again.';
   } finally {
     appState.isGenerating = false;
     generateButton.disabled = false;
@@ -159,7 +289,9 @@ const setupEventListeners = () => {
     if (button) {
       button.addEventListener('click', () => {
         appState.selectedCategory = category.id;
-        document.querySelectorAll('.category-button').forEach((btn) => btn.classList.remove('selected'));
+        document
+          .querySelectorAll('.category-button')
+          .forEach((btn) => btn.classList.remove('selected'));
         button.classList.add('selected');
       });
     }
@@ -201,6 +333,22 @@ const setupEventListeners = () => {
     URL.revokeObjectURL(url);
   });
 
+  clearHistoryButton.addEventListener('click', () => {
+    appState.history = [];
+    renderHistory();
+  });
+
+  historyList.addEventListener('click', (e) => {
+    const btn = e.target.closest('.history-copy');
+    if (!btn) return;
+    const index = parseInt(btn.getAttribute('data-index'), 10);
+    const text = appState.history[index];
+    if (!text) return;
+    navigator.clipboard.writeText(text).catch((err) => {
+      console.error('Failed to copy text: ', err);
+    });
+  });
+
   langEnButton.addEventListener('click', () => setLanguage('en'));
   langTrButton.addEventListener('click', () => setLanguage('tr'));
 
@@ -222,35 +370,42 @@ export const initializeApp = () => {
   themeDarkButton = document.getElementById('theme-dark');
   themeLinkElement = document.getElementById('theme-css');
   appLogo = document.getElementById('app-logo');
+  historyPanel = document.getElementById('history-panel');
+  historyList = document.getElementById('history-list');
+  clearHistoryButton = document.getElementById('clear-history');
 
   const runLucide = () => {
     if (window.lucide && typeof window.lucide.createIcons === 'function') {
       window.lucide.createIcons();
 
-      document.querySelectorAll('#category-buttons .category-button').forEach((button) => {
-        const iconEl = button.querySelector('i[data-lucide]');
-        const emojiEl = button.querySelector('.emoji-icon');
-        if (!iconEl) return;
+      document
+        .querySelectorAll('#category-buttons .category-button')
+        .forEach((button) => {
+          const iconEl = button.querySelector('i[data-lucide]');
+          const emojiEl = button.querySelector('.emoji-icon');
+          if (!iconEl) return;
 
-        let iconName = iconEl.getAttribute('data-lucide');
-        const pascal = iconName.replace(/(^.|-.)/g, (s) => s.replace('-', '').toUpperCase());
-        if (!window.lucide.icons || !window.lucide.icons[pascal]) {
-          const fallback = ICON_FALLBACKS[iconName];
-          if (fallback) {
-            iconName = fallback;
-            iconEl.setAttribute('data-lucide', iconName);
+          let iconName = iconEl.getAttribute('data-lucide');
+          const pascal = iconName.replace(/(^.|-.)/g, (s) =>
+            s.replace('-', '').toUpperCase(),
+          );
+          if (!window.lucide.icons || !window.lucide.icons[pascal]) {
+            const fallback = ICON_FALLBACKS[iconName];
+            if (fallback) {
+              iconName = fallback;
+              iconEl.setAttribute('data-lucide', iconName);
+            }
           }
-        }
 
-        const hasSvg = iconEl.querySelector('svg');
-        if (!hasSvg) {
-          emojiEl && emojiEl.classList.remove('hidden');
-          iconEl.style.display = 'none';
-        } else {
-          iconEl.style.display = 'block';
-          emojiEl && emojiEl.classList.add('hidden');
-        }
-      });
+          const hasSvg = iconEl.querySelector('svg');
+          if (!hasSvg) {
+            emojiEl && emojiEl.classList.remove('hidden');
+            iconEl.style.display = 'none';
+          } else {
+            iconEl.style.display = 'block';
+            emojiEl && emojiEl.classList.add('hidden');
+          }
+        });
 
       window.lucide.createIcons();
       return true;
@@ -268,8 +423,12 @@ export const initializeApp = () => {
   categories.forEach((category) => {
     const button = document.createElement('button');
     button.id = `category-${category.id}`;
-    button.className = 'category-button focus:outline-none focus:ring-2 focus:ring-white/50';
-    button.setAttribute('aria-label', `${category.name[appState.language]} category`);
+    button.className =
+      'category-button focus:outline-none focus:ring-2 focus:ring-white/50';
+    button.setAttribute(
+      'aria-label',
+      `${category.name[appState.language]} category`,
+    );
     if (category.id === appState.selectedCategory) {
       button.classList.add('selected');
     }
@@ -282,6 +441,8 @@ export const initializeApp = () => {
   if (window.lucideScripts && window.lucideScripts.loadPromise) {
     window.lucideScripts.loadPromise.then(runLucide);
   }
+
+  renderHistory();
 
   setupEventListeners();
 };


### PR DESCRIPTION
## Summary
- show history panel in the UI to revisit generated prompts
- push prompts to `appState.history` and render into the list
- allow copying previous prompts and clearing history
- tweak styles and themes for the history section
- update prompt generation code to drop old history arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c9f252fe8832fb5029543589b80fa