### PR TITLE
Add lastmod and changefreq to sitemap generation

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -4,22 +4,44 @@ const path = require('path');
 
 const BASE_URL = 'https://prompterai.space';
 
-const urls = [
-  `${BASE_URL}/`,
-  `${BASE_URL}/es/`,
-  `${BASE_URL}/tr/`,
-  `${BASE_URL}/zh/`,
-  `${BASE_URL}/fr/`,
-  `${BASE_URL}/hi/`,
-  `${BASE_URL}/privacy.html`,
-  `${BASE_URL}/my-prompts.html`, // new page
-];
+const rootDir = path.join(__dirname, '..');
+
+function getHtmlFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') return [];
+      return getHtmlFiles(res);
+    }
+    return entry.isFile() && entry.name.endsWith('.html') ? [res] : [];
+  });
+}
+
+function pathToUrl(file) {
+  const rel = path.relative(rootDir, file).replace(/\\/g, '/');
+  if (rel === 'index.html') return `${BASE_URL}/`;
+  if (rel.endsWith('/index.html')) {
+    return `${BASE_URL}/${rel.slice(0, -'index.html'.length)}`;
+  }
+  return `${BASE_URL}/${rel}`;
+}
+
+const urls = getHtmlFiles(rootDir).map((file) => ({
+  loc: pathToUrl(file),
+  lastmod: fs.statSync(file).mtime.toISOString().split('T')[0],
+  changefreq: 'monthly',
+}));
 
 const xml =
   '<?xml version="1.0" encoding="UTF-8"?>\n' +
   '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
-  urls.map((u) => `  <url><loc>${u}</loc></url>`).join('\n') +
+  urls
+    .map(
+      (u) =>
+        `  <url><loc>${u.loc}</loc><lastmod>${u.lastmod}</lastmod><changefreq>${u.changefreq}</changefreq></url>`
+    )
+    .join('\n') +
   '\n</urlset>\n';
 
-fs.writeFileSync(path.join(__dirname, '..', 'sitemap.xml'), xml);
+fs.writeFileSync(path.join(rootDir, 'sitemap.xml'), xml);
 console.log('Wrote sitemap.xml');

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://prompterai.space/</loc></url>
-  <url><loc>https://prompterai.space/es/</loc></url>
-  <url><loc>https://prompterai.space/tr/</loc></url>
-  <url><loc>https://prompterai.space/zh/</loc></url>
-  <url><loc>https://prompterai.space/fr/</loc></url>
-  <url><loc>https://prompterai.space/hi/</loc></url>
-  <url><loc>https://prompterai.space/privacy.html</loc></url>
-  <url><loc>https://prompterai.space/my-prompts.html</loc></url>
+  <url><loc>https://prompterai.space/es/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/fr/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/hi/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/my-prompts.html</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/privacy.html</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/tr/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/zh/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
 </urlset>


### PR DESCRIPTION
## Summary
- update `generate-sitemap.js` to read HTML files on disk
- include `<lastmod>` and `<changefreq>` elements
- regenerate `sitemap.xml`

## Testing
- `npm run build:sitemap`


------
https://chatgpt.com/codex/tasks/task_e_68547f47e978832fa9f2b9b4dc09d59d