### PR TITLE
Refactor back icon display

### DIFF
--- a/my-prompts.html
+++ b/my-prompts.html
@@ -26,9 +26,8 @@
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-3xl mx-auto relative">
       <div class="absolute top-4 left-4">
-        <a href="index.html" class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
+        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
           <i data-lucide="arrow-left" class="w-5 h-5" aria-hidden="true"></i>
-          <span class="ml-1 text-sm">Back</span>
         </a>
       </div>
       <div class="absolute top-4 right-4 flex items-center gap-2">

--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -62,10 +62,6 @@ const updateTexts = () => {
   if (backLink) {
     backLink.title = uiText[appState.language].back;
     backLink.setAttribute('aria-label', uiText[appState.language].back);
-    const label = backLink.querySelector('span');
-    if (label) {
-      label.textContent = uiText[appState.language].back;
-    }
   }
 };
 


### PR DESCRIPTION
## Summary
- remove text and background around back icon in `my-prompts.html`
- update `my-prompts.js` accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d53fb2488832fa684b39125ceec69