### PR TITLE
Enable immediate service worker activation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "theme_color": "#000000",
   "background_color": "#000000",
   "display": "standalone",
-  "version": "17",
+  "version": "18",
   "start_url": "./",
   "icons": [
     {

--- a/src/main.js
+++ b/src/main.js
@@ -6,4 +6,7 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('sw.js').catch(console.error);
   });
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    window.location.reload();
+  });
 }

--- a/sw.js
+++ b/sw.js
@@ -19,8 +19,6 @@ const ASSETS = [
   './lucide.min.js',
   './src/main.js',
   './icons/logo.svg',
-  './icons/twitter.svg',
-  './icons/mastodon.svg',
   './css/app.css',
   './css/theme-dark.css',
   './css/theme-light.css',
@@ -56,7 +54,7 @@ const ASSETS = [
   './prompts/tr/mindBlowing.json',
   './prompts/tr/perspective.json',
   './prompts/tr/productivity.json',
-  './prompts/tr/video.json',
+  './prompts/tr/video.json'
 ];
 
 self.addEventListener('install', (event) => {
@@ -65,6 +63,7 @@ self.addEventListener('install', (event) => {
       await updateCacheName();
       const cache = await caches.open(CACHE_NAME);
       await cache.addAll(ASSETS);
+      self.skipWaiting();
     })()
   );
 });
@@ -79,6 +78,7 @@ self.addEventListener('activate', (event) => {
           .filter((key) => key !== CACHE_NAME)
           .map((key) => caches.delete(key))
       );
+      self.clients.claim();
     })()
   );
 });


### PR DESCRIPTION
## Summary
- ensure the installing worker becomes active by calling `skipWaiting()`
- claim clients during activation
- reload page on controller change
- bump service worker cache version and rebuild assets

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d438f8b38832f97ffae2ee4568cc2