### PR TITLE
Fix manifest version check

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const fetchManifestVersion = async () => {
   try {
     const link = document.querySelector('link[rel="manifest"]');
     if (!link) return null;
-    const url = link.getAttribute('href');
+    const url = link.href; // ensures correct path under <base>
     const sep = url.includes('?') ? '&' : '?';
     const res = await fetch(`${url}${sep}v=${Date.now()}`, { cache: 'no-store' });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary
- improve manifest URL retrieval for version check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685336860064832fb9022599d9d8db6a