### PR TITLE
Update category names for crazy and hellprompts

### DIFF
--- a/src/prompts.js
+++ b/src/prompts.js
@@ -87,7 +87,7 @@ export const categories = [
     id: 'crazy',
     icon: 'laugh',
     emoji: '😂',
-    name: { en: 'Crazy', tr: 'Çılgın Fikirler', es: 'Ideas Locas' },
+    name: { en: 'Crazy', tr: 'Uçuk', es: 'Ideas Locas' },
   },
   {
     id: 'perspective',
@@ -123,7 +123,7 @@ export const categories = [
     id: 'hellprompts',
     icon: 'skull',
     emoji: '💀',
-    name: { en: 'Hellprompts', tr: 'Cehennem Promptları', es: 'Prompts Infernales' },
+    name: { en: 'hellprompts', tr: 'hellprompts', es: 'hellprompts' },
   },
 ];
 


### PR DESCRIPTION
## Summary
- update Turkish translation for the `crazy` category
- show `hellprompts` name identically across languages

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d8407a49c832fbb53e1e9afe35404