### PR TITLE
Fix language dropdown menu behavior

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -296,7 +296,7 @@
           </span>
           <div
             id="lang-menu"
-            class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"
+            class="lang-menu hidden absolute right-0 top-full mt-1 rounded-md border border-white/20 text-sm"
           >
             <button
               id="lang-en"

--- a/fr/index.html
+++ b/fr/index.html
@@ -313,7 +313,7 @@
           </span>
           <div
             id="lang-menu"
-            class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"
+            class="lang-menu hidden absolute right-0 top-full mt-1 rounded-md border border-white/20 text-sm"
           >
             <button
               id="lang-en"

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
           </span>
           <div
             id="lang-menu"
-            class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"
+            class="lang-menu hidden absolute right-0 top-full mt-1 rounded-md border border-white/20 text-sm"
           >
             <button
               id="lang-en"

--- a/tr/index.html
+++ b/tr/index.html
@@ -296,7 +296,7 @@
           </span>
           <div
             id="lang-menu"
-            class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"
+            class="lang-menu hidden absolute right-0 top-full mt-1 rounded-md border border-white/20 text-sm"
           >
             <button
               id="lang-en"

--- a/zh/index.html
+++ b/zh/index.html
@@ -316,7 +316,7 @@
           </span>
           <div
             id="lang-menu"
-            class="lang-menu hidden absolute right-0 mt-1 rounded-md border border-white/20 text-sm"
+            class="lang-menu hidden absolute right-0 top-full mt-1 rounded-md border border-white/20 text-sm"
           >
             <button
               id="lang-en"


### PR DESCRIPTION
## Summary
- fix orientation for language dropdown so it opens downward

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852ffe76120832f819442c9c37e1eaa