### PR TITLE
Update my-prompts save button icon

### DIFF
--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -87,10 +87,13 @@ const renderList = () => {
     const actions = document.createElement('div');
     actions.className = 'flex gap-2 mt-2';
     const saveBtn = document.createElement('button');
-    saveBtn.textContent = uiText[appState.language].saveChanges;
     saveBtn.className =
-      'save-change px-3 py-1 rounded bg-white/20 hover:bg-white/30';
+      'save-change p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+    saveBtn.title = uiText[appState.language].saveChanges;
+    saveBtn.setAttribute('aria-label', uiText[appState.language].saveChanges);
     saveBtn.dataset.index = i.toString();
+    saveBtn.innerHTML =
+      '<i data-lucide="save" class="w-4 h-4" role="img" aria-label="Save icon"></i>';
     const delBtn = document.createElement('button');
     delBtn.className =
       'delete-prompt p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';


### PR DESCRIPTION
## Summary
- display a lucide save icon for entries in My Prompts
- use tooltip text for save button

## Testing
- `npm test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_684daa7da278832fb96283a9bb468422