### PR TITLE
Add ad slot near history panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,14 +491,28 @@
           s.settings = ebuww || {};
           s.src = "\/\/complete-drink.com\/bsXRVnsld.G\/lB0gYzWocl\/_eXm\/9uu_ZSUjlMkYPFT\/Y_0dMezpUI2\/NvzCUot\/NzjUQYzDNMTVYS3INKgF";
           s.async = true;
+        s.referrerPolicy = 'no-referrer-when-downgrade';
+        l.parentNode.insertBefore(s, l);
+      })({})
+    </script>
+    <div class="mt-4 flex justify-end">
+      <script>
+        (function(ccqp){
+          var d = document,
+            s = d.createElement('script'),
+            l = d.scripts[d.scripts.length - 1];
+          s.settings = ccqp || {};
+          s.src = "\/\/complete-drink.com\/b\/XxV.sydBGBlg0zYGWIcx\/ceAmE9juAZGU\/l-k\/PwTJYB0WMEzIUM4SMETjYIteNfjHQLzENzTRgdxxNewE";
+          s.async = true;
           s.referrerPolicy = 'no-referrer-when-downgrade';
           l.parentNode.insertBefore(s, l);
         })({})
       </script>
-      <!-- Prompt History -->
-      <div
-        id="history-panel"
-        class="hidden bg-white/10 backdrop-blur-md rounded-2xl p-4 mt-4 border border-white/20 shadow-lg"
+    </div>
+    <!-- Prompt History -->
+    <div
+      id="history-panel"
+      class="hidden bg-white/10 backdrop-blur-md rounded-2xl p-4 mt-4 border border-white/20 shadow-lg"
       >
         <div class="flex justify-between items-center mb-3">
           <h3 id="history-title" class="text-lg font-semibold">


### PR DESCRIPTION
## Summary
- add a new advertisement script before the history panel
- wrap the new ad in a right-aligned container so it doesn't overlap the existing ad

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852d3a77b88832f9f9239e260783630