### PR TITLE
Add new ad banner near history section

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -555,6 +555,16 @@
       </script>
       <script async="async" data-cfasync="false" src="//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js"></script>
       <div id="container-a1f7e9c6d98927233c3bdba5a0b35b69"></div>
+      <script type="text/javascript">
+        atOptions = {
+          'key' : 'cc61698e949aeab017670a8799193d84',
+          'format' : 'iframe',
+          'height' : 300,
+          'width' : 160,
+          'params' : {}
+        };
+      </script>
+      <script type="text/javascript" src="//www.highperformanceformat.com/cc61698e949aeab017670a8799193d84/invoke.js"></script>
     </div>
     <!-- Prompt History -->
     <div

--- a/index.html
+++ b/index.html
@@ -507,6 +507,16 @@
     <div class="mt-4 flex flex-wrap justify-between gap-4 items-start">
       <script async="async" data-cfasync="false" src="//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js"></script>
       <div id="container-a1f7e9c6d98927233c3bdba5a0b35b69"></div>
+      <script type="text/javascript">
+        atOptions = {
+          'key' : 'cc61698e949aeab017670a8799193d84',
+          'format' : 'iframe',
+          'height' : 300,
+          'width' : 160,
+          'params' : {}
+        };
+      </script>
+      <script type="text/javascript" src="//www.highperformanceformat.com/cc61698e949aeab017670a8799193d84/invoke.js"></script>
     </div>
     <!-- Prompt History -->
     <div

--- a/zh/index.html
+++ b/zh/index.html
@@ -558,6 +558,16 @@
       </script>
       <script async="async" data-cfasync="false" src="//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js"></script>
       <div id="container-a1f7e9c6d98927233c3bdba5a0b35b69"></div>
+      <script type="text/javascript">
+        atOptions = {
+          'key' : 'cc61698e949aeab017670a8799193d84',
+          'format' : 'iframe',
+          'height' : 300,
+          'width' : 160,
+          'params' : {}
+        };
+      </script>
+      <script type="text/javascript" src="//www.highperformanceformat.com/cc61698e949aeab017670a8799193d84/invoke.js"></script>
     </div>
     <!-- Prompt History -->
     <div


### PR DESCRIPTION
## Summary
- place new advertisement code next to existing ad before the prompt history panel
- replicate this across English, French and Chinese pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e4918a14832f9034042f44fb9846