### PR TITLE
Enable saving prompts to Firestore

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -58,7 +58,7 @@
     </div>
     <script type="module">
       import { initFirebase, firebaseConfig } from './src/firebase.js';
-      import { getAllPrompts, likePrompt } from './src/prompt.js';
+      import { getAllPrompts, likePrompt, savePrompt } from './src/prompt.js';
       import { appState } from './src/state.js';
 
       initFirebase(firebaseConfig);
@@ -102,6 +102,9 @@
               'savedPrompts',
               JSON.stringify(appState.savedPrompts)
             );
+            if (appState.currentUser) {
+              savePrompt(p.text, appState.currentUser.uid);
+            }
           });
 
           const likeBtn = document.createElement('button');

--- a/index.html
+++ b/index.html
@@ -545,16 +545,27 @@
     </div>
     <script type="module" src="src/main.js?v=30"></script>
     <script type="module">
-      // Import the functions you need from the SDKs you need
       import { initFirebase, app, firebaseConfig } from "./src/firebase.js";
       import { onAuth } from "./src/auth.js";
+      import { appState } from "./src/state.js";
       import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js";
-      // TODO: Add SDKs for Firebase products that you want to use
-      // https://firebase.google.com/docs/web/setup#available-libraries
 
-      // Initialize Firebase
       initFirebase(firebaseConfig);
       const analytics = getAnalytics(app);
+
+      const loginLink = document.getElementById('login-link');
+      const profileLink = document.getElementById('profile-link');
+
+      onAuth((user) => {
+        appState.currentUser = user;
+        if (user) {
+          loginLink?.classList.add('hidden');
+          profileLink?.classList.remove('hidden');
+        } else {
+          profileLink?.classList.add('hidden');
+          loginLink?.classList.remove('hidden');
+        }
+      });
     </script>
   </body>
 </html>

--- a/src/state.js
+++ b/src/state.js
@@ -16,6 +16,7 @@ export const appState = {
   copySuccess: false,
   language: 'en',
   theme: THEMES.DARK,
+  currentUser: null,
   history: readLocal('promptHistory', []),
   savedPrompts: readLocal('savedPrompts', []),
   partHistory: [],

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,6 @@
 import { appState, THEMES } from './state.js';
 import { categories, ICON_FALLBACKS, generatePrompt } from './prompts.js';
+import { savePrompt } from './prompt.js';
 
 const uiText = {
   en: {
@@ -942,6 +943,9 @@ const setupEventListeners = () => {
         'savedPrompts',
         JSON.stringify(appState.savedPrompts)
       );
+      if (appState.currentUser) {
+        savePrompt(appState.generatedPrompt, appState.currentUser.uid);
+      }
       saveSuccessMessage.classList.remove('hidden');
       setTimeout(() => {
         saveSuccessMessage.classList.add('hidden');
@@ -1053,6 +1057,9 @@ const setupEventListeners = () => {
         'savedPrompts',
         JSON.stringify(appState.savedPrompts)
       );
+      if (appState.currentUser) {
+        savePrompt(text, appState.currentUser.uid);
+      }
       const feedback = saveBtn.parentElement.querySelector('.save-feedback');
       if (feedback) {
         feedback.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- track logged-in user in `appState`
- connect index page auth state to show/hide profile link
- save generated and history prompts to Firestore when logged in
- let explore page save prompts remotely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857032c81f4832f984781eb0bb07db7