### PR TITLE
Shrink history panel

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -218,7 +218,7 @@ body {
 
 /* History panel */
 #history-panel {
-  max-height: 15rem;
+  max-height: 7.5rem;
   overflow-y: auto;
 }
 .history-copy i {


### PR DESCRIPTION
## Summary
- limit history panel height to 7.5rem

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851c65aa394832fb925c9bc4f3abeec