### PR TITLE
Add likes feature

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -58,7 +58,7 @@
     </div>
     <script type="module">
       import { initFirebase, firebaseConfig } from './src/firebase.js';
-      import { getAllPrompts } from './src/prompt.js';
+      import { getAllPrompts, likePrompt } from './src/prompt.js';
 
       initFirebase(firebaseConfig);
 
@@ -84,7 +84,30 @@
           const card = document.createElement('div');
           card.className =
             'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
-          card.textContent = p.text;
+
+          const text = document.createElement('p');
+          text.textContent = p.text;
+
+          const likeRow = document.createElement('div');
+          likeRow.className = 'flex items-center gap-2 mt-2';
+          const likeBtn = document.createElement('button');
+          likeBtn.className =
+            'like-btn p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+          likeBtn.innerHTML = '<i data-lucide="heart" class="w-4 h-4" aria-hidden="true"></i>';
+
+          const likeCount = document.createElement('span');
+          likeCount.textContent = (p.likes || 0).toString();
+
+          likeBtn.addEventListener('click', async () => {
+            await likePrompt(p.id);
+            likeCount.textContent = (parseInt(likeCount.textContent, 10) + 1).toString();
+          });
+
+          likeRow.appendChild(likeBtn);
+          likeRow.appendChild(likeCount);
+
+          card.appendChild(text);
+          card.appendChild(likeRow);
           list.appendChild(card);
         });
         window.lucide?.createIcons();

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,6 +4,8 @@ service cloud.firestore {
     match /prompts/{promptId} {
       allow read: if true;
       allow create: if request.auth != null;
+      allow update: if request.auth != null &&
+        request.resource.data.diff(resource.data).changedKeys().hasOnly(['likes']);
     }
   }
 }

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,6 +1,6 @@
 import { initFirebase, firebaseConfig } from './firebase.js';
 import { onAuth, logout } from './auth.js';
-import { getUserPrompts } from './prompt.js';
+import { getUserPrompts, likePrompt } from './prompt.js';
 import { appState, THEMES } from './state.js';
 
 let themeLightButton;
@@ -54,7 +54,30 @@ const renderSharedPrompts = (prompts) => {
     const item = document.createElement('div');
     item.className =
       'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
-    item.textContent = p.text;
+
+    const text = document.createElement('p');
+    text.textContent = p.text;
+
+    const likeRow = document.createElement('div');
+    likeRow.className = 'flex items-center gap-2 mt-2';
+    const likeBtn = document.createElement('button');
+    likeBtn.className =
+      'like-btn p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+    likeBtn.innerHTML = '<i data-lucide="heart" class="w-4 h-4" aria-hidden="true"></i>';
+
+    const likeCount = document.createElement('span');
+    likeCount.textContent = (p.likes || 0).toString();
+
+    likeBtn.addEventListener('click', async () => {
+      await likePrompt(p.id);
+      likeCount.textContent = (parseInt(likeCount.textContent, 10) + 1).toString();
+    });
+
+    likeRow.appendChild(likeBtn);
+    likeRow.appendChild(likeCount);
+
+    item.appendChild(text);
+    item.appendChild(likeRow);
     list.appendChild(item);
   });
 };

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -1,4 +1,15 @@
-import { collection, addDoc, query, where, getDocs, orderBy, Timestamp } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import {
+  collection,
+  addDoc,
+  query,
+  where,
+  getDocs,
+  orderBy,
+  Timestamp,
+  updateDoc,
+  doc,
+  increment,
+} from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { db } from './firebase.js';
 
 const samplePrompts = [
@@ -18,6 +29,7 @@ export const savePrompt = (text, userId) =>
     text,
     userId,
     createdAt: Timestamp.now(),
+    likes: 0,
   });
 
 export const getUserPrompts = async (userId) => {
@@ -27,11 +39,14 @@ export const getUserPrompts = async (userId) => {
     orderBy('createdAt', 'desc')
   );
   const snap = await getDocs(q);
-  return snap.docs.map((d) => d.data());
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 };
 
 export const getAllPrompts = async () => {
   const q = query(collection(db, 'prompts'), orderBy('createdAt', 'desc'));
   const snap = await getDocs(q);
-  return snap.docs.map((d) => d.data());
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 };
+
+export const likePrompt = (promptId) =>
+  updateDoc(doc(db, 'prompts', promptId), { likes: increment(1) });


### PR DESCRIPTION
## Summary
- allow saving prompt likes and updating them
- show like button on explore and profile pages
- return likes and ids from prompt fetches
- permit authenticated users to update prompt likes in Firebase rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f9028050832f9cbeef4f9aa9a422