### PR TITLE
Improve login error handling

### DIFF
--- a/login.html
+++ b/login.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prompter Login</title>
+  <base href="./">
   <link rel="stylesheet" href="css/app.css?v=31">
   <script type="module" src="src/firebase.js?v=31"></script>
   <script src="https://cdn.tailwindcss.com"></script>
@@ -26,6 +27,7 @@
     function init() {
       const loginForm = document.getElementById('login-form');
       const registerForm = document.getElementById('register-form');
+      const authError = document.getElementById('auth-error');
 
       onAuth((user) => {
         if (user) {
@@ -39,9 +41,12 @@
         const password = document.getElementById('login-password').value;
         login(email, password)
           .then(() => {
+            authError.textContent = '';
             window.location.href = 'index.html';
           })
-          .catch((err) => alert(err.message));
+          .catch((err) => {
+            authError.textContent = err.message;
+          });
       });
 
       registerForm.addEventListener('submit', (e) => {
@@ -50,9 +55,12 @@
         const password = document.getElementById('register-password').value;
         register(email, password)
           .then(() => {
+            authError.textContent = '';
             window.location.href = 'index.html';
           })
-          .catch((err) => alert(err.message));
+          .catch((err) => {
+            authError.textContent = err.message;
+          });
       });
     }
 
@@ -67,6 +75,7 @@
       </a>
     </div>
     <h1 class="text-2xl font-bold text-center mb-6">Prompter</h1>
+    <p id="auth-error" class="text-red-500 text-center mb-4"></p>
     <form id="login-form" class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-4 border border-white/20 shadow-lg space-y-2">
       <h2 class="text-lg font-semibold mb-2">Giriş</h2>
       <input id="login-email" type="email" placeholder="E-posta" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">


### PR DESCRIPTION
## Summary
- add `<base>` tag before relative imports in login page
- show authentication errors on the page instead of `alert`
- clear error text after successful auth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f5bf5ffc832fb4995dca2adebe4d