### PR TITLE
Disable automatic page reload on SW updates

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,9 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('sw.js').catch(console.error);
   });
-  navigator.serviceWorker.addEventListener('controllerchange', () => {
-    window.location.reload();
-  });
+  // Commented out to prevent automatic page refresh when the service worker
+  // activates. Reload manually if you want to update the cached assets.
+  // navigator.serviceWorker.addEventListener('controllerchange', () => {
+  //   window.location.reload();
+  // });
 }


### PR DESCRIPTION
## Summary
- disable the `controllerchange` auto-reload in `src/main.js`

## Testing
- `npm test`
- `npm run build` *(fails: ASSETS array not found in sw.js)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685092af7b44832fb9b7d418b67ba6c4