### PR TITLE
Display current language next to toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,6 +256,7 @@
               aria-label="Languages icon"
             ></i>
           </button>
+          <span id="current-lang" class="text-blue-200 text-sm font-semibold">EN</span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"

--- a/src/ui.js
+++ b/src/ui.js
@@ -107,6 +107,7 @@ let langTrButton;
 let langEsButton;
 let langToggleButton;
 let langMenu;
+let currentLangLabel;
 let themeLightButton;
 let themeDarkButton;
 let themeLinkElement;
@@ -223,6 +224,9 @@ const setLanguage = (lang) => {
   if (langEsButton) {
     langEsButton.title = uiText[lang].langEsLabel;
     langEsButton.setAttribute('aria-label', uiText[lang].langEsLabel);
+  }
+  if (currentLangLabel) {
+    currentLangLabel.textContent = lang.toUpperCase();
   }
 
   categories.forEach((category) => {
@@ -788,6 +792,7 @@ export const initializeApp = () => {
   langEsButton = document.getElementById('lang-es');
   langToggleButton = document.getElementById('lang-toggle');
   langMenu = document.getElementById('lang-menu');
+  currentLangLabel = document.getElementById('current-lang');
   themeLightButton = document.getElementById('theme-light');
   themeDarkButton = document.getElementById('theme-dark');
   themeLinkElement = document.getElementById('theme-css');

--- a/tr/index.html
+++ b/tr/index.html
@@ -259,6 +259,7 @@
               aria-label="Languages icon"
             ></i>
           </button>
+          <span id="current-lang" class="text-blue-200 text-sm font-semibold">TR</span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"


### PR DESCRIPTION
## Summary
- show selected language code beside language switcher on main pages
- update JS to keep label in sync with selection

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ddc448f64832f81d42c73f084f39a