### PR TITLE
Add like/unlike toggling with user tracking

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -249,3 +249,8 @@ html {
 .history-copy i {
   pointer-events: none;
 }
+
+.like-btn.active svg {
+  fill: currentColor;
+  stroke: none;
+}

--- a/explore.html
+++ b/explore.html
@@ -60,7 +60,12 @@
     </div>
     <script type="module">
       
-      import { getAllPrompts, likePrompt, savePrompt } from './src/prompt.js';
+      import {
+        getAllPrompts,
+        likePrompt,
+        unlikePrompt,
+        savePrompt,
+      } from './src/prompt.js';
       import { appState } from './src/state.js';
 
       const setTheme = (theme) => {
@@ -115,17 +120,46 @@
           const likeCount = document.createElement('span');
           likeCount.textContent = (p.likes || 0).toString();
 
-          if (appState.likedPrompts.includes(p.id)) {
-            likeBtn.disabled = true;
+          const liked =
+            appState.currentUser && p.likedBy && p.likedBy.includes(appState.currentUser.uid);
+          if (liked) {
+            likeBtn.classList.add('active');
           }
+
+          const updateLikeIcon = () => {
+            const svg = likeBtn.querySelector('svg');
+            if (svg) svg.setAttribute('fill', likeBtn.classList.contains('active') ? 'currentColor' : 'none');
+          };
+
           likeBtn.addEventListener('click', async () => {
-            if (appState.likedPrompts.includes(p.id)) return;
-            await likePrompt(p.id);
-            appState.likedPrompts.push(p.id);
-            localStorage.setItem('likedPrompts', JSON.stringify(appState.likedPrompts));
-            likeCount.textContent = (parseInt(likeCount.textContent, 10) + 1).toString();
+            if (!appState.currentUser) {
+              alert('Login required');
+              return;
+            }
             likeBtn.disabled = true;
+            const already = likeBtn.classList.contains('active');
+            try {
+              if (already) {
+                await unlikePrompt(p.id, appState.currentUser.uid);
+                likeCount.textContent = (parseInt(likeCount.textContent, 10) - 1).toString();
+                appState.likedPrompts = appState.likedPrompts.filter((id) => id !== p.id);
+                likeBtn.classList.remove('active');
+              } else {
+                await likePrompt(p.id, appState.currentUser.uid);
+                likeCount.textContent = (parseInt(likeCount.textContent, 10) + 1).toString();
+                appState.likedPrompts.push(p.id);
+                likeBtn.classList.add('active');
+              }
+              localStorage.setItem('likedPrompts', JSON.stringify(appState.likedPrompts));
+              updateLikeIcon();
+            } catch (err) {
+              console.error('Failed to toggle like:', err);
+            } finally {
+              likeBtn.disabled = false;
+            }
           });
+
+          updateLikeIcon();
 
           likeRow.appendChild(saveBtn);
           likeRow.appendChild(likeBtn);
@@ -136,6 +170,14 @@
           list.appendChild(card);
         });
         window.lucide?.createIcons();
+        document
+          .querySelectorAll('#all-prompts .like-btn')
+          .forEach((b) => {
+            const svg = b.querySelector('svg');
+            if (svg && b.classList.contains('active')) {
+              svg.setAttribute('fill', 'currentColor');
+            }
+          });
       }
 
       document.addEventListener('DOMContentLoaded', init);

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
       allow read: if true;
       allow create: if request.auth != null;
       allow update: if request.auth != null &&
-        request.resource.data.diff(resource.data).changedKeys().hasOnly(['likes']);
+        request.resource.data.diff(resource.data).changedKeys().hasOnly(['likes', 'likedBy', 'sharedBy']);
     }
   }
 }

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -9,6 +9,8 @@ import {
   updateDoc,
   doc,
   increment,
+  arrayUnion,
+  arrayRemove,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { db } from './firebase.js';
 
@@ -30,6 +32,8 @@ export const savePrompt = (text, userId) =>
     userId,
     createdAt: Timestamp.now(),
     likes: 0,
+    likedBy: [],
+    sharedBy: [userId],
   });
 
 export const getUserPrompts = async (userId) => {
@@ -46,8 +50,22 @@ export const getAllPrompts = async () => {
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 };
 
-export const likePrompt = (promptId) =>
-  updateDoc(doc(db, 'prompts', promptId), { likes: increment(1) });
+export const likePrompt = (promptId, userId) =>
+  updateDoc(doc(db, 'prompts', promptId), {
+    likes: increment(1),
+    likedBy: arrayUnion(userId),
+  });
+
+export const unlikePrompt = (promptId, userId) =>
+  updateDoc(doc(db, 'prompts', promptId), {
+    likes: increment(-1),
+    likedBy: arrayRemove(userId),
+  });
+
+export const unsharePrompt = (promptId, userId) =>
+  updateDoc(doc(db, 'prompts', promptId), {
+    sharedBy: arrayRemove(userId),
+  });
 
 export const saveUserPrompt = (text, userId) =>
   addDoc(collection(db, `users/${userId}/savedPrompts`), {
@@ -63,3 +81,4 @@ export const getUserSavedPrompts = async (userId) => {
   const snap = await getDocs(q);
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 };
+


### PR DESCRIPTION
## Summary
- track users that liked or shared a prompt using `likedBy` and `sharedBy` arrays
- expose `unlikePrompt` and `unsharePrompt` helpers
- allow updating these fields in Firestore rules
- update like buttons to toggle state with filled icons

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f861b988832f921a2c9bfc841afd