### PR TITLE
Add dropdown indicator for language switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,13 @@
               aria-label="Languages icon"
             ></i>
           </button>
-          <span id="current-lang" class="text-blue-200 text-sm font-semibold cursor-pointer">EN</span>
+          <span
+            id="current-lang"
+            class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
+          >
+            EN
+            <i data-lucide="chevron-down" class="w-3 h-3 mt-0.5" aria-hidden="true"></i>
+          </span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"

--- a/tr/index.html
+++ b/tr/index.html
@@ -259,7 +259,13 @@
               aria-label="Languages icon"
             ></i>
           </button>
-          <span id="current-lang" class="text-blue-200 text-sm font-semibold cursor-pointer">TR</span>
+          <span
+            id="current-lang"
+            class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
+          >
+            TR
+            <i data-lucide="chevron-down" class="w-3 h-3 mt-0.5" aria-hidden="true"></i>
+          </span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"


### PR DESCRIPTION
## Summary
- indicate that the current language opens a menu by adding a chevron-down icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df83c94e8832f82e9007a3e1648be