### PR TITLE
Swap header controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
     >
       <!-- Theme Toggle -->
       <div
-        class="theme-toggle-container absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="theme-toggle-container absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
       >
         <button
           id="theme-light"
@@ -244,7 +244,7 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
       >
         <div class="relative flex items-center" id="lang-container">
           <button

--- a/tr/index.html
+++ b/tr/index.html
@@ -214,7 +214,7 @@
     >
       <!-- Theme Toggle -->
       <div
-        class="theme-toggle-container absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="theme-toggle-container absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
       >
         <button
           id="theme-light"
@@ -246,7 +246,7 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
       >
         <div class="relative flex items-center" id="lang-container">
           <button


### PR DESCRIPTION
## Summary
- swap the theme toggle with the language/My Prompts container
- keep both positions consistent on the Turkish homepage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685093d60f24832f8e0c311147960ee0