### PR TITLE
Add visible dropdown arrow

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,25 @@
               aria-label="Languages icon"
             ></i>
           </button>
-          <span id="current-lang" class="text-blue-200 text-sm font-semibold cursor-pointer">EN</span>
+          <span
+            id="current-lang"
+            class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
+          >
+            EN
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-3 h-3 mt-0.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"

--- a/src/ui.js
+++ b/src/ui.js
@@ -226,7 +226,11 @@ const setLanguage = (lang) => {
     langEsButton.setAttribute('aria-label', uiText[lang].langEsLabel);
   }
   if (currentLangLabel) {
+    const arrow = currentLangLabel.querySelector('svg');
     currentLangLabel.textContent = lang.toUpperCase();
+    if (arrow) {
+      currentLangLabel.appendChild(arrow);
+    }
   }
 
   categories.forEach((category) => {

--- a/tr/index.html
+++ b/tr/index.html
@@ -259,7 +259,25 @@
               aria-label="Languages icon"
             ></i>
           </button>
-          <span id="current-lang" class="text-blue-200 text-sm font-semibold cursor-pointer">TR</span>
+          <span
+            id="current-lang"
+            class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
+          >
+            TR
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-3 h-3 mt-0.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </span>
           <div
             id="lang-menu"
             class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"


### PR DESCRIPTION
## Summary
- render the dropdown arrow with inline SVG so the language menu indicator always shows
- ensure `setLanguage` preserves the dropdown arrow when updating the language label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df83c94e8832f82e9007a3e1648be