### PR TITLE
Handle save errors

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -96,14 +96,19 @@
           saveBtn.className =
             'p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
           saveBtn.innerHTML = '<i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>';
-          saveBtn.addEventListener('click', () => {
+          saveBtn.addEventListener('click', async () => {
             appState.savedPrompts.push(p.text);
             localStorage.setItem(
               'savedPrompts',
               JSON.stringify(appState.savedPrompts)
             );
             if (appState.currentUser) {
-              savePrompt(p.text, appState.currentUser.uid);
+              try {
+                await savePrompt(p.text, appState.currentUser.uid);
+              } catch (err) {
+                console.error(err);
+                alert('Failed to save prompt');
+              }
             }
           });
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -936,7 +936,7 @@ const setupEventListeners = () => {
   });
 
   if (saveButton) {
-    saveButton.addEventListener('click', () => {
+    saveButton.addEventListener('click', async () => {
       if (!appState.generatedPrompt) return;
       appState.savedPrompts.push(appState.generatedPrompt);
       localStorage.setItem(
@@ -944,7 +944,13 @@ const setupEventListeners = () => {
         JSON.stringify(appState.savedPrompts)
       );
       if (appState.currentUser) {
-        savePrompt(appState.generatedPrompt, appState.currentUser.uid);
+        try {
+          await savePrompt(appState.generatedPrompt, appState.currentUser.uid);
+        } catch (err) {
+          console.error(err);
+          alert('Failed to save prompt');
+          return;
+        }
       }
       saveSuccessMessage.classList.remove('hidden');
       setTimeout(() => {
@@ -986,7 +992,7 @@ const setupEventListeners = () => {
     renderHistory();
   });
 
-  historyList.addEventListener('click', (e) => {
+  historyList.addEventListener('click', async (e) => {
     const copyBtn = e.target.closest('.history-copy');
     const downloadBtn = e.target.closest('.history-download');
     const saveBtn = e.target.closest('.history-save');
@@ -1058,7 +1064,13 @@ const setupEventListeners = () => {
         JSON.stringify(appState.savedPrompts)
       );
       if (appState.currentUser) {
-        savePrompt(text, appState.currentUser.uid);
+        try {
+          await savePrompt(text, appState.currentUser.uid);
+        } catch (err) {
+          console.error(err);
+          alert('Failed to save prompt');
+          return;
+        }
       }
       const feedback = saveBtn.parentElement.querySelector('.save-feedback');
       if (feedback) {


### PR DESCRIPTION
## Summary
- handle errors when saving prompts in main UI and Explore page
- show alert on failure and use async save function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685706377b88832fafe139044cb38490