### PR TITLE
Fix back arrow still showing brackets

### DIFF
--- a/my-prompts.html
+++ b/my-prompts.html
@@ -26,23 +26,13 @@
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-3xl mx-auto relative">
       <div class="absolute top-4 left-4">
-        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            width="20"
-            height="20"
-            class="w-5 h-5"
-            aria-hidden="true"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <line x1="19" y1="12" x2="5" y2="12" />
-            <polyline points="12 19 5 12 12 5" />
-          </svg>
+        <a
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-5 h-5 inline-block" aria-hidden="true">&larr;</span>
         </a>
       </div>
       <div class="absolute top-4 right-4 flex items-center gap-2">


### PR DESCRIPTION
## Summary
- replace lucide icon with a simple Unicode arrow on My Prompts page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de0c52c64832f8c3ce61aa0f05008