### PR TITLE
Initialize Firebase via shared module

### DIFF
--- a/explore.html
+++ b/explore.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=32"></script>
     <link rel="stylesheet" href="css/app.css?v=32" />
+    <script type="module" src="src/init-app.js?v=32"></script>
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=32" />
     <script>
       (function () {
@@ -57,11 +58,9 @@
       <div id="all-prompts" class="space-y-4"></div>
     </div>
     <script type="module">
-      import { initFirebase, firebaseConfig } from './src/firebase.js';
+      
       import { getAllPrompts, likePrompt, savePrompt } from './src/prompt.js';
       import { appState } from './src/state.js';
-
-      initFirebase(firebaseConfig);
 
       const setTheme = (theme) => {
         const linkEl = document.getElementById('theme-css');

--- a/index.html
+++ b/index.html
@@ -543,21 +543,19 @@
         </a>
       </div>
     </div>
-    <script type="module" src="src/main.js?v=32"></script>
+    <script type="module" src="src/init-app.js?v=32"></script>
+<script type="module" src="src/main.js?v=32"></script>
     <script type="module">
-      import { initFirebase, app, firebaseConfig } from "./src/firebase.js";
+      import { app } from './src/firebase.js';
       import { onAuth } from "./src/auth.js";
       import { appState } from "./src/state.js";
       import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js";
-
-      initFirebase(firebaseConfig);
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');
       const profileLink = document.getElementById('profile-link');
 
       onAuth((user) => {
-        appState.currentUser = user;
         if (user) {
           loginLink?.classList.add('hidden');
           profileLink?.classList.remove('hidden');

--- a/login.html
+++ b/login.html
@@ -7,7 +7,7 @@
   <title>Prompter Login</title>
   <base href="./">
   <link rel="stylesheet" href="css/app.css?v=32">
-  <script type="module" src="src/firebase.js?v=32"></script>
+  <script type="module" src="src/init-app.js?v=32"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=32"></script>
   <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=32">
@@ -19,10 +19,8 @@
   </script>
   <script type="module" src="src/auth.js?v=32"></script>
   <script type="module">
-    import { initFirebase, firebaseConfig } from './src/firebase.js';
+     
     import { login, register, onAuth } from './src/auth.js';
-
-    initFirebase(firebaseConfig);
 
     function init() {
       const loginForm = document.getElementById('login-form');

--- a/profile.html
+++ b/profile.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=32"></script>
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=32" />
+    <script type="module" src="src/init-app.js?v=32"></script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');

--- a/src/init-app.js
+++ b/src/init-app.js
@@ -1,0 +1,9 @@
+import { initFirebase, firebaseConfig } from './firebase.js';
+import { onAuth } from './auth.js';
+import { appState } from './state.js';
+
+initFirebase(firebaseConfig);
+
+onAuth((user) => {
+  appState.currentUser = user;
+});

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,4 +1,3 @@
-import { initFirebase, firebaseConfig } from './firebase.js';
 import { onAuth, logout } from './auth.js';
 import { getUserPrompts, likePrompt } from './prompt.js';
 import { appState, THEMES } from './state.js';
@@ -122,5 +121,4 @@ const init = () => {
   });
 };
 
-initFirebase(firebaseConfig);
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- add new `init-app.js` module to centralize Firebase init and auth state handling
- include `init-app.js` before Firebase-dependent scripts
- drop inline `initFirebase` calls
- remove duplicate init from `profile.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857083495b8832f91a0341c7d8baf0e