### PR TITLE
Fix default language redirect to root

### DIFF
--- a/language-redirect.js
+++ b/language-redirect.js
@@ -17,10 +17,10 @@
   const lang = (navigator.language || '').toLowerCase();
   const prefix = lang.slice(0, 2);
 
-  const target = routes[prefix] || '/en/';
+  const target = routes[prefix] || '/';
 
   // Avoid redirect loops by checking current path
-  if (!location.pathname.startsWith(target)) {
+  if (location.pathname !== target) {
     // Use replace so the redirect doesn't create a history entry
     location.replace(target);
   }

--- a/workers/redirect.js
+++ b/workers/redirect.js
@@ -26,7 +26,7 @@ export default {
       ['CN', '/zh/'],
     ]);
 
-    const target = routes.get(country) || '/en/';
+    const target = routes.get(country) || '/';
 
     const redirectUrl = new URL(target, url.origin);
     // Return 302 redirect to the appropriate language path


### PR DESCRIPTION
## Summary
- default to `/` when language is not mapped
- avoid showing `/index.html` on English detection
- serve `/` for unmapped countries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68541660ac2c832fbdf1ee805c9d9a62