### PR TITLE
Add 404 page and update sitemap

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <title>404 - Page Not Found</title>
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=29" />
+    <link rel="manifest" href="manifest.json?v=29" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="stylesheet" href="css/app.css?v=29" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=29" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+  </head>
+  <body class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4">
+    <h1 class="text-2xl font-bold mb-4">404 - Page Not Found</h1>
+    <p class="mb-4">The page you're looking for could not be found.</p>
+    <a href="/" class="text-blue-400 underline">Return Home</a>
+  </body>
+</html>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -26,7 +26,11 @@ function pathToUrl(file) {
   return `${BASE_URL}/${rel}`;
 }
 
-const urls = getHtmlFiles(rootDir).map((file) => ({
+let htmlFiles = getHtmlFiles(rootDir);
+const customFiles = [path.join(rootDir, '404.html')];
+htmlFiles = Array.from(new Set([...htmlFiles, ...customFiles]));
+
+const urls = htmlFiles.map((file) => ({
   loc: pathToUrl(file),
   lastmod: fs.statSync(file).mtime.toISOString().split('T')[0],
   changefreq: 'monthly',

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://prompterai.space/es/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/fr/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/hi/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/my-prompts.html</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/privacy.html</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/tr/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/zh/</loc><lastmod>2025-06-19</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/404.html</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/es/</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/fr/</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/hi/</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/my-prompts.html</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/privacy.html</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/tr/</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/zh/</loc><lastmod>2025-06-20</lastmod><changefreq>monthly</changefreq></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add a simple 404.html with branding
- include 404.html in sitemap generation
- regenerate sitemap

## Testing
- `npm run build:sitemap`

------
https://chatgpt.com/codex/tasks/task_e_6854aaa2649c832f9d50bb022ca399d7