### PR TITLE
Preserve theme CSS version on load and toggle

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -195,11 +195,12 @@
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=20" />
     <script>
       (function () {
-        const savedTheme = localStorage.getItem('theme');
-        if (!savedTheme) return;
         const linkEl = document.getElementById('theme-css');
-        if (linkEl) {
-          linkEl.href = `css/theme-${savedTheme}.css`;
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
         }
       })();
     </script>

--- a/index.html
+++ b/index.html
@@ -197,11 +197,12 @@
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=20" />
     <script>
       (function () {
-        const savedTheme = localStorage.getItem('theme');
-        if (!savedTheme) return;
         const linkEl = document.getElementById('theme-css');
-        if (linkEl) {
-          linkEl.href = `css/theme-${savedTheme}.css`;
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
         }
       })();
     </script>

--- a/my-prompts.html
+++ b/my-prompts.html
@@ -30,11 +30,12 @@
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=20" />
     <script>
       (function () {
-        const savedTheme = localStorage.getItem('theme');
-        if (!savedTheme) return;
         const linkEl = document.getElementById('theme-css');
-        if (linkEl) {
-          linkEl.href = `css/theme-${savedTheme}.css`;
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
         }
       })();
     </script>

--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -48,12 +48,14 @@ const uiText = {
 let themeLightButton;
 let themeDarkButton;
 let themeLinkElement;
+let themeVersion = '';
 let listContainer;
 
 const setTheme = (theme) => {
   appState.theme = theme;
   if (themeLinkElement) {
-    themeLinkElement.href = `css/theme-${theme}.css`;
+    const versionSuffix = themeVersion ? `?${themeVersion}` : '';
+    themeLinkElement.href = `css/theme-${theme}.css${versionSuffix}`;
   }
   localStorage.setItem('theme', theme);
   updateTexts();
@@ -270,6 +272,13 @@ const init = () => {
   themeLightButton = document.getElementById('theme-light');
   themeDarkButton = document.getElementById('theme-dark');
   themeLinkElement = document.getElementById('theme-css');
+  if (themeLinkElement) {
+    const href = themeLinkElement.getAttribute('href') || '';
+    const parts = href.split('?');
+    if (parts[1]) {
+      themeVersion = parts[1];
+    }
+  }
   listContainer = document.getElementById('saved-list');
 
   const lang = localStorage.getItem('language') || 'en';

--- a/src/ui.js
+++ b/src/ui.js
@@ -111,6 +111,7 @@ let currentLangLabel;
 let themeLightButton;
 let themeDarkButton;
 let themeLinkElement;
+let themeVersion = '';
 let appLogo;
 let historyPanel;
 let historyList;
@@ -120,7 +121,8 @@ let lastGeneratedCategoryId = appState.selectedCategory;
 const setTheme = (theme) => {
   appState.theme = theme;
   if (themeLinkElement) {
-    themeLinkElement.href = `css/theme-${theme}.css`;
+    const versionSuffix = themeVersion ? `?${themeVersion}` : '';
+    themeLinkElement.href = `css/theme-${theme}.css${versionSuffix}`;
   }
   if (theme === THEMES.LIGHT) {
     themeLightButton.classList.add(
@@ -806,6 +808,13 @@ export const initializeApp = () => {
   themeLightButton = document.getElementById('theme-light');
   themeDarkButton = document.getElementById('theme-dark');
   themeLinkElement = document.getElementById('theme-css');
+  if (themeLinkElement) {
+    const href = themeLinkElement.getAttribute('href') || '';
+    const parts = href.split('?');
+    if (parts[1]) {
+      themeVersion = parts[1];
+    }
+  }
   appLogo = document.getElementById('app-logo');
   historyPanel = document.getElementById('history-panel');
   historyList = document.getElementById('history-list');

--- a/tr/index.html
+++ b/tr/index.html
@@ -195,11 +195,12 @@
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=20" />
     <script>
       (function () {
-        const savedTheme = localStorage.getItem('theme');
-        if (!savedTheme) return;
         const linkEl = document.getElementById('theme-css');
-        if (linkEl) {
-          linkEl.href = `css/theme-${savedTheme}.css`;
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- keep version query when toggling themes
- respect version in early theme scripts across all pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e221ccb4832fbc0df33cca2b32e4