### PR TITLE
Remove old service workers on saved prompts page

### DIFF
--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -281,6 +281,17 @@ const init = () => {
   renderList();
   setupEvents();
   window.lucide?.createIcons();
+
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker
+      .getRegistrations()
+      .then((regs) => {
+        for (const reg of regs) {
+          reg.unregister().catch(() => {});
+        }
+      })
+      .catch(() => {});
+  }
 };
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- unregister any existing service workers when `my-prompts.js` initializes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d466dd30832faa2872e9be09a5f4