### PR TITLE
Fix Firebase bucket URL

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -6,7 +6,7 @@ export const firebaseConfig = {
   apiKey: 'AIzaSyCiSVRdzDJPsYCWsTvGxueCs-Fcf5LCaYM',
   authDomain: 'prompter-cc95c.firebaseapp.com',
   projectId: 'prompter-cc95c',
-  storageBucket: 'prompter-cc95c.firebasestorage.app',
+  storageBucket: 'prompter-cc95c.appspot.com',
   messagingSenderId: '349560111475',
   appId: '1:349560111475:web:b8152fd082702df9e18506',
   measurementId: 'G-HTSK6FGDQD',


### PR DESCRIPTION
## Summary
- fix Firebase storage bucket URL in `firebaseConfig`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856ec5257dc832f9b43b7402196ae8a