### PR TITLE
Add banner when opened from file protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python3 -m http.server
 
 and then visit `http://localhost:8000`. This ensures the JSON prompt files load correctly. The generator still requires an internet connection.
 
-You can open `index.html` directly from your file system, but prompts will not load because the app fetches its data over the network.
+You can open `index.html` directly from your file system, but prompts will not load because the app fetches its data over the network. When opened this way, the app shows a small banner reminding you to start a local server such as `python3 -m http.server`.
 
 ## Authentication
 

--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,14 @@ const hideEmptyAdSlots = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (location.protocol === 'file:') {
+    const banner = document.createElement('div');
+    banner.textContent =
+      'Start a local web server (e.g. "python3 -m http.server") for full functionality.';
+    banner.style.cssText =
+      'background:#f87171;color:#fff;padding:8px;text-align:center;font-size:14px;';
+    document.body.prepend(banner);
+  }
   initializeApp();
   if (window.lucide && typeof window.lucide.createIcons === 'function') {
     window.lucide.createIcons();


### PR DESCRIPTION
## Summary
- warn users if the app is opened via the `file:` protocol
- document this warning in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68572901c5a0832f894a8e0bbc4fc55a