### PR TITLE
Update base href docs and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,14 @@ Prompter includes a range of optimizations to help search engines crawl and inde
 Before deploying your own instance, update all references to the default domain
 (`https://prompterai.space`).
 
-- Edit the canonical `<link>` tags in `index.html` and `tr/index.html` so they
-  point to your final site.
-- Set the `<base>` tag in `index.html` and `tr/index.html` to the directory where the site is hosted (e.g., `<base href="/">` or `<base href="/subdir/">`).
+- Edit the canonical `<link>` tags in all HTML files so they point to your final
+  site.
+- Ensure the `<base>` tag in every HTML file matches the path where the site is
+  hosted. A mismatched value will break relative URLs. Example: `<base
+  href="/subdir/">` when serving from `/subdir/`.
+- You can automatically rewrite the `<base>` tags by setting the `BASE_HREF`
+  environment variable when running `npm run build`, e.g. `BASE_HREF=/subdir/
+  npm run build`.
 - In `scripts/generate-sitemap.js` replace the `BASE_URL` constant and run
   `npm run build:sitemap` to regenerate `sitemap.xml`.
 - Update the `Sitemap:` line inside `robots.txt` with your new domain.

--- a/scripts/build-prompts.js
+++ b/scripts/build-prompts.js
@@ -94,11 +94,18 @@ function appendVersionToAssets(html, version) {
   return result;
 }
 
-function updateHtmlFiles(version) {
+function updateBaseHref(html, href) {
+  return html.replace(/<base\s+href="[^"]*"\s*\/?>(?=)/i, `<base href="${href}" />`);
+}
+
+function updateHtmlFiles(version, baseHref) {
   const htmlFiles = getHtmlFiles(rootDir);
   for (const file of htmlFiles) {
     const original = fs.readFileSync(file, 'utf8');
-    const updated = appendVersionToAssets(original, version);
+    let updated = appendVersionToAssets(original, version);
+    if (baseHref) {
+      updated = updateBaseHref(updated, baseHref);
+    }
     fs.writeFileSync(file, updated);
     console.log(`Updated ${path.relative(rootDir, file)}`);
   }
@@ -114,4 +121,5 @@ fs.writeFileSync(outputFile, output);
 console.log(`Wrote ${outputFile}`);
 
 const version = bumpManifestVersion();
-updateHtmlFiles(version);
+const baseHref = process.env.BASE_HREF;
+updateHtmlFiles(version, baseHref);


### PR DESCRIPTION
## Summary
- clarify that `<base>` must match hosting path
- allow `BASE_HREF` environment variable during build to rewrite the `<base>` tag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685729e46f28832fb3da8f1ee26e06d4