### PR TITLE
Adjust layout for language and prompts controls

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -249,11 +249,11 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-4 flex items-center gap-2 z-10"
+        class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10"
       >
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
         >
           <button
             id="lang-toggle"
@@ -337,7 +337,7 @@
         <a
           id="my-prompts-link"
           href="my-prompts.html"
-          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200"
+          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200 w-full text-center"
           >My Prompts</a
         >
       </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -266,11 +266,11 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-0 flex items-center gap-2 z-10"
+        class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10"
       >
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
         >
           <button
             id="lang-toggle"
@@ -354,7 +354,7 @@
         <a
           id="my-prompts-link"
           href="my-prompts.html"
-          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200"
+          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200 w-full text-center"
           >My Prompts</a
         >
       </div>

--- a/hi/index.html
+++ b/hi/index.html
@@ -249,11 +249,11 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-4 flex items-center gap-2 z-10"
+        class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10"
       >
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
         >
           <button
             id="lang-toggle"
@@ -330,7 +330,7 @@
         <a
           id="my-prompts-link"
           href="my-prompts.html"
-          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200"
+          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200 w-full text-center"
           >My Prompts</a
         >
       </div>

--- a/index.html
+++ b/index.html
@@ -249,11 +249,11 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-0 flex items-center gap-2 z-10"
+        class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10"
       >
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
         >
           <button
             id="lang-toggle"
@@ -337,7 +337,7 @@
         <a
           id="my-prompts-link"
           href="my-prompts.html"
-          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200"
+          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200 w-full text-center"
           >My Prompts</a
         >
       </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -249,11 +249,11 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-4 flex items-center gap-2 z-10"
+        class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10"
       >
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
         >
           <button
             id="lang-toggle"
@@ -337,7 +337,7 @@
         <a
           id="my-prompts-link"
           href="my-prompts.html"
-          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200"
+          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200 w-full text-center"
           >My Prompts</a
         >
       </div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -269,11 +269,11 @@
 
       <!-- Language Switcher -->
       <div
-        class="absolute top-4 left-0 flex items-center gap-2 z-10"
+        class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10"
       >
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
         >
           <button
             id="lang-toggle"
@@ -357,7 +357,7 @@
         <a
           id="my-prompts-link"
           href="my-prompts.html"
-          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200"
+          class="px-1 py-0.5 rounded-md text-xs font-medium bg-white/20 hover:bg-white/30 transition-all duration-200 w-full text-center"
           >My Prompts</a
         >
       </div>


### PR DESCRIPTION
## Summary
- vertically stack the language selector and My Prompts link
- give both controls matching width for a symmetrical appearance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854abc0c5a0832fa98618494e1107f4