### PR TITLE
Fix layout for language selector box

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -249,9 +249,12 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-4 flex items-center gap-2 z-10"
       >
-        <div class="relative flex items-center" id="lang-container">
+        <div
+          id="lang-container"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+        >
           <button
             id="lang-toggle"
             class="p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"

--- a/fr/index.html
+++ b/fr/index.html
@@ -266,9 +266,12 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-0 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-0 flex items-center gap-2 z-10"
       >
-        <div class="relative flex items-center" id="lang-container">
+        <div
+          id="lang-container"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+        >
           <button
             id="lang-toggle"
             class="p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"

--- a/hi/index.html
+++ b/hi/index.html
@@ -249,9 +249,12 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-4 flex items-center gap-2 z-10"
       >
-        <div class="relative flex items-center" id="lang-container">
+        <div
+          id="lang-container"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+        >
           <button
             id="lang-toggle"
             class="p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"

--- a/index.html
+++ b/index.html
@@ -249,9 +249,12 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-0 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-0 flex items-center gap-2 z-10"
       >
-        <div class="relative flex items-center" id="lang-container">
+        <div
+          id="lang-container"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+        >
           <button
             id="lang-toggle"
             class="p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"

--- a/tr/index.html
+++ b/tr/index.html
@@ -249,9 +249,12 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-4 flex items-center gap-2 z-10"
       >
-        <div class="relative flex items-center" id="lang-container">
+        <div
+          id="lang-container"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+        >
           <button
             id="lang-toggle"
             class="p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"

--- a/zh/index.html
+++ b/zh/index.html
@@ -269,9 +269,12 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-0 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
+        class="absolute top-4 left-0 flex items-center gap-2 z-10"
       >
-        <div class="relative flex items-center" id="lang-container">
+        <div
+          id="lang-container"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+        >
           <button
             id="lang-toggle"
             class="p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"


### PR DESCRIPTION
## Summary
- avoid language selector box covering "My Prompts" by making only the selector have background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854a9b6a6d8832fb5d5cef5f05d6fee