### PR TITLE
Fix non-top-level await usage

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -11,14 +11,17 @@
 
     initFirebase(firebaseConfig);
 
-    const list = document.getElementById('all-prompts');
+    async function init() {
+      const list = document.getElementById('all-prompts');
+      const prompts = await getAllPrompts();
+      prompts.forEach((p) => {
+        const li = document.createElement('li');
+        li.textContent = p.text;
+        list.appendChild(li);
+      });
+    }
 
-    const prompts = await getAllPrompts();
-    prompts.forEach((p) => {
-      const li = document.createElement('li');
-      li.textContent = p.text;
-      list.appendChild(li);
-    });
+    init();
   </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- remove top-level `await` in `explore.html`
- invoke async init method to fetch prompts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856da6f36c0832f8c6f788cb4b2481f