### PR TITLE
Fix back link label and lucide icons

### DIFF
--- a/my-prompts.html
+++ b/my-prompts.html
@@ -28,6 +28,7 @@
       <div class="absolute top-4 left-4">
         <a href="index.html" class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
           <i data-lucide="arrow-left" class="w-5 h-5" aria-hidden="true"></i>
+          <span class="ml-1 text-sm">Back</span>
         </a>
       </div>
       <div class="absolute top-4 right-4 flex items-center gap-2">

--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -62,6 +62,10 @@ const updateTexts = () => {
   if (backLink) {
     backLink.title = uiText[appState.language].back;
     backLink.setAttribute('aria-label', uiText[appState.language].back);
+    const label = backLink.querySelector('span');
+    if (label) {
+      label.textContent = uiText[appState.language].back;
+    }
   }
 };
 
@@ -139,6 +143,7 @@ const init = () => {
 
   renderList();
   setupEvents();
+  window.lucide?.createIcons();
 };
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- show translated "Back" label in my-prompts page
- invoke lucide icon rendering when initializing the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d50f171a0832f94a98a421faf0c71