### PR TITLE
Add OG image alt tags

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -9,9 +9,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="preload" href="icons/logo.svg?v=26" as="image" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="preload" href="icons/logo.svg?v=29" as="image" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -33,7 +33,8 @@
       property="og:description"
       content="Generador de prompts creativos para IA que requiere conexión a Internet."
     />
-    <meta property="og:image" content="icons/logo.svg?v=26" />
+    <meta property="og:image" content="icons/logo.svg?v=29" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="PROMPTER" />
@@ -41,7 +42,7 @@
       name="twitter:description"
       content="Generador de prompts creativos para IA que requiere conexión a Internet."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=26" />
+    <meta name="twitter:image" content="icons/logo.svg?v=29" />
     <meta property="og:url" content="https://prompterai.space/es/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -173,11 +174,11 @@
 
         const tailwindScripts = loadWithFallback(
           'https://cdn.tailwindcss.com',
-          'tailwind.js?v=26'
+          'tailwind.js?v=29'
         );
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=26',
-          'lucide.min.js?v=26'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=29',
+          'lucide.min.js?v=29'
         );
         Promise.all([
           tailwindScripts.loadPromise,
@@ -190,8 +191,8 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -341,7 +342,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-2">
         <img
-          src="icons/logo.svg?v=26"
+          src="icons/logo.svg?v=29"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -478,7 +479,7 @@
           aria-label="Grupo de WhatsApp"
         >
           <img
-            src="icons/whatsapp.svg?v=26"
+            src="icons/whatsapp.svg?v=29"
             class="w-6 h-6"
             alt="Logo de WhatsApp"
           />
@@ -486,6 +487,6 @@
       </div>
     </div>
 
-    <script type="module" src="src/main.js?v=26"></script>
+    <script type="module" src="src/main.js?v=29"></script>
   </body>
 </html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -11,9 +11,9 @@
     />
     <title>PROMPTER</title>
     <base href="./" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="preload" href="icons/logo.svg?v=26" as="image" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="preload" href="icons/logo.svg?v=29" as="image" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -35,7 +35,8 @@
       property="og:description"
       content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet."
     />
-    <meta property="og:image" content="icons/logo.svg?v=26" />
+    <meta property="og:image" content="icons/logo.svg?v=29" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="PROMPTER" />
@@ -43,7 +44,7 @@
       name="twitter:description"
       content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=26" />
+    <meta name="twitter:image" content="icons/logo.svg?v=29" />
     <meta property="og:url" content="https://prompterai.space/fr/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -175,11 +176,11 @@
 
         const tailwindScripts = loadWithFallback(
           'https://cdn.tailwindcss.com',
-          'tailwind.js?v=26'
+          'tailwind.js?v=29'
         );
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=26',
-          'lucide.min.js?v=26'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=29',
+          'lucide.min.js?v=29'
         );
         Promise.all([
           tailwindScripts.loadPromise,
@@ -192,8 +193,8 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -358,7 +359,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-2">
         <img
-          src="icons/logo.svg?v=26"
+          src="icons/logo.svg?v=29"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -598,10 +599,10 @@
           class="flex justify-center mt-2"
           aria-label="WhatsApp Group"
         >
-          <img src="icons/whatsapp.svg?v=26" class="w-6 h-6" alt="WhatsApp logo" />
+          <img src="icons/whatsapp.svg?v=29" class="w-6 h-6" alt="WhatsApp logo" />
         </a>
       </div>
     </div>
-    <script type="module" src="src/main.js?v=26"></script>
+    <script type="module" src="src/main.js?v=29"></script>
   </body>
 </html>

--- a/hi/index.html
+++ b/hi/index.html
@@ -9,9 +9,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="preload" href="icons/logo.svg?v=26" as="image" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="preload" href="icons/logo.svg?v=29" as="image" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -33,7 +33,8 @@
       property="og:description"
       content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर."
     />
-    <meta property="og:image" content="icons/logo.svg?v=26" />
+    <meta property="og:image" content="icons/logo.svg?v=29" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="PROMPTER" />
@@ -41,7 +42,7 @@
       name="twitter:description"
       content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=26" />
+    <meta name="twitter:image" content="icons/logo.svg?v=29" />
     <meta property="og:url" content="https://prompterai.space/hi/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -173,11 +174,11 @@
 
         const tailwindScripts = loadWithFallback(
           'https://cdn.tailwindcss.com',
-          'tailwind.js?v=26'
+          'tailwind.js?v=29'
         );
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=26',
-          'lucide.min.js?v=26'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=29',
+          'lucide.min.js?v=29'
         );
         Promise.all([
           tailwindScripts.loadPromise,
@@ -190,8 +191,8 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -334,7 +335,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-2">
         <img
-          src="icons/logo.svg?v=26"
+          src="icons/logo.svg?v=29"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -471,7 +472,7 @@
           aria-label="Grupo de WhatsApp"
         >
           <img
-            src="icons/whatsapp.svg?v=26"
+            src="icons/whatsapp.svg?v=29"
             class="w-6 h-6"
             alt="Logo de WhatsApp"
           />
@@ -479,6 +480,6 @@
       </div>
     </div>
 
-    <script type="module" src="src/main.js?v=26"></script>
+    <script type="module" src="src/main.js?v=29"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
     />
     <title>PROMPTER</title>
     <base href="./" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="preload" href="icons/logo.svg?v=26" as="image" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="preload" href="icons/logo.svg?v=29" as="image" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -34,7 +34,8 @@
       property="og:description"
       content="Creative AI prompt generator that requires an internet connection."
     />
-    <meta property="og:image" content="icons/logo.svg?v=26" />
+    <meta property="og:image" content="icons/logo.svg?v=29" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="PROMPTER" />
@@ -42,7 +43,7 @@
       name="twitter:description"
       content="Creative AI prompt generator that requires an internet connection."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=26" />
+    <meta name="twitter:image" content="icons/logo.svg?v=29" />
     <meta property="og:url" content="https://prompterai.space/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -174,11 +175,11 @@
 
         const tailwindScripts = loadWithFallback(
           'https://cdn.tailwindcss.com',
-          'tailwind.js?v=26'
+          'tailwind.js?v=29'
         );
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=26',
-          'lucide.min.js?v=26'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=29',
+          'lucide.min.js?v=29'
         );
         Promise.all([
           tailwindScripts.loadPromise,
@@ -191,8 +192,8 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -341,7 +342,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-2">
         <img
-          src="icons/logo.svg?v=26"
+          src="icons/logo.svg?v=29"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -533,10 +534,10 @@
           class="flex justify-center mt-2"
           aria-label="WhatsApp Group"
         >
-          <img src="icons/whatsapp.svg?v=26" class="w-6 h-6" alt="WhatsApp logo" />
+          <img src="icons/whatsapp.svg?v=29" class="w-6 h-6" alt="WhatsApp logo" />
         </a>
       </div>
     </div>
-    <script type="module" src="src/main.js?v=26"></script>
+    <script type="module" src="src/main.js?v=29"></script>
   </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "theme_color": "#000000",
   "background_color": "#000000",
   "display": "standalone",
-  "version": "26",
+  "version": "29",
   "start_url": "./",
   "icons": [
     {

--- a/my-prompts.html
+++ b/my-prompts.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Prompts - Prompter</title>
     <base href="./" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -31,9 +31,9 @@
     <meta property="og:locale:alternate" content="fr" />
     <meta name="twitter:url" content="https://prompterai.space/my-prompts.html" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=26"></script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=29"></script>
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -82,7 +82,7 @@
       </div>
       <div class="text-center mb-6 pt-16">
         <img
-          src="icons/logo.svg?v=26"
+          src="icons/logo.svg?v=29"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -93,6 +93,6 @@
       <div class="mt-4 flex flex-wrap justify-between gap-4 items-start">
       </div>
     </div>
-    <script type="module" src="src/my-prompts.js?v=26"></script>
+    <script type="module" src="src/my-prompts.js?v=29"></script>
   </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -14,9 +14,9 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
-    <script src="tailwind.js?v=26"></script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <script src="tailwind.js?v=29"></script>
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <link rel="canonical" href="https://prompterai.space/privacy.html" />
     <meta property="og:url" content="https://prompterai.space/privacy.html" />
     <meta property="og:site_name" content="Prompter" />

--- a/tr/index.html
+++ b/tr/index.html
@@ -9,9 +9,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="preload" href="icons/logo.svg?v=26" as="image" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="preload" href="icons/logo.svg?v=29" as="image" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -33,7 +33,8 @@
       property="og:description"
       content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi."
     />
-    <meta property="og:image" content="icons/logo.svg?v=26" />
+    <meta property="og:image" content="icons/logo.svg?v=29" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="PROMPTER" />
@@ -41,7 +42,7 @@
       name="twitter:description"
       content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=26" />
+    <meta name="twitter:image" content="icons/logo.svg?v=29" />
     <meta property="og:url" content="https://prompterai.space/tr/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -173,11 +174,11 @@
 
         const tailwindScripts = loadWithFallback(
           'https://cdn.tailwindcss.com',
-          'tailwind.js?v=26'
+          'tailwind.js?v=29'
         );
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=26',
-          'lucide.min.js?v=26'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=29',
+          'lucide.min.js?v=29'
         );
         Promise.all([
           tailwindScripts.loadPromise,
@@ -190,8 +191,8 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -341,7 +342,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-2">
         <img
-          src="icons/logo.svg?v=26"
+          src="icons/logo.svg?v=29"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -478,7 +479,7 @@
           aria-label="WhatsApp Grubu"
         >
           <img
-            src="icons/whatsapp.svg?v=26"
+            src="icons/whatsapp.svg?v=29"
             class="w-6 h-6"
             alt="WhatsApp logosu"
           />
@@ -486,6 +487,6 @@
       </div>
     </div>
 
-    <script type="module" src="src/main.js?v=26"></script>
+    <script type="module" src="src/main.js?v=29"></script>
   </body>
 </html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -11,9 +11,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=26" />
-    <link rel="preload" href="icons/logo.svg?v=26" as="image" />
-    <link rel="manifest" href="manifest.json?v=26" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="preload" href="icons/logo.svg?v=29" as="image" />
+    <link rel="manifest" href="manifest.json?v=29" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -35,7 +35,8 @@
       property="og:description"
       content="需要互联网连接的创意AI提示生成器."
     />
-    <meta property="og:image" content="icons/logo.svg?v=26" />
+    <meta property="og:image" content="icons/logo.svg?v=29" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="PROMPTER" />
@@ -43,7 +44,7 @@
       name="twitter:description"
       content="需要互联网连接的创意AI提示生成器."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=26" />
+    <meta name="twitter:image" content="icons/logo.svg?v=29" />
     <meta property="og:url" content="https://prompterai.space/zh/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -178,11 +179,11 @@
 
         const tailwindScripts = loadWithFallback(
           'https://cdn.tailwindcss.com',
-          'tailwind.js?v=26'
+          'tailwind.js?v=29'
         );
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=26',
-          'lucide.min.js?v=26'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=29',
+          'lucide.min.js?v=29'
         );
         Promise.all([
           tailwindScripts.loadPromise,
@@ -195,8 +196,8 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/app.css?v=26" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=26" />
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -361,7 +362,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-2">
         <img
-          src="icons/logo.svg?v=26"
+          src="icons/logo.svg?v=29"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -601,10 +602,10 @@
           class="flex justify-center mt-2"
           aria-label="WhatsApp Group"
         >
-          <img src="icons/whatsapp.svg?v=26" class="w-6 h-6" alt="WhatsApp logo" />
+          <img src="icons/whatsapp.svg?v=29" class="w-6 h-6" alt="WhatsApp logo" />
         </a>
       </div>
     </div>
-    <script type="module" src="src/main.js?v=26"></script>
+    <script type="module" src="src/main.js?v=29"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `og:image:alt` meta tags to every page with an OG image
- run build to bump asset versions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854809474c4832f867a26080d18b037