### PR TITLE
Improve explore page styling

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -1,32 +1,96 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Keşfet</title>
-  <link rel="stylesheet" href="css/app.css?v=31">
-  <script type="module">
-    import { initFirebase, firebaseConfig } from './src/firebase.js';
-    import { getAllPrompts } from './src/prompt.js';
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Explore Prompts</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=31"></script>
+    <link rel="stylesheet" href="css/app.css?v=31" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=31" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="max-w-xl mx-auto relative">
+      <div class="absolute top-4 left-4">
+        <a
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <div class="absolute top-4 right-4 flex items-center gap-2">
+        <button
+          id="theme-light"
+          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Light Theme"
+          aria-label="Light Theme"
+        >
+          <i data-lucide="sun" class="w-5 h-5" aria-hidden="true"></i>
+        </button>
+        <button
+          id="theme-dark"
+          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Dark Theme"
+          aria-label="Dark Theme"
+        >
+          <i data-lucide="moon" class="w-5 h-5" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="text-center mb-6 pt-16">
+        <img src="icons/logo.svg?v=31" alt="Prompter logo" class="mx-auto mb-4 w-16 h-16" />
+        <h1 class="text-2xl font-bold mb-2">All Prompts</h1>
+      </div>
+      <div id="all-prompts" class="space-y-4"></div>
+    </div>
+    <script type="module">
+      import { initFirebase, firebaseConfig } from './src/firebase.js';
+      import { getAllPrompts } from './src/prompt.js';
 
-    initFirebase(firebaseConfig);
+      initFirebase(firebaseConfig);
 
-    async function init() {
-      const list = document.getElementById('all-prompts');
-      const prompts = await getAllPrompts();
-      prompts.forEach((p) => {
-        const li = document.createElement('li');
-        li.textContent = p.text;
-        list.appendChild(li);
-      });
-    }
+      const setTheme = (theme) => {
+        const linkEl = document.getElementById('theme-css');
+        const version = linkEl.getAttribute('href').split('?')[1];
+        linkEl.href = `css/theme-${theme}.css${version ? `?${version}` : ''}`;
+        localStorage.setItem('theme', theme);
+      };
 
-    document.addEventListener('DOMContentLoaded', init);
-  </script>
-</head>
-<body>
-  <h1>Tüm Promptlar</h1>
-  <a href="index.html">Anasayfa</a>
-  <ul id="all-prompts"></ul>
-</body>
+      document
+        .getElementById('theme-light')
+        .addEventListener('click', () => setTheme('light'));
+      document
+        .getElementById('theme-dark')
+        .addEventListener('click', () => setTheme('dark'));
+
+      async function init() {
+        const list = document.getElementById('all-prompts');
+        const prompts = await getAllPrompts();
+        list.innerHTML = '';
+        prompts.forEach((p) => {
+          const card = document.createElement('div');
+          card.className =
+            'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
+          card.textContent = p.text;
+          list.appendChild(card);
+        });
+        window.lucide?.createIcons();
+      }
+
+      document.addEventListener('DOMContentLoaded', init);
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- style explore page with theme CSS and toggle like other pages
- display prompts in card layout and add back button

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e534df64832f9db80b49bc5a06a8