### PR TITLE
Fix build script to handle missing sw.js

### DIFF
--- a/scripts/build-prompts.js
+++ b/scripts/build-prompts.js
@@ -64,6 +64,10 @@ function listPromptFiles() {
 }
 
 function updateServiceWorker(promptFiles) {
+  if (!fs.existsSync(swFile)) {
+    console.log(`Warning: ${swFile} not found, skipping service worker update.`);
+    return;
+  }
   const swSrc = fs.readFileSync(swFile, 'utf8');
   const lines = swSrc.split(/\r?\n/);
   const start = lines.findIndex((l) => l.trim() === 'const ASSETS = [');


### PR DESCRIPTION
## Summary
- check if `sw.js` exists when updating service worker

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d5148510832fb83f9fb51b5e3a96