### PR TITLE
Add localized hint for prompt history

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -8,7 +8,8 @@ const uiText = {
       'Prompt generator for AI - the ultimate prompt engineering online space',
     chooseStyleTitle: 'Select Your Prompt Inspiration',
     generateButtonText: 'Generate New Prompt',
-    yourPromptTitle: 'Your Unique Prompt:',
+    yourPromptTitle: 'Your Unique Prompt',
+    historyBottom: 'Prompt History is at the Bottom',
     copyButtonTitle: 'Copy to clipboard',
     downloadButtonTitle: 'Download as .txt',
     shareTwitterTitle: 'Share on Twitter',
@@ -39,7 +40,8 @@ const uiText = {
       'YZ için prompt üretici - prompt mühendisliğinin online adresi',
     chooseStyleTitle: 'Prompt İlhamınızı Seçin',
     generateButtonText: 'Yeni Prompt Üret',
-    yourPromptTitle: 'Benzersiz Promptunuz:',
+    yourPromptTitle: 'Benzersiz Promptunuz',
+    historyBottom: 'Geçmiş aşağıda',
     copyButtonTitle: 'Panoya kopyala',
     downloadButtonTitle: '.txt olarak indir',
     shareTwitterTitle: "Twitter'da paylaş",
@@ -69,7 +71,8 @@ const uiText = {
     appSubtitle: 'Generador de prompts para IA - creatividad ilimitada',
     chooseStyleTitle: 'Selecciona tu inspiración de prompt',
     generateButtonText: 'Generar nuevo prompt',
-    yourPromptTitle: 'Tu prompt único:',
+    yourPromptTitle: 'Tu prompt único',
+    historyBottom: 'El historial de prompts está en la parte inferior',
     copyButtonTitle: 'Copiar al portapapeles',
     downloadButtonTitle: 'Descargar como .txt',
     shareTwitterTitle: 'Compartir en Twitter',
@@ -100,7 +103,8 @@ const uiText = {
       "Générateur de prompts pour IA - l'espace ultime de l'ingénierie des prompts en ligne",
     chooseStyleTitle: 'Sélectionnez votre inspiration de prompt',
     generateButtonText: 'Générer un nouveau prompt',
-    yourPromptTitle: 'Votre prompt unique :',
+    yourPromptTitle: 'Votre prompt unique',
+    historyBottom: "L'historique des prompts est en bas",
     copyButtonTitle: 'Copier dans le presse-papiers',
     downloadButtonTitle: 'Télécharger en .txt',
     shareTwitterTitle: 'Partager sur Twitter',
@@ -130,7 +134,8 @@ const uiText = {
     appSubtitle: '面向AI的提示生成器 - 终极提示工程在线空间',
     chooseStyleTitle: '选择你的提示灵感',
     generateButtonText: '生成新的提示',
-    yourPromptTitle: '你的专属提示：',
+    yourPromptTitle: '你的专属提示',
+    historyBottom: '提示历史在底部',
     copyButtonTitle: '复制到剪贴板',
     downloadButtonTitle: '下载为 .txt',
     shareTwitterTitle: '在 Twitter 上分享',
@@ -161,7 +166,8 @@ const uiText = {
       'एआई के लिए प्रॉम्प्ट जनरेटर - सर्वश्रेष्ठ प्रॉम्प्ट इंजीनियरिंग ऑनलाइन स्पेस',
     chooseStyleTitle: 'अपनी प्रॉम्प्ट प्रेरणा चुनें',
     generateButtonText: 'नया प्रॉम्प्ट बनाएं',
-    yourPromptTitle: 'आपका अनोखा प्रॉम्प्ट:',
+    yourPromptTitle: 'आपका अनोखा प्रॉम्प्ट',
+    historyBottom: 'प्रॉम्प्ट इतिहास नीचे है',
     copyButtonTitle: 'क्लिपबोर्ड पर कॉपी करें',
     downloadButtonTitle: '.txt के रूप में डाउनलोड करें',
     shareTwitterTitle: 'ट्विटर पर साझा करें',
@@ -287,8 +293,14 @@ const setLanguage = (lang) => {
   document.getElementById('generate-button-text').textContent =
     uiText[lang].generateButtonText;
   generateButton.setAttribute('aria-label', uiText[lang].generateButtonText);
-  document.getElementById('your-prompt-title').textContent =
-    uiText[lang].yourPromptTitle;
+  const promptTitleEl = document.getElementById('your-prompt-title');
+  promptTitleEl.textContent = uiText[lang].yourPromptTitle;
+  const arrowEl = document.createElement('span');
+  arrowEl.textContent = ' \u2193 ';
+  const noteEl = document.createElement('span');
+  noteEl.textContent = uiText[lang].historyBottom;
+  promptTitleEl.appendChild(arrowEl);
+  promptTitleEl.appendChild(noteEl);
   if (appLogo) {
     appLogo.alt = uiText[lang].appLogoAlt;
   }


### PR DESCRIPTION
## Summary
- add new `historyBottom` string to all language packs
- show down arrow and localized note after **Your Unique Prompt**

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853288add84832fbab8fb3905c7a6ca