### PR TITLE
Make generated prompts editable and update history

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,6 +398,7 @@
         <div
           id="generated-prompt-text"
           class="bg-black/30 rounded-xl p-3 leading-relaxed whitespace-pre-wrap text-base font-mono selection:bg-purple-500 selection:text-white"
+          contenteditable="true"
           role="status"
           aria-live="polite"
         >

--- a/src/ui.js
+++ b/src/ui.js
@@ -373,18 +373,19 @@ const renderHistory = () => {
   appState.history.forEach((prompt, idx) => {
     const li = document.createElement('li');
     li.className = 'flex justify-between items-start gap-2';
-    const span = document.createElement('span');
-    span.className = 'flex-1 whitespace-pre-wrap font-mono';
-    span.textContent = prompt;
+    const textarea = document.createElement('textarea');
+    textarea.className = 'history-edit flex-1 whitespace-pre-wrap font-mono bg-transparent p-1 rounded-md';
+    textarea.value = prompt;
+    textarea.setAttribute('data-index', idx);
     const btn = document.createElement('button');
-    btn.className =
-      'history-copy p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
-    btn.title = uiText[appState.language].copyButtonTitle;
-    btn.setAttribute('aria-label', uiText[appState.language].copyButtonTitle);
-    btn.setAttribute('data-index', idx);
-    btn.innerHTML =
-      '<i data-lucide="copy" class="w-3 h-3" aria-hidden="true"></i>';
-    li.appendChild(span);
+      btn.className =
+        'history-copy p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+      btn.title = uiText[appState.language].copyButtonTitle;
+      btn.setAttribute('aria-label', uiText[appState.language].copyButtonTitle);
+      btn.setAttribute('data-index', idx);
+      btn.innerHTML =
+        '<i data-lucide="copy" class="w-3 h-3" aria-hidden="true"></i>';
+    li.appendChild(textarea);
     li.appendChild(btn);
     historyList.appendChild(li);
   });
@@ -445,6 +446,14 @@ const setupEventListeners = () => {
   generateButton.addEventListener('click', () => {
     generateButton.disabled = true;
     handleGenerate();
+  });
+
+  generatedPromptText.addEventListener('input', () => {
+    const val =
+      'value' in generatedPromptText
+        ? generatedPromptText.value
+        : generatedPromptText.textContent;
+    appState.generatedPrompt = val;
   });
 
   copyButton.addEventListener('click', () => {
@@ -516,6 +525,17 @@ const setupEventListeners = () => {
     navigator.clipboard.writeText(text).catch((err) => {
       console.error('Failed to copy text: ', err);
     });
+  });
+
+  historyList.addEventListener('input', (e) => {
+    const target = e.target.closest('.history-edit');
+    if (!target) return;
+    const idx = Number(target.getAttribute('data-index'));
+    const value = 'value' in target ? target.value : target.textContent;
+    if (!Number.isNaN(idx)) {
+      appState.history[idx] = value;
+      localStorage.setItem('promptHistory', JSON.stringify(appState.history));
+    }
   });
 
   langEnButton.addEventListener('click', () => setLanguage('en'));

--- a/tr/index.html
+++ b/tr/index.html
@@ -230,7 +230,7 @@
                 </button>
               </div>
             </div>
-            <div id="generated-prompt-text" class="bg-black/30 rounded-xl p-3 leading-relaxed whitespace-pre-wrap text-base font-mono selection:bg-purple-500 selection:text-white" role="status" aria-live="polite">
+            <div id="generated-prompt-text" class="bg-black/30 rounded-xl p-3 leading-relaxed whitespace-pre-wrap text-base font-mono selection:bg-purple-500 selection:text-white" contenteditable="true" role="status" aria-live="polite">
               <!-- Generated prompt text loads here -->
             </div>
             <p id="copy-success-message" class="text-green-400 text-sm mt-2 animate-pulse hidden">


### PR DESCRIPTION
## Summary
- allow editing generated prompt text in English and Turkish UIs
- keep app state in sync with edits
- render history list as editable textareas and store changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d52482638832fa70385488c432f80