### PR TITLE
Add save and delete feedback animations

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -136,6 +136,22 @@ body {
 .fade-out {
   animation: fadeOut 0.3s forwards;
 }
+
+@keyframes pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.button-pop {
+  animation: pop 0.3s ease;
+}
 .lucide {
   width: 1em;
   height: 1em;

--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -9,6 +9,7 @@ const uiText = {
     light: 'Light Theme',
     dark: 'Dark Theme',
     back: 'Back',
+    saveFeedback: 'Saved!',
   },
   tr: {
     pageTitle: 'Kayıtlı Promptlarım',
@@ -18,6 +19,7 @@ const uiText = {
     light: 'Açık Tema',
     dark: 'Koyu Tema',
     back: 'Geri',
+    saveFeedback: 'Kaydedildi!',
   },
   es: {
     pageTitle: 'Mis Prompts',
@@ -27,6 +29,7 @@ const uiText = {
     light: 'Tema Claro',
     dark: 'Tema Oscuro',
     back: 'Volver',
+    saveFeedback: '¡Guardado!',
   },
 };
 
@@ -96,7 +99,11 @@ const renderList = () => {
     delBtn.dataset.index = i.toString();
     delBtn.innerHTML =
       '<i data-lucide="trash" class="w-3 h-3" aria-hidden="true"></i>';
+    const feedback = document.createElement('span');
+    feedback.className = 'save-feedback text-green-400 text-xs ml-1 hidden';
+    feedback.textContent = uiText[appState.language].saveFeedback;
     actions.appendChild(saveBtn);
+    actions.appendChild(feedback);
     actions.appendChild(delBtn);
     wrapper.appendChild(textarea);
     wrapper.appendChild(actions);
@@ -137,10 +144,19 @@ const setupEvents = () => {
           'savedPrompts',
           JSON.stringify(appState.savedPrompts)
         );
+        const feedback = save.nextElementSibling;
+        if (feedback && feedback.classList.contains('save-feedback')) {
+          feedback.classList.remove('hidden');
+          setTimeout(() => feedback.classList.add('hidden'), 1000);
+        }
+        save.classList.add('button-pop');
+        setTimeout(() => save.classList.remove('button-pop'), 300);
       }
     } else if (del) {
       const wrapper = del.closest('div');
       if (wrapper) wrapper.classList.add('fade-out');
+      del.classList.add('button-pop');
+      setTimeout(() => del.classList.remove('button-pop'), 300);
       setTimeout(() => {
         appState.savedPrompts.splice(idx, 1);
         localStorage.setItem(

--- a/src/ui.js
+++ b/src/ui.js
@@ -19,6 +19,7 @@ const uiText = {
     copySuccessMessage: 'Prompt copied successfully!',
     saveSuccessMessage: 'Prompt saved!',
     downloadSuccessMessage: 'Downloading...',
+    saveFeedback: 'Saved!',
     appStats: 'Prompts that will unlock the potential of your mind',
     footerPrompter: 'Prompter',
     randomCategory: 'Random',
@@ -46,6 +47,7 @@ const uiText = {
     copySuccessMessage: 'Kopyalandı!',
     saveSuccessMessage: 'Kaydedildi!',
     downloadSuccessMessage: 'İndiriliyor...',
+    saveFeedback: 'Kaydedildi!',
     appStats: 'Zihninizin potansiyelini açığa çıkaracak promptlar',
     footerPrompter: 'Prompter',
     randomCategory: 'Rastgele',
@@ -72,6 +74,7 @@ const uiText = {
     copySuccessMessage: '¡Copiado!',
     saveSuccessMessage: '¡Guardado!',
     downloadSuccessMessage: 'Descargando...',
+    saveFeedback: '¡Guardado!',
     appStats: 'Prompts que liberarán el potencial de tu mente',
     footerPrompter: 'Prompter',
     randomCategory: 'Aleatorio',
@@ -450,6 +453,11 @@ const renderHistory = () => {
       '<i data-lucide="trash" class="w-3 h-3" aria-hidden="true"></i>';
     actions.appendChild(deleteBtn);
 
+    const feedback = document.createElement('span');
+    feedback.className = 'save-feedback text-green-400 text-xs ml-1 hidden';
+    feedback.textContent = uiText[appState.language].saveFeedback;
+    actions.appendChild(feedback);
+
     li.appendChild(textarea);
     li.appendChild(actions);
     historyList.appendChild(li);
@@ -568,6 +576,10 @@ const setupEventListeners = () => {
       setTimeout(() => {
         saveSuccessMessage.classList.add('hidden');
       }, 2000);
+      saveButton.classList.add('button-pop');
+      setTimeout(() => {
+        saveButton.classList.remove('button-pop');
+      }, 300);
       saveButton.disabled = true;
       setTimeout(() => {
         saveButton.disabled = false;
@@ -604,6 +616,10 @@ const setupEventListeners = () => {
     if (deleteBtn) {
       const li = deleteBtn.closest('li');
       if (li) li.classList.add('fade-out');
+      deleteBtn.classList.add('button-pop');
+      setTimeout(() => {
+        deleteBtn.classList.remove('button-pop');
+      }, 300);
       setTimeout(() => {
         appState.history.splice(index, 1);
         localStorage.setItem('promptHistory', JSON.stringify(appState.history));
@@ -631,6 +647,17 @@ const setupEventListeners = () => {
         'savedPrompts',
         JSON.stringify(appState.savedPrompts)
       );
+      const feedback = saveBtn.parentElement.querySelector('.save-feedback');
+      if (feedback) {
+        feedback.classList.remove('hidden');
+        setTimeout(() => {
+          feedback.classList.add('hidden');
+        }, 1000);
+      }
+      saveBtn.classList.add('button-pop');
+      setTimeout(() => {
+        saveBtn.classList.remove('button-pop');
+      }, 300);
     } else if (shareBtn) {
       sharePrompt(text, 'https://twitter.com/intent/tweet?text=');
     }


### PR DESCRIPTION
## Summary
- add `button-pop` animation and keyframe
- localize short feedback messages for 'Saved!'
- show animated feedback when saving prompts
- animate delete buttons on prompt removal
- display small saved indicator in history and saved prompts pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da43afcc0832fb458396a15634593