### PR TITLE
Fix Hellprompts capitalization

### DIFF
--- a/src/prompts.js
+++ b/src/prompts.js
@@ -123,7 +123,7 @@ export const categories = [
     id: 'hellprompts',
     icon: 'skull',
     emoji: '💀',
-    name: { en: 'hellprompts', tr: 'hellprompts', es: 'hellprompts' },
+    name: { en: 'Hellprompts', tr: 'Hellprompts', es: 'Hellprompts' },
   },
 ];
 


### PR DESCRIPTION
## Summary
- capitalize the Hellprompts category name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d8b7bc760832f860e54aaeded25a6