### PR TITLE
Fix caching issues by disabling offline features

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python3 -m http.server
 
 and then visit `http://localhost:8000`. This ensures the JSON prompt files load correctly. The generator still requires an internet connection.
 
-You can open `index.html` directly from your file system, but prompts will not load unless `prompts.js` is available because the JSON prompt files cannot be fetched when using the `file://` protocol.
+You can open `index.html` directly from your file system, but prompts will not load because the app fetches its data over the network.
 
 ### Versioning
 

--- a/es/index.html
+++ b/es/index.html
@@ -131,6 +131,10 @@
             resolveLoad = resolve;
           });
 
+          if (!navigator.onLine) {
+            return { cdn: null, local: null, loadPromise: Promise.reject(new Error('offline')) };
+          }
+
           const addLocal = () => {
             if (!localScript) {
               localScript = document.createElement('script');
@@ -141,13 +145,7 @@
             }
           };
 
-          // If offline, load local immediately
-          if (!navigator.onLine) {
-            addLocal();
-            return { cdn: null, local: localScript, loadPromise };
-          }
-
-          // Online: Try CDN with fallback
+          // Try CDN first with local fallback if the request fails
           let fallbackTimer = null;
 
           // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
@@ -500,7 +498,6 @@
       </div>
     </div>
 
-    <script src="prompts.js?v=20"></script>
     <script type="module" src="src/main.js?v=20"></script>
   </body>
 </html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -133,6 +133,10 @@
             resolveLoad = resolve;
           });
 
+          if (!navigator.onLine) {
+            return { cdn: null, local: null, loadPromise: Promise.reject(new Error('offline')) };
+          }
+
           const addLocal = () => {
             if (!localScript) {
               localScript = document.createElement('script');
@@ -143,13 +147,7 @@
             }
           };
 
-          // If offline, load local immediately
-          if (!navigator.onLine) {
-            addLocal();
-            return { cdn: null, local: localScript, loadPromise };
-          }
-
-          // Online: Try CDN with fallback
+          // Try CDN first with local fallback if the request fails
           let fallbackTimer = null;
 
           // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
@@ -604,7 +602,6 @@
         </a>
       </div>
     </div>
-    <script src="prompts.js?v=20"></script>
     <script type="module" src="src/main.js?v=20"></script>
   </body>
 </html>

--- a/hi/index.html
+++ b/hi/index.html
@@ -131,6 +131,10 @@
             resolveLoad = resolve;
           });
 
+          if (!navigator.onLine) {
+            return { cdn: null, local: null, loadPromise: Promise.reject(new Error('offline')) };
+          }
+
           const addLocal = () => {
             if (!localScript) {
               localScript = document.createElement('script');
@@ -141,13 +145,7 @@
             }
           };
 
-          // If offline, load local immediately
-          if (!navigator.onLine) {
-            addLocal();
-            return { cdn: null, local: localScript, loadPromise };
-          }
-
-          // Online: Try CDN with fallback
+          // Try CDN first with local fallback if the request fails
           let fallbackTimer = null;
 
           // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
@@ -493,7 +491,6 @@
       </div>
     </div>
 
-    <script src="prompts.js?v=20"></script>
     <script type="module" src="src/main.js?v=20"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -133,6 +133,10 @@
             resolveLoad = resolve;
           });
 
+          if (!navigator.onLine) {
+            return { cdn: null, local: null, loadPromise: Promise.reject(new Error('offline')) };
+          }
+
           const addLocal = () => {
             if (!localScript) {
               localScript = document.createElement('script');
@@ -143,13 +147,7 @@
             }
           };
 
-          // If offline, load local immediately
-          if (!navigator.onLine) {
-            addLocal();
-            return { cdn: null, local: localScript, loadPromise };
-          }
-
-          // Online: Try CDN with fallback
+          // Try CDN first with local fallback if the request fails
           let fallbackTimer = null;
 
           // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
@@ -604,7 +602,6 @@
         </a>
       </div>
     </div>
-    <script src="prompts.js?v=20"></script>
     <script type="module" src="src/main.js?v=20"></script>
   </body>
 </html>

--- a/my-prompts.html
+++ b/my-prompts.html
@@ -44,9 +44,8 @@
     <meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta name="twitter:url" content="https://prompterai.space/my-prompts.html" />
-    <script src="prompts.js?v=20"></script>
-    <script src="tailwind.js?v=20"></script>
-    <script src="lucide.min.js?v=20"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
     <link rel="stylesheet" href="css/app.css?v=20" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=20" />
     <script>

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -213,7 +213,9 @@ export const loadCategory = async (lang, cat) => {
     // copy preloaded data so global window.prompts is never mutated
     data = { ...preloaded };
   } else {
-    const res = await fetch(`prompts/${lang}/${cat}.json`);
+    const res = await fetch(`prompts/${lang}/${cat}.json`, {
+      cache: 'no-store',
+    });
     data = await res.json();
   }
 
@@ -223,6 +225,9 @@ export const loadCategory = async (lang, cat) => {
 };
 
 export const generatePrompt = async () => {
+  if (!navigator.onLine) {
+    throw new Error('offline');
+  }
   appState.isGenerating = true;
   let selectedCatId = appState.selectedCategory;
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -853,8 +853,12 @@ const handleGenerate = async () => {
     lastGeneratedCategoryId = categoryId;
   } catch (err) {
     console.error(err);
-    generatedPromptText.textContent =
-      'Error generating prompt. Please try again.';
+    if (err && err.message === 'offline') {
+      generatedPromptText.textContent = 'Internet connection required.';
+    } else {
+      generatedPromptText.textContent =
+        'Error generating prompt. Please try again.';
+    }
   } finally {
     appState.isGenerating = false;
     generateButton.disabled = false;

--- a/tr/index.html
+++ b/tr/index.html
@@ -131,6 +131,10 @@
             resolveLoad = resolve;
           });
 
+          if (!navigator.onLine) {
+            return { cdn: null, local: null, loadPromise: Promise.reject(new Error('offline')) };
+          }
+
           const addLocal = () => {
             if (!localScript) {
               localScript = document.createElement('script');
@@ -141,13 +145,7 @@
             }
           };
 
-          // If offline, load local immediately
-          if (!navigator.onLine) {
-            addLocal();
-            return { cdn: null, local: localScript, loadPromise };
-          }
-
-          // Online: Try CDN with fallback
+          // Try CDN first with local fallback if the request fails
           let fallbackTimer = null;
 
           // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
@@ -500,7 +498,6 @@
       </div>
     </div>
 
-    <script src="prompts.js?v=20"></script>
     <script type="module" src="src/main.js?v=20"></script>
   </body>
 </html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -136,6 +136,10 @@
             resolveLoad = resolve;
           });
 
+          if (!navigator.onLine) {
+            return { cdn: null, local: null, loadPromise: Promise.reject(new Error('offline')) };
+          }
+
           const addLocal = () => {
             if (!localScript) {
               localScript = document.createElement('script');
@@ -146,13 +150,7 @@
             }
           };
 
-          // If offline, load local immediately
-          if (!navigator.onLine) {
-            addLocal();
-            return { cdn: null, local: localScript, loadPromise };
-          }
-
-          // Online: Try CDN with fallback
+          // Try CDN first with local fallback if the request fails
           let fallbackTimer = null;
 
           // Set up fallback timer (500ms to quickly load local icons if CDN is slow)
@@ -607,7 +605,6 @@
         </a>
       </div>
     </div>
-    <script src="prompts.js?v=20"></script>
     <script type="module" src="src/main.js?v=20"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- disable offline fallback scripts for CDN files
- remove prompts.js to ensure data loads from the network
- fetch prompt JSON with `no-store` caching and detect offline state
- show a clear error message when offline
- update README about local usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532ff1705c832f935b495576bb95a0