### PR TITLE
Add username profile support

### DIFF
--- a/login.html
+++ b/login.html
@@ -34,8 +34,9 @@
   <script type="module" src="src/auth.js?v=45"></script>
   <script nomodule src="dist/auth.js?v=45"></script>
   <script type="module">
-     
+
     import { login, register, onAuth } from './src/auth.js';
+    import { setUserProfile } from './src/user.js';
 
     function init() {
       const loginForm = document.getElementById('login-form');
@@ -66,7 +67,9 @@
         e.preventDefault();
         const email = document.getElementById('register-email').value;
         const password = document.getElementById('register-password').value;
+        const name = document.getElementById('register-name').value;
         register(email, password)
+          .then((cred) => setUserProfile(cred.user.uid, { name }))
           .then(() => {
             authError.textContent = '';
             window.location.href = 'index.html';
@@ -98,6 +101,7 @@
     <form id="register-form" class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-4 border border-white/20 shadow-lg space-y-2">
       <h2 class="text-lg font-semibold mb-2">Kayıt</h2>
       <input id="register-email" type="email" placeholder="E-posta" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
+      <input id="register-name" type="text" placeholder="Name" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
       <input id="register-password" type="password" placeholder="Şifre" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
       <button type="submit" class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 rounded-lg transition-all duration-300 ease-in-out">Kayıt Ol</button>
     </form>

--- a/profile.html
+++ b/profile.html
@@ -140,6 +140,7 @@
       <div class="text-center mb-6 pt-16">
         <img id="app-logo" src="icons/logo.svg?v=45" alt="Prompter logo" class="mx-auto mb-4 w-16 h-16" />
         <h1 id="page-title" class="text-2xl font-bold mb-2">Profile</h1>
+        <p id="user-name" class="text-blue-200 mb-2"></p>
         <p id="user-email" class="text-blue-200 mb-2"></p>
         <button
           id="logout"

--- a/social.html
+++ b/social.html
@@ -76,6 +76,7 @@
         updatePromptText,
       } from './src/prompt.js';
       import { appState } from './src/state.js';
+      import { getUserProfile } from './src/user.js';
 
       const setTheme = (theme) => {
         const linkEl = document.getElementById('theme-css');
@@ -91,17 +92,30 @@
         .getElementById('theme-dark')
         .addEventListener('click', () => setTheme('dark'));
 
+      const profileCache = {};
+      const fetchName = async (uid) => {
+        if (profileCache[uid]) return profileCache[uid];
+        const prof = await getUserProfile(uid);
+        const name = prof?.name || '';
+        profileCache[uid] = name;
+        return name;
+      };
+
       async function init() {
         const list = document.getElementById('all-prompts');
         const prompts = await getAllPrompts();
         list.innerHTML = '';
-        prompts.forEach((p) => {
+        for (const p of prompts) {
           const card = document.createElement('div');
           card.className =
             'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
 
           const text = document.createElement('p');
           text.textContent = p.text;
+
+          const nameEl = document.createElement('p');
+          nameEl.className = 'text-blue-200 text-sm mt-1';
+          nameEl.textContent = await fetchName(p.userId);
 
           const likeRow = document.createElement('div');
           likeRow.className = 'flex items-center gap-2 mt-2';
@@ -243,9 +257,10 @@
           likeRow.appendChild(likeCount);
 
           card.appendChild(text);
+          card.appendChild(nameEl);
           card.appendChild(likeRow);
           list.appendChild(card);
-        });
+        }
         window.lucide?.createIcons();
         document.querySelectorAll('#all-prompts .like-btn').forEach((b) => {
           const svg = b.querySelector('svg');

--- a/src/profile.js
+++ b/src/profile.js
@@ -7,6 +7,7 @@ import {
   updatePromptText,
   unsharePrompt,
 } from './prompt.js';
+import { getUserProfile } from './user.js';
 import { appState, THEMES } from './state.js';
 
 const uiText = {
@@ -128,6 +129,7 @@ let langToggleButton;
 let langMenu;
 let currentLangLabel;
 let sharedPromptsData = [];
+let currentUserName = '';
 
 const setTheme = (theme) => {
   appState.theme = theme;
@@ -389,6 +391,10 @@ const renderSharedPrompts = (prompts) => {
     const text = document.createElement('p');
     text.textContent = p.text;
 
+    const nameEl = document.createElement('p');
+    nameEl.className = 'text-blue-200 text-sm mt-1';
+    nameEl.textContent = currentUserName;
+
     const likeRow = document.createElement('div');
     likeRow.className = 'flex items-center gap-2 mt-2';
     const likeBtn = document.createElement('button');
@@ -571,6 +577,7 @@ const renderSharedPrompts = (prompts) => {
     likeRow.appendChild(likeCount);
 
     item.appendChild(text);
+    item.appendChild(nameEl);
     item.appendChild(likeRow);
     list.appendChild(item);
   });
@@ -679,11 +686,21 @@ const init = () => {
         window.lucide?.createIcons();
       }
       document.getElementById('user-email').textContent = '';
+      const nameEl = document.getElementById('user-name');
+      if (nameEl) nameEl.textContent = '';
       return;
     }
     loginBtn?.remove();
     logoutBtn?.classList.remove('hidden');
     document.getElementById('user-email').textContent = user.email || '';
+    try {
+      const profile = await getUserProfile(user.uid);
+      currentUserName = profile?.name || '';
+      const nameEl = document.getElementById('user-name');
+      if (nameEl) nameEl.textContent = currentUserName;
+    } catch (err) {
+      console.error('Failed to load profile:', err);
+    }
     try {
       const prompts = await getUserPrompts(user.uid);
       sharedPromptsData = prompts;

--- a/src/user.js
+++ b/src/user.js
@@ -1,0 +1,10 @@
+import { doc, setDoc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import { db } from './firebase.js';
+
+export const setUserProfile = (uid, profile) =>
+  setDoc(doc(db, 'users', uid, 'profile'), profile);
+
+export const getUserProfile = async (uid) => {
+  const snap = await getDoc(doc(db, 'users', uid, 'profile'));
+  return snap.exists() ? snap.data() : null;
+};


### PR DESCRIPTION
## Summary
- extend registration with a name field
- save chosen name to Firestore after registering
- display the saved name on the profile page
- show user names next to shared prompts
- expose `getUserProfile` and `setUserProfile` helpers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580e645e70832fb0dc16d3ae7c768a