### PR TITLE
Add UI feedback and delete animations

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -23,28 +23,20 @@
   animation: spin 1s linear infinite;
 }
 body {
-  font-family:
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     sans-serif;
-  transition:
-    background-color 0.3s ease,
-    color 0.3s ease;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 .bg-gradient-to-br {
   background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
 }
 .from-purple-900 {
   --tw-gradient-from: #581c87;
-  --tw-gradient-stops:
-    var(--tw-gradient-from), var(--tw-gradient-to, rgba(88, 28, 135, 0));
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(88, 28, 135, 0));
 }
 .via-blue-900 {
-  --tw-gradient-stops:
-    var(--tw-gradient-from), #1e3a8a,
+  --tw-gradient-stops: var(--tw-gradient-from), #1e3a8a,
     var(--tw-gradient-to, rgba(30, 58, 138, 0));
 }
 .to-indigo-900 {
@@ -55,24 +47,24 @@ body {
 }
 .from-cyan-400 {
   --tw-gradient-from: #22d3ee;
-  --tw-gradient-stops:
-    var(--tw-gradient-from), var(--tw-gradient-to, rgba(34, 211, 238, 0));
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(34, 211, 238, 0));
 }
 .to-purple-400 {
   --tw-gradient-to: #c084fc;
 }
 .from-purple-500 {
   --tw-gradient-from: #a855f7;
-  --tw-gradient-stops:
-    var(--tw-gradient-from), var(--tw-gradient-to, rgba(168, 85, 247, 0));
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(168, 85, 247, 0));
 }
 .to-pink-500 {
   --tw-gradient-to: #ec4899;
 }
 .from-cyan-500 {
   --tw-gradient-from: #06b6d4;
-  --tw-gradient-stops:
-    var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 182, 212, 0));
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(6, 182, 212, 0));
 }
 .to-purple-500 {
   --tw-gradient-to: #a855f7;
@@ -129,6 +121,21 @@ body {
 .animate-pulse {
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+.fade-out {
+  animation: fadeOut 0.3s forwards;
+}
 .lucide {
   width: 1em;
   height: 1em;
@@ -158,8 +165,7 @@ body {
   background-image: linear-gradient(to right, var(--tw-gradient-stops));
   --tw-gradient-from: #a855f7;
   --tw-gradient-to: #ec4899;
-  box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
     0 2px 4px -1px rgba(0, 0, 0, 0.06);
   transform: scale(1.05);
   --tw-ring-color: #f472b6;
@@ -191,9 +197,7 @@ body {
 }
 /* Theme Toggle Styles */
 .theme-toggle-container button {
-  transition:
-    background-color 0.2s ease,
-    color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 /* History panel */

--- a/index.html
+++ b/index.html
@@ -274,7 +274,8 @@
           id="my-prompts-link"
           href="my-prompts.html"
           class="px-2 py-1 rounded-md text-sm font-medium bg-white/20 hover:bg-white/30 transition-all duration-200"
-          >My Prompts</a>
+          >My Prompts</a
+        >
       </div>
 
       <!-- Header -->
@@ -375,7 +376,12 @@
               title="Save prompt"
               aria-label="Save prompt"
             >
-              <i data-lucide="save" class="w-4 h-4" role="img" aria-label="Save icon"></i>
+              <i
+                data-lucide="save"
+                class="w-4 h-4"
+                role="img"
+                aria-label="Save icon"
+              ></i>
             </button>
             <button
               id="share-twitter"
@@ -401,6 +407,18 @@
           class="text-green-400 text-sm mt-2 animate-pulse hidden"
         >
           Prompt copied successfully!
+        </p>
+        <p
+          id="download-success-message"
+          class="text-green-400 text-sm mt-2 animate-pulse hidden"
+        >
+          Downloading...
+        </p>
+        <p
+          id="save-success-message"
+          class="text-green-400 text-sm mt-2 animate-pulse hidden"
+        >
+          Prompt saved!
         </p>
       </div>
 

--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -85,7 +85,8 @@ const renderList = () => {
     actions.className = 'flex gap-2 mt-2';
     const saveBtn = document.createElement('button');
     saveBtn.textContent = uiText[appState.language].saveChanges;
-    saveBtn.className = 'save-change px-3 py-1 rounded bg-white/20 hover:bg-white/30';
+    saveBtn.className =
+      'save-change px-3 py-1 rounded bg-white/20 hover:bg-white/30';
     saveBtn.dataset.index = i.toString();
     const delBtn = document.createElement('button');
     delBtn.className =
@@ -93,7 +94,8 @@ const renderList = () => {
     delBtn.title = uiText[appState.language].deletePrompt;
     delBtn.setAttribute('aria-label', uiText[appState.language].deletePrompt);
     delBtn.dataset.index = i.toString();
-    delBtn.innerHTML = '<i data-lucide="trash" class="w-3 h-3" aria-hidden="true"></i>';
+    delBtn.innerHTML =
+      '<i data-lucide="trash" class="w-3 h-3" aria-hidden="true"></i>';
     actions.appendChild(saveBtn);
     actions.appendChild(delBtn);
     wrapper.appendChild(textarea);
@@ -108,9 +110,15 @@ const renderList = () => {
 const setupEvents = () => {
   themeLightButton.addEventListener('click', () => setTheme(THEMES.LIGHT));
   themeDarkButton.addEventListener('click', () => setTheme(THEMES.DARK));
-  document.getElementById('lang-en')?.addEventListener('click', () => setLanguage('en'));
-  document.getElementById('lang-tr')?.addEventListener('click', () => setLanguage('tr'));
-  document.getElementById('lang-es')?.addEventListener('click', () => setLanguage('es'));
+  document
+    .getElementById('lang-en')
+    ?.addEventListener('click', () => setLanguage('en'));
+  document
+    .getElementById('lang-tr')
+    ?.addEventListener('click', () => setLanguage('tr'));
+  document
+    .getElementById('lang-es')
+    ?.addEventListener('click', () => setLanguage('es'));
 
   listContainer.addEventListener('click', (e) => {
     const save = e.target.closest('.save-change');
@@ -120,15 +128,27 @@ const setupEvents = () => {
     const idx = parseInt(btn.dataset.index, 10);
     if (Number.isNaN(idx)) return;
     if (save) {
-      const textarea = listContainer.querySelector(`textarea[data-index="${idx}"]`);
+      const textarea = listContainer.querySelector(
+        `textarea[data-index="${idx}"]`
+      );
       if (textarea) {
         appState.savedPrompts[idx] = textarea.value;
-        localStorage.setItem('savedPrompts', JSON.stringify(appState.savedPrompts));
+        localStorage.setItem(
+          'savedPrompts',
+          JSON.stringify(appState.savedPrompts)
+        );
       }
     } else if (del) {
-      appState.savedPrompts.splice(idx, 1);
-      localStorage.setItem('savedPrompts', JSON.stringify(appState.savedPrompts));
-      renderList();
+      const wrapper = del.closest('div');
+      if (wrapper) wrapper.classList.add('fade-out');
+      setTimeout(() => {
+        appState.savedPrompts.splice(idx, 1);
+        localStorage.setItem(
+          'savedPrompts',
+          JSON.stringify(appState.savedPrompts)
+        );
+        renderList();
+      }, 300);
     }
   });
 };

--- a/src/ui.js
+++ b/src/ui.js
@@ -17,6 +17,8 @@ const uiText = {
     historyTitle: 'Previous Prompts',
     clearHistoryTitle: 'Clear history',
     copySuccessMessage: 'Prompt copied successfully!',
+    saveSuccessMessage: 'Prompt saved!',
+    downloadSuccessMessage: 'Downloading...',
     appStats: 'Prompts that will unlock the potential of your mind',
     footerPrompter: 'Prompter',
     randomCategory: 'Random',
@@ -41,7 +43,9 @@ const uiText = {
     deleteButtonTitle: 'Sil',
     historyTitle: 'Önceki Promptlar',
     clearHistoryTitle: 'Geçmişi temizle',
-    copySuccessMessage: 'Prompt başarıyla kopyalandı!',
+    copySuccessMessage: 'Kopyalandı!',
+    saveSuccessMessage: 'Kaydedildi!',
+    downloadSuccessMessage: 'İndiriliyor...',
     appStats: 'Zihninizin potansiyelini açığa çıkaracak promptlar',
     footerPrompter: 'Prompter',
     randomCategory: 'Rastgele',
@@ -65,7 +69,9 @@ const uiText = {
     deleteButtonTitle: 'Eliminar',
     historyTitle: 'Prompts anteriores',
     clearHistoryTitle: 'Borrar historial',
-    copySuccessMessage: '¡Prompt copiado con éxito!',
+    copySuccessMessage: '¡Copiado!',
+    saveSuccessMessage: '¡Guardado!',
+    downloadSuccessMessage: 'Descargando...',
     appStats: 'Prompts que liberarán el potencial de tu mente',
     footerPrompter: 'Prompter',
     randomCategory: 'Aleatorio',
@@ -87,6 +93,8 @@ let downloadButton;
 let saveButton;
 let shareTwitterButton;
 let copySuccessMessage;
+let downloadSuccessMessage;
+let saveSuccessMessage;
 let langEnButton;
 let langTrButton;
 let langEsButton;
@@ -187,6 +195,8 @@ const setLanguage = (lang) => {
     );
   }
   copySuccessMessage.textContent = uiText[lang].copySuccessMessage;
+  downloadSuccessMessage.textContent = uiText[lang].downloadSuccessMessage;
+  saveSuccessMessage.textContent = uiText[lang].saveSuccessMessage;
   document.getElementById('history-title').textContent =
     uiText[lang].historyTitle;
   clearHistoryButton.title = uiText[lang].clearHistoryTitle;
@@ -341,7 +351,10 @@ const updateButtonTitles = () => {
   );
   if (saveButton) {
     saveButton.title = uiText[appState.language].saveButtonTitle;
-    saveButton.setAttribute('aria-label', uiText[appState.language].saveButtonTitle);
+    saveButton.setAttribute(
+      'aria-label',
+      uiText[appState.language].saveButtonTitle
+    );
   }
   if (shareTwitterButton) {
     shareTwitterButton.title = uiText[appState.language].shareTwitterTitle;
@@ -361,7 +374,8 @@ const renderHistory = () => {
     const li = document.createElement('li');
     li.className = 'flex justify-between items-start gap-2';
     const textarea = document.createElement('textarea');
-    textarea.className = 'history-edit flex-1 whitespace-pre-wrap font-mono bg-transparent p-1 rounded-md';
+    textarea.className =
+      'history-edit flex-1 whitespace-pre-wrap font-mono bg-transparent p-1 rounded-md';
     textarea.value = prompt;
     textarea.setAttribute('data-index', idx);
     const actions = document.createElement('div');
@@ -371,18 +385,26 @@ const renderHistory = () => {
     copyBtn.className =
       'history-copy p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
     copyBtn.title = uiText[appState.language].copyButtonTitle;
-    copyBtn.setAttribute('aria-label', uiText[appState.language].copyButtonTitle);
+    copyBtn.setAttribute(
+      'aria-label',
+      uiText[appState.language].copyButtonTitle
+    );
     copyBtn.setAttribute('data-index', idx);
-    copyBtn.innerHTML = '<i data-lucide="copy" class="w-3 h-3" aria-hidden="true"></i>';
+    copyBtn.innerHTML =
+      '<i data-lucide="copy" class="w-3 h-3" aria-hidden="true"></i>';
     actions.appendChild(copyBtn);
 
     const downloadBtn = document.createElement('button');
     downloadBtn.className =
       'history-download p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
     downloadBtn.title = uiText[appState.language].downloadButtonTitle;
-    downloadBtn.setAttribute('aria-label', uiText[appState.language].downloadButtonTitle);
+    downloadBtn.setAttribute(
+      'aria-label',
+      uiText[appState.language].downloadButtonTitle
+    );
     downloadBtn.setAttribute('data-index', idx);
-    downloadBtn.innerHTML = '<i data-lucide="download" class="w-3 h-3" aria-hidden="true"></i>';
+    downloadBtn.innerHTML =
+      '<i data-lucide="download" class="w-3 h-3" aria-hidden="true"></i>';
     actions.appendChild(downloadBtn);
 
     if (saveButton) {
@@ -390,9 +412,13 @@ const renderHistory = () => {
       saveBtn.className =
         'history-save p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
       saveBtn.title = uiText[appState.language].saveButtonTitle;
-      saveBtn.setAttribute('aria-label', uiText[appState.language].saveButtonTitle);
+      saveBtn.setAttribute(
+        'aria-label',
+        uiText[appState.language].saveButtonTitle
+      );
       saveBtn.setAttribute('data-index', idx);
-      saveBtn.innerHTML = '<i data-lucide="save" class="w-3 h-3" aria-hidden="true"></i>';
+      saveBtn.innerHTML =
+        '<i data-lucide="save" class="w-3 h-3" aria-hidden="true"></i>';
       actions.appendChild(saveBtn);
     }
 
@@ -401,9 +427,13 @@ const renderHistory = () => {
       shareBtn.className =
         'history-share p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
       shareBtn.title = uiText[appState.language].shareTwitterTitle;
-      shareBtn.setAttribute('aria-label', uiText[appState.language].shareTwitterTitle);
+      shareBtn.setAttribute(
+        'aria-label',
+        uiText[appState.language].shareTwitterTitle
+      );
       shareBtn.setAttribute('data-index', idx);
-      shareBtn.innerHTML = '<i data-lucide="twitter" class="w-3 h-3" aria-hidden="true"></i>';
+      shareBtn.innerHTML =
+        '<i data-lucide="twitter" class="w-3 h-3" aria-hidden="true"></i>';
       actions.appendChild(shareBtn);
     }
 
@@ -511,6 +541,10 @@ const setupEventListeners = () => {
 
   downloadButton.addEventListener('click', () => {
     if (!appState.generatedPrompt) return;
+    downloadSuccessMessage.classList.remove('hidden');
+    setTimeout(() => {
+      downloadSuccessMessage.classList.add('hidden');
+    }, 2000);
     const blob = new Blob([appState.generatedPrompt], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -526,7 +560,14 @@ const setupEventListeners = () => {
     saveButton.addEventListener('click', () => {
       if (!appState.generatedPrompt) return;
       appState.savedPrompts.push(appState.generatedPrompt);
-      localStorage.setItem('savedPrompts', JSON.stringify(appState.savedPrompts));
+      localStorage.setItem(
+        'savedPrompts',
+        JSON.stringify(appState.savedPrompts)
+      );
+      saveSuccessMessage.classList.remove('hidden');
+      setTimeout(() => {
+        saveSuccessMessage.classList.add('hidden');
+      }, 2000);
       saveButton.disabled = true;
       setTimeout(() => {
         saveButton.disabled = false;
@@ -536,7 +577,10 @@ const setupEventListeners = () => {
 
   if (shareTwitterButton) {
     shareTwitterButton.addEventListener('click', () =>
-      sharePrompt(appState.generatedPrompt, 'https://twitter.com/intent/tweet?text=')
+      sharePrompt(
+        appState.generatedPrompt,
+        'https://twitter.com/intent/tweet?text='
+      )
     );
   }
 
@@ -558,9 +602,13 @@ const setupEventListeners = () => {
     if (Number.isNaN(index)) return;
     const text = appState.history[index];
     if (deleteBtn) {
-      appState.history.splice(index, 1);
-      localStorage.setItem('promptHistory', JSON.stringify(appState.history));
-      renderHistory();
+      const li = deleteBtn.closest('li');
+      if (li) li.classList.add('fade-out');
+      setTimeout(() => {
+        appState.history.splice(index, 1);
+        localStorage.setItem('promptHistory', JSON.stringify(appState.history));
+        renderHistory();
+      }, 300);
     } else if (!text) {
       return;
     } else if (copyBtn) {
@@ -579,7 +627,10 @@ const setupEventListeners = () => {
       URL.revokeObjectURL(url);
     } else if (saveBtn) {
       appState.savedPrompts.push(text);
-      localStorage.setItem('savedPrompts', JSON.stringify(appState.savedPrompts));
+      localStorage.setItem(
+        'savedPrompts',
+        JSON.stringify(appState.savedPrompts)
+      );
     } else if (shareBtn) {
       sharePrompt(text, 'https://twitter.com/intent/tweet?text=');
     }
@@ -616,6 +667,8 @@ export const initializeApp = () => {
   saveButton = document.getElementById('save-button');
   shareTwitterButton = document.getElementById('share-twitter');
   copySuccessMessage = document.getElementById('copy-success-message');
+  downloadSuccessMessage = document.getElementById('download-success-message');
+  saveSuccessMessage = document.getElementById('save-success-message');
   langEnButton = document.getElementById('lang-en');
   langTrButton = document.getElementById('lang-tr');
   langEsButton = document.getElementById('lang-es');


### PR DESCRIPTION
## Summary
- show small confirmation messages for download and save buttons
- localize new messages in all languages
- animate deletions from history and saved lists
- add fade out CSS animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da0945af0832f8cfd10889e22ba2b