### PR TITLE
Rename explore page to social

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@
           >Profile</a
         >
         <a id="login-link" href="login.html" class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center">Login</a>
-        <a id="explore-link" href="explore.html" class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center">Explore</a>
+        <a id="explore-link" href="social.html" class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center">Social</a>
       </div>
 
       <!-- Header -->

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://prompterai.space/404.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
   <url><loc>https://prompterai.space/es/</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
-  <url><loc>https://prompterai.space/explore.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/social.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
   <url><loc>https://prompterai.space/fr/</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
   <url><loc>https://prompterai.space/hi/</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
   <url><loc>https://prompterai.space/</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>

--- a/social.html
+++ b/social.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Explore Prompts</title>
+    <title>Prompter Social</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=45"></script>
     <link rel="stylesheet" href="css/app.css?v=45" />
@@ -64,7 +64,7 @@
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
         />
-        <h1 class="text-2xl font-bold mb-2">All Prompts</h1>
+        <h1 class="text-2xl font-bold mb-2">Prompter Social</h1>
       </div>
       <div id="all-prompts" class="space-y-4"></div>
     </div>


### PR DESCRIPTION
## Summary
- rename the `explore.html` page to `social.html`
- update heading and title text to "Prompter Social"
- point navigation link to the new `social.html` page
- update sitemap entry for the social page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685809631438832f8ac27e2e426c7a3c