### PR TITLE
Enable toggling language menu via label

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
               aria-label="Languages icon"
             ></i>
           </button>
-          <span id="current-lang" class="text-blue-200 text-sm font-semibold">EN</span>
+          <span id="current-lang" class="text-blue-200 text-sm font-semibold cursor-pointer">EN</span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"

--- a/src/ui.js
+++ b/src/ui.js
@@ -756,6 +756,12 @@ const setupEventListeners = () => {
     });
   }
 
+  if (currentLangLabel && langMenu) {
+    currentLangLabel.addEventListener('click', () => {
+      langMenu.classList.toggle('hidden');
+    });
+  }
+
   langEnButton.addEventListener('click', () => setLanguage('en'));
   langTrButton.addEventListener('click', () => setLanguage('tr'));
   if (langEsButton) {

--- a/tr/index.html
+++ b/tr/index.html
@@ -259,7 +259,7 @@
               aria-label="Languages icon"
             ></i>
           </button>
-          <span id="current-lang" class="text-blue-200 text-sm font-semibold">TR</span>
+          <span id="current-lang" class="text-blue-200 text-sm font-semibold cursor-pointer">TR</span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"


### PR DESCRIPTION
## Summary
- make the language label clickable to toggle the dropdown
- style the current language label as a pointer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ddde16fa8832f98da0a105be28622