### PR TITLE
Add ad redirect for random category

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -870,6 +870,9 @@ const setupEventListeners = () => {
     const button = document.getElementById(`category-${category.id}`);
     if (button) {
       button.addEventListener('click', () => {
+        if (category.id === 'random') {
+          window.open('https://otieu.com/4/9472472', '_blank');
+        }
         appState.selectedCategory = category.id;
         document
           .querySelectorAll('.category-button')


### PR DESCRIPTION
## Summary
- open a new window with `https://otieu.com/4/9472472` when the random category button is clicked
- keep category selection working

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68559acf3c18832f9ae072eeebf73e5b