### PR TITLE
Add multilingual support to profile page

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -23,8 +23,92 @@
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-xl mx-auto relative">
-      <div class="absolute top-4 left-4">
+      <div class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10">
+        <div
+          id="lang-container"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
+        >
+          <button
+            id="lang-toggle"
+            class="p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"
+            aria-label="Languages"
+          >
+            <i
+              data-lucide="languages"
+              class="w-5 h-5 text-blue-300"
+              role="img"
+              aria-label="Languages icon"
+            ></i>
+          </button>
+          <span
+            id="current-lang"
+            class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
+          >
+            EN
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-3 h-3 mt-0.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </span>
+          <div
+            id="lang-menu"
+            class="lang-menu hidden absolute right-0 top-full mt-1 rounded-md border border-white/20 text-sm"
+          >
+            <button
+              id="lang-en"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to English"
+            >
+              EN
+            </button>
+            <button
+              id="lang-tr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Turkish"
+            >
+              TR
+            </button>
+            <button
+              id="lang-es"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Spanish"
+            >
+              ES
+            </button>
+            <button
+              id="lang-fr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to French"
+            >
+              FR
+            </button>
+            <button
+              id="lang-zh"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Chinese"
+            >
+              ZH
+            </button>
+            <button
+              id="lang-hi"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Hindi"
+            >
+              HI
+            </button>
+          </div>
+        </div>
         <a
+          id="back-link"
           href="index.html"
           class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
           title="Back"
@@ -52,8 +136,8 @@
         </button>
       </div>
       <div class="text-center mb-6 pt-16">
-        <img src="icons/logo.svg?v=39" alt="Prompter logo" class="mx-auto mb-4 w-16 h-16" />
-        <h1 class="text-2xl font-bold mb-2">Profile</h1>
+        <img id="app-logo" src="icons/logo.svg?v=39" alt="Prompter logo" class="mx-auto mb-4 w-16 h-16" />
+        <h1 id="page-title" class="text-2xl font-bold mb-2">Profile</h1>
         <p id="user-email" class="text-blue-200 mb-2"></p>
         <button
           id="logout"
@@ -65,14 +149,14 @@
       </div>
       <section class="mb-6">
         <h2 class="text-xl font-semibold mb-2">
-          Saved Prompts (<span id="saved-count">0</span>)
+          <span id="saved-title-text">Saved Prompts</span> (<span id="saved-count">0</span>)
         </h2>
         <div id="saved-list" class="space-y-4"></div>
       </section>
 
       <section class="mb-6">
         <h2 class="text-xl font-semibold mb-2">
-          Shared Prompts (<span id="shared-count">0</span>)
+          <span id="shared-title-text">Shared Prompts</span> (<span id="shared-count">0</span>)
         </h2>
         <div id="shared-list" class="space-y-4"></div>
       </section>

--- a/src/profile.js
+++ b/src/profile.js
@@ -2,17 +2,198 @@ import { onAuth, logout } from './auth.js';
 import { getUserPrompts, likePrompt, savePrompt } from './prompt.js';
 import { appState, THEMES } from './state.js';
 
+const uiText = {
+  en: {
+    profile: 'Profile',
+    savedPrompts: 'Saved Prompts',
+    sharedPrompts: 'Shared Prompts',
+    noPrompts: 'No prompts yet.',
+    logout: 'Logout',
+    back: 'Back',
+    themeLightTitle: 'Light Theme',
+    themeDarkTitle: 'Dark Theme',
+    langEnLabel: 'Switch to English',
+    langTrLabel: 'Switch to Turkish',
+    langEsLabel: 'Switch to Spanish',
+    langFrLabel: 'Switch to French',
+    langZhLabel: 'Switch to Chinese',
+    langHiLabel: 'Switch to Hindi',
+    appLogoAlt: 'Prompter logo',
+  },
+  tr: {
+    profile: 'Profil',
+    savedPrompts: 'Kaydedilen Promptlar',
+    sharedPrompts: 'Paylaşılan Promptlar',
+    noPrompts: 'Henüz prompt yok.',
+    logout: 'Çıkış Yap',
+    back: 'Geri',
+    themeLightTitle: 'Açık Tema',
+    themeDarkTitle: 'Koyu Tema',
+    langEnLabel: "İngilizce'ye geç",
+    langTrLabel: "Türkçe'ye geç",
+    langEsLabel: "İspanyolca'ya geç",
+    langFrLabel: "Fransızca'ya geç",
+    langZhLabel: "Çince'ye geç",
+    langHiLabel: 'Hintçe\u0027ye geç',
+    appLogoAlt: 'Prompter logosu',
+  },
+  es: {
+    profile: 'Perfil',
+    savedPrompts: 'Prompts Guardados',
+    sharedPrompts: 'Prompts Compartidos',
+    noPrompts: 'Aún no hay prompts.',
+    logout: 'Cerrar sesión',
+    back: 'Atrás',
+    themeLightTitle: 'Tema Claro',
+    themeDarkTitle: 'Tema Oscuro',
+    langEnLabel: 'Cambiar a inglés',
+    langTrLabel: 'Cambiar a turco',
+    langEsLabel: 'Cambiar a español',
+    langFrLabel: 'Cambiar a francés',
+    langZhLabel: 'Cambiar a chino',
+    langHiLabel: 'Cambiar a hindi',
+    appLogoAlt: 'Logo de Prompter',
+  },
+  fr: {
+    profile: 'Profil',
+    savedPrompts: 'Prompts Enregistrés',
+    sharedPrompts: 'Prompts Partagés',
+    noPrompts: 'Pas encore de prompts.',
+    logout: 'Se déconnecter',
+    back: 'Retour',
+    themeLightTitle: 'Thème clair',
+    themeDarkTitle: 'Thème sombre',
+    langEnLabel: "Passer à l'anglais",
+    langTrLabel: 'Passer au turc',
+    langEsLabel: "Passer à l'espagnol",
+    langFrLabel: 'Passer au français',
+    langZhLabel: 'Passer au chinois',
+    langHiLabel: 'Passer au hindi',
+    appLogoAlt: 'Logo de Prompter',
+  },
+  zh: {
+    profile: '个人资料',
+    savedPrompts: '已保存的提示',
+    sharedPrompts: '分享的提示',
+    noPrompts: '暂无提示。',
+    logout: '登出',
+    back: '返回',
+    themeLightTitle: '浅色主题',
+    themeDarkTitle: '深色主题',
+    langEnLabel: '切换到英文',
+    langTrLabel: '切换到土耳其语',
+    langEsLabel: '切换到西班牙语',
+    langFrLabel: '切换到法语',
+    langZhLabel: '切换到中文',
+    langHiLabel: '切换到印地语',
+    appLogoAlt: 'Prompter 标志',
+  },
+  hi: {
+    profile: 'प्रोफ़ाइल',
+    savedPrompts: 'सहेजे गए प्रॉम्प्ट',
+    sharedPrompts: 'साझा किए गए प्रॉम्प्ट',
+    noPrompts: 'अभी कोई प्रॉम्प्ट नहीं।',
+    logout: 'लॉग आउट',
+    back: 'वापस',
+    themeLightTitle: 'लाइट थीम',
+    themeDarkTitle: 'डार्क थीम',
+    langEnLabel: 'अंग्रेजी पर स्विच करें',
+    langTrLabel: 'तुर्की पर स्विच करें',
+    langEsLabel: 'स्पेनिश पर स्विच करें',
+    langFrLabel: 'फ्रेंच पर स्विच करें',
+    langZhLabel: 'चीनी पर स्विच करें',
+    langHiLabel: 'हिंदी पर स्विच करें',
+    appLogoAlt: 'Prompter लोगो',
+  },
+};
+
 let themeLightButton;
 let themeDarkButton;
 let themeLinkElement;
 let themeVersion = '';
+let langEnButton;
+let langTrButton;
+let langEsButton;
+let langFrButton;
+let langZhButton;
+let langHiButton;
+let langToggleButton;
+let langMenu;
+let currentLangLabel;
+let sharedPromptsData = [];
 
 const setTheme = (theme) => {
+  appState.theme = theme;
   if (themeLinkElement) {
     const versionSuffix = themeVersion ? `?${themeVersion}` : '';
     themeLinkElement.href = `css/theme-${theme}.css${versionSuffix}`;
   }
   localStorage.setItem('theme', theme);
+  updateTexts();
+};
+
+const setLanguage = (lang) => {
+  appState.language = lang;
+  document.documentElement.lang = lang;
+  updateTexts();
+  renderSavedPrompts(appState.savedPrompts);
+  renderSharedPrompts(sharedPromptsData);
+  localStorage.setItem('language', lang);
+};
+
+const updateTexts = () => {
+  if (themeLightButton) {
+    themeLightButton.title = uiText[appState.language].themeLightTitle;
+    themeLightButton.setAttribute('aria-label', uiText[appState.language].themeLightTitle);
+  }
+  if (themeDarkButton) {
+    themeDarkButton.title = uiText[appState.language].themeDarkTitle;
+    themeDarkButton.setAttribute('aria-label', uiText[appState.language].themeDarkTitle);
+  }
+  const backLink = document.getElementById('back-link');
+  if (backLink) {
+    backLink.title = uiText[appState.language].back;
+    backLink.setAttribute('aria-label', uiText[appState.language].back);
+  }
+  const pageTitle = document.getElementById('page-title');
+  if (pageTitle) pageTitle.textContent = uiText[appState.language].profile;
+  const logo = document.getElementById('app-logo');
+  if (logo) logo.alt = uiText[appState.language].appLogoAlt;
+  const logoutSpan = document.querySelector('#logout span');
+  if (logoutSpan) logoutSpan.textContent = uiText[appState.language].logout;
+  const savedTitle = document.getElementById('saved-title-text');
+  if (savedTitle) savedTitle.textContent = uiText[appState.language].savedPrompts;
+  const sharedTitle = document.getElementById('shared-title-text');
+  if (sharedTitle) sharedTitle.textContent = uiText[appState.language].sharedPrompts;
+  if (langEnButton) {
+    langEnButton.title = uiText[appState.language].langEnLabel;
+    langEnButton.setAttribute('aria-label', uiText[appState.language].langEnLabel);
+  }
+  if (langTrButton) {
+    langTrButton.title = uiText[appState.language].langTrLabel;
+    langTrButton.setAttribute('aria-label', uiText[appState.language].langTrLabel);
+  }
+  if (langEsButton) {
+    langEsButton.title = uiText[appState.language].langEsLabel;
+    langEsButton.setAttribute('aria-label', uiText[appState.language].langEsLabel);
+  }
+  if (langFrButton) {
+    langFrButton.title = uiText[appState.language].langFrLabel;
+    langFrButton.setAttribute('aria-label', uiText[appState.language].langFrLabel);
+  }
+  if (langZhButton) {
+    langZhButton.title = uiText[appState.language].langZhLabel;
+    langZhButton.setAttribute('aria-label', uiText[appState.language].langZhLabel);
+  }
+  if (langHiButton) {
+    langHiButton.title = uiText[appState.language].langHiLabel;
+    langHiButton.setAttribute('aria-label', uiText[appState.language].langHiLabel);
+  }
+  if (currentLangLabel) {
+    const arrow = currentLangLabel.querySelector('svg');
+    currentLangLabel.textContent = appState.language.toUpperCase();
+    if (arrow) currentLangLabel.appendChild(arrow);
+  }
 };
 
 const updateCount = (id, count) => {
@@ -26,7 +207,7 @@ const renderSavedPrompts = (prompts) => {
   updateCount('saved-count', prompts.length);
   if (!prompts || prompts.length === 0) {
     const p = document.createElement('p');
-    p.textContent = 'No prompts yet.';
+    p.textContent = uiText[appState.language].noPrompts;
     list.appendChild(p);
     return;
   }
@@ -45,7 +226,7 @@ const renderSharedPrompts = (prompts) => {
   updateCount('shared-count', prompts.length);
   if (!prompts || prompts.length === 0) {
     const p = document.createElement('p');
-    p.textContent = 'No prompts yet.';
+    p.textContent = uiText[appState.language].noPrompts;
     list.appendChild(p);
     return;
   }
@@ -106,8 +287,18 @@ const init = () => {
     }
   }
 
+  langEnButton = document.getElementById('lang-en');
+  langTrButton = document.getElementById('lang-tr');
+  langEsButton = document.getElementById('lang-es');
+  langFrButton = document.getElementById('lang-fr');
+  langZhButton = document.getElementById('lang-zh');
+  langHiButton = document.getElementById('lang-hi');
+  langToggleButton = document.getElementById('lang-toggle');
+  langMenu = document.getElementById('lang-menu');
+  currentLangLabel = document.getElementById('current-lang');
+
   const savedLang = localStorage.getItem('language') || 'en';
-  document.documentElement.lang = savedLang;
+  setLanguage(savedLang);
 
   const currentTheme = localStorage.getItem('theme') || THEMES.DARK;
   setTheme(currentTheme);
@@ -115,6 +306,38 @@ const init = () => {
   themeLightButton?.addEventListener('click', () => setTheme(THEMES.LIGHT));
   themeDarkButton?.addEventListener('click', () => setTheme(THEMES.DARK));
   document.getElementById('logout')?.addEventListener('click', logout);
+  langEnButton?.addEventListener('click', () => setLanguage('en'));
+  langTrButton?.addEventListener('click', () => setLanguage('tr'));
+  langEsButton?.addEventListener('click', () => setLanguage('es'));
+  langFrButton?.addEventListener('click', () => setLanguage('fr'));
+  langZhButton?.addEventListener('click', () => setLanguage('zh'));
+  langHiButton?.addEventListener('click', () => setLanguage('hi'));
+
+  [
+    langEnButton,
+    langTrButton,
+    langEsButton,
+    langFrButton,
+    langZhButton,
+    langHiButton,
+  ].forEach((btn) => {
+    if (btn) {
+      btn.addEventListener('click', () => {
+        langMenu && langMenu.classList.add('hidden');
+      });
+    }
+  });
+
+  if (langToggleButton && langMenu) {
+    langToggleButton.addEventListener('click', () => {
+      langMenu.classList.toggle('hidden');
+    });
+  }
+  if (currentLangLabel && langMenu) {
+    currentLangLabel.addEventListener('click', () => {
+      langMenu.classList.toggle('hidden');
+    });
+  }
 
   onAuth(async (user) => {
     if (!user) {
@@ -126,7 +349,8 @@ const init = () => {
       let prompts = await getUserPrompts(user.uid);
       await syncLocalPrompts(user.uid, prompts.map((p) => p.text));
       prompts = await getUserPrompts(user.uid);
-      renderSharedPrompts(prompts);
+      sharedPromptsData = prompts;
+      renderSharedPrompts(sharedPromptsData);
       const merged = Array.from(
         new Set([...appState.savedPrompts, ...prompts.map((p) => p.text)])
       );


### PR DESCRIPTION
## Summary
- add language dictionaries and switching logic to `profile.js`
- internationalize the static headings in `profile.html`
- include language selector dropdown and persisting preference

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685714f11500832f920651308fec0029