### PR TITLE
Sync saved prompts per user

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -1,5 +1,5 @@
 import { onAuth, logout } from './auth.js';
-import { getUserPrompts, likePrompt } from './prompt.js';
+import { getUserPrompts, likePrompt, getUserSavedPrompts } from './prompt.js';
 import { appState, THEMES } from './state.js';
 
 const uiText = {
@@ -365,6 +365,14 @@ const init = () => {
       const prompts = await getUserPrompts(user.uid);
       sharedPromptsData = prompts;
       renderSharedPrompts(sharedPromptsData);
+
+      const savedDocs = await getUserSavedPrompts(user.uid);
+      const savedTexts = savedDocs.map((p) => p.text);
+      const merged = Array.from(
+        new Set([...appState.savedPrompts, ...savedTexts])
+      );
+      appState.savedPrompts = merged;
+      localStorage.setItem('savedPrompts', JSON.stringify(merged));
       renderSavedPrompts(appState.savedPrompts);
     } catch (err) {
       console.error('Failed to load prompts:', err);

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -48,3 +48,18 @@ export const getAllPrompts = async () => {
 
 export const likePrompt = (promptId) =>
   updateDoc(doc(db, 'prompts', promptId), { likes: increment(1) });
+
+export const saveUserPrompt = (text, userId) =>
+  addDoc(collection(db, `users/${userId}/savedPrompts`), {
+    text,
+    createdAt: Timestamp.now(),
+  });
+
+export const getUserSavedPrompts = async (userId) => {
+  const q = query(
+    collection(db, `users/${userId}/savedPrompts`),
+    orderBy('createdAt', 'desc')
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+};

--- a/src/ui.js
+++ b/src/ui.js
@@ -929,7 +929,12 @@ const setupEventListeners = () => {
         JSON.stringify(appState.savedPrompts)
       );
       if (appState.currentUser) {
-        // prompt remains private until shared
+        try {
+          const { saveUserPrompt } = await import('./prompt.js');
+          await saveUserPrompt(appState.generatedPrompt, appState.currentUser.uid);
+        } catch (err) {
+          console.error('Failed to sync prompt:', err);
+        }
       }
       saveSuccessMessage.classList.remove('hidden');
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- add `saveUserPrompt` & `getUserSavedPrompts` utilities
- call `saveUserPrompt` when the save button is used
- merge saved prompts from Firestore on profile load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f58dba30832fbe20f032ba9f0ece