### PR TITLE
Add file protocol banner and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python3 -m http.server
 
 and then visit `http://localhost:8000`. This ensures the JSON prompt files load correctly. The generator still requires an internet connection.
 
-You can open `index.html` directly from your file system, but prompts will not load because the app fetches its data over the network. When opened this way, the app shows a small banner reminding you to start a local server such as `python3 -m http.server`.
+Opening `index.html` over `file://` URLs is not supported. Browsers block JavaScript modules when loaded from the file system, so the application cannot initialize. Always serve the directory over HTTP using a command such as `python3 -m http.server` and then visit `http://localhost:8000`.
 
 ## Authentication
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script>
+      if (location.protocol === 'file:') {
+        document.addEventListener('DOMContentLoaded', function () {
+          const banner = document.createElement('div');
+          banner.textContent =
+            'Run "python3 -m http.server" and open http://localhost:8000/ in your browser.';
+          banner.style.cssText =
+            'background:#f87171;color:#fff;padding:8px;text-align:center;font-size:14px;';
+          document.body.prepend(banner);
+        });
+        window.stopInit = true;
+      }
+    </script>
     <script src="https://fpyf8.com/88/tag.min.js" data-zone="153053" async data-cfasync="false"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/login.html
+++ b/login.html
@@ -1,6 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>
+    if (location.protocol === 'file:') {
+      document.addEventListener('DOMContentLoaded', function () {
+        const banner = document.createElement('div');
+        banner.textContent =
+          'Run "python3 -m http.server" and open http://localhost:8000/ in your browser.';
+        banner.style.cssText =
+          'background:#f87171;color:#fff;padding:8px;text-align:center;font-size:14px;';
+        document.body.prepend(banner);
+      });
+      window.stopInit = true;
+    }
+  </script>
   <script src="https://fpyf8.com/88/tag.min.js" data-zone="153053" async data-cfasync="false"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/main.js
+++ b/src/main.js
@@ -42,14 +42,7 @@ const hideEmptyAdSlots = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (location.protocol === 'file:') {
-    const banner = document.createElement('div');
-    banner.textContent =
-      'Start a local web server (e.g. "python3 -m http.server") for full functionality.';
-    banner.style.cssText =
-      'background:#f87171;color:#fff;padding:8px;text-align:center;font-size:14px;';
-    document.body.prepend(banner);
-  }
+  if (window.stopInit) return;
   initializeApp();
   if (window.lucide && typeof window.lucide.createIcons === 'function') {
     window.lucide.createIcons();


### PR DESCRIPTION
## Summary
- show a banner when pages are opened via `file:` protocol and stop initialization
- skip initializing the app in `main.js` if the banner ran
- note that `file://` URLs won't work in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68572de680a0832f8282832ca242d25a