### PR TITLE
Update tagline and domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Prompter includes a range of optimizations to help search engines crawl and inde
 
 ## Changing the base URL
 
-Before deploying your own instance, update all references to the default GitHub
-Pages address (`https://muratcangencturk.github.io/prompter`).
+Before deploying your own instance, update all references to the default domain
+(`https://prompterai.space`).
 
 - Edit the canonical `<link>` tags in `index.html` and `tr/index.html` so they
   point to your final site.

--- a/index.html
+++ b/index.html
@@ -35,27 +35,27 @@
       content="Creative AI prompt generator that works offline."
     />
     <meta name="twitter:image" content="icons/logo.svg" />
-    <link rel="canonical" href="https://muratcangencturk.github.io/prompter/" />
+    <link rel="canonical" href="https://prompterai.space/" />
     <link
       rel="alternate"
-      href="https://muratcangencturk.github.io/prompter/"
+      href="https://prompterai.space/"
       hreflang="en"
     />
     <link
       rel="alternate"
-      href="https://muratcangencturk.github.io/prompter/tr/"
+      href="https://prompterai.space/tr/"
       hreflang="tr"
     />
     <link
       rel="alternate"
-      href="https://muratcangencturk.github.io/prompter/es/"
+      href="https://prompterai.space/es/"
       hreflang="es"
     />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "url": "https://muratcangencturk.github.io/prompter/",
+        "url": "https://prompterai.space/",
         "name": "Prompter",
         "alternateName": "Prompter",
         "inLanguage": ["en", "tr", "es"],
@@ -310,7 +310,7 @@
           PROMPTER
         </h1>
         <p id="app-subtitle" class="text-blue-200 text-lg md:text-xl px-2">
-          Prompt generator for AI - unprecedented, limitless creativity
+          Prompt generator for AI - the ultimate prompt engineering online space
         </p>
       </div>
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://muratcangencturk.github.io/prompter/sitemap.xml
+Sitemap: https://prompterai.space/sitemap.xml

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const BASE_URL = 'https://muratcangencturk.github.io/prompter';
+const BASE_URL = 'https://prompterai.space';
 
 const urls = [`${BASE_URL}/`, `${BASE_URL}/tr/`];
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://muratcangencturk.github.io/prompter/</loc></url>
-  <url><loc>https://muratcangencturk.github.io/prompter/tr/</loc></url>
+  <url><loc>https://prompterai.space/</loc></url>
+  <url><loc>https://prompterai.space/tr/</loc></url>
 </urlset>

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,7 +5,7 @@ const uiText = {
   en: {
     appTitle: 'PROMPTER',
     appSubtitle:
-      'Prompt generator for AI - unprecedented, limitless creativity',
+      'Prompt generator for AI - the ultimate prompt engineering online space',
     chooseStyleTitle: 'Select Your Prompt Inspiration',
     generateButtonText: 'Generate New Prompt',
     yourPromptTitle: 'Your Unique Prompt:',
@@ -34,7 +34,7 @@ const uiText = {
   tr: {
     appTitle: 'PROMPTER',
     appSubtitle:
-      'YZ için prompt üretici - eşi benzeri görülmemiş sınırsız yaratıcılık',
+      'YZ için prompt üretici - prompt mühendisliğinin online adresi',
     chooseStyleTitle: 'Prompt İlhamınızı Seçin',
     generateButtonText: 'Yeni Prompt Üret',
     yourPromptTitle: 'Benzersiz Promptunuz:',

--- a/tr/index.html
+++ b/tr/index.html
@@ -37,28 +37,28 @@
     <meta name="twitter:image" content="../icons/logo.svg" />
     <link
       rel="canonical"
-      href="https://muratcangencturk.github.io/prompter/tr/"
+      href="https://prompterai.space/tr/"
     />
     <link
       rel="alternate"
-      href="https://muratcangencturk.github.io/prompter/"
+      href="https://prompterai.space/"
       hreflang="en"
     />
     <link
       rel="alternate"
-      href="https://muratcangencturk.github.io/prompter/tr/"
+      href="https://prompterai.space/tr/"
       hreflang="tr"
     />
     <link
       rel="alternate"
-      href="https://muratcangencturk.github.io/prompter/es/"
+      href="https://prompterai.space/es/"
       hreflang="es"
     />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "url": "https://muratcangencturk.github.io/prompter/tr/",
+        "url": "https://prompterai.space/tr/",
         "name": "Prompter",
         "alternateName": "Prompter",
         "inLanguage": ["tr", "en", "es"],
@@ -313,7 +313,7 @@
           PROMPTER
         </h1>
         <p id="app-subtitle" class="text-blue-200 text-lg md:text-xl px-2">
-          Prompt generator for AI - unprecedented, limitless creativity
+          YZ için prompt üretici - prompt mühendisliğinin online adresi
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- update tagline text for English and Turkish
- switch canonical links and SEO references to `prompterai.space`
- adjust example URL in README
- regenerate sitemap

## Testing
- `npm install`
- `npm test`
- `npm run build:sitemap`


------
https://chatgpt.com/codex/tasks/task_e_684df1d99ccc832f95fbf305d697156f