### PR TITLE
Add storage listener for saved prompts

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -339,6 +339,27 @@ const init = () => {
     });
   }
 
+  window.addEventListener('storage', async (e) => {
+    if (e.key === 'savedPrompts') {
+      try {
+        const saved = e.newValue ? JSON.parse(e.newValue) : [];
+        appState.savedPrompts = saved;
+        renderSavedPrompts(saved);
+        if (appState.currentUser) {
+          try {
+            const prompts = await getUserPrompts(appState.currentUser.uid);
+            sharedPromptsData = prompts;
+            renderSharedPrompts(sharedPromptsData);
+          } catch (err) {
+            console.error('Failed to load prompts:', err);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to parse savedPrompts from storage event:', err);
+      }
+    }
+  });
+
   onAuth(async (user) => {
     if (!user) {
       window.location.href = 'index.html';


### PR DESCRIPTION
## Summary
- reload saved prompts when they change in localStorage
- optionally refresh shared prompts from Firebase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571728c878832fa3df7f05e7fbbb21