### PR TITLE
Fix ad alignment above history section

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,6 +483,7 @@
           Sharing...
         </p>
       </div>
+    <div class="mt-4 flex justify-between items-start">
       <script>
        (function(ebuww){
          var d = document,
@@ -494,8 +495,7 @@
         s.referrerPolicy = 'no-referrer-when-downgrade';
         l.parentNode.insertBefore(s, l);
       })({})
-    </script>
-    <div class="mt-4 flex justify-end">
+      </script>
       <script>
         (function(ccqp){
           var d = document,


### PR DESCRIPTION
## Summary
- wrap the two ad scripts in a shared flex container to align them

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852d540c5fc832fbba0b215d83314b2