### PR TITLE
Add link to twitter share

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -863,7 +863,8 @@ const handleGenerate = async () => {
 
 const sharePrompt = (prompt, baseUrl) => {
   if (!prompt) return;
-  const url = `${baseUrl}${encodeURIComponent(prompt)}`;
+  const link = ' https://prompterai.space';
+  const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
   window.open(url, '_blank');
 };
 


### PR DESCRIPTION
## Summary
- include site link when sharing prompts to Twitter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532b6ff194832fa35f64ad48ad8920