### PR TITLE
Add prompt comments and like summaries

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -11,6 +11,11 @@ service cloud.firestore {
           request.resource.data.diff(resource.data).changedKeys().hasOnly(['text'])
         )
       );
+
+      match /comments/{commentId} {
+        allow read: if true;
+        allow create: if request.auth != null;
+      }
     }
   }
 }

--- a/social.html
+++ b/social.html
@@ -74,6 +74,8 @@
         likePrompt,
         unlikePrompt,
         updatePromptText,
+        addComment,
+        getComments,
       } from './src/prompt.js';
       import { appState } from './src/state.js';
       import { getUserProfile } from './src/user.js';
@@ -145,6 +147,40 @@
           const likeCount = document.createElement('span');
           likeCount.textContent = (p.likes || 0).toString();
 
+          let likedBy = p.likedBy || [];
+          const likeSummary = document.createElement('p');
+          likeSummary.className =
+            'text-xs text-blue-200 mt-1 underline cursor-pointer';
+          const likeList = document.createElement('div');
+          likeList.className = 'hidden text-xs mt-1 space-y-1';
+          likeSummary.addEventListener('click', () => {
+            likeList.classList.toggle('hidden');
+          });
+
+          const renderLikeSummary = async () => {
+            if (!likedBy.length) {
+              likeSummary.style.display = 'none';
+              likeList.innerHTML = '';
+              return;
+            }
+            likeSummary.style.display = '';
+            const names = [];
+            for (const uid of likedBy) {
+              names.push(await fetchName(uid));
+            }
+            likeList.innerHTML = names
+              .map((n) => `<div class="px-2">${n}</div>`)
+              .join('');
+            const first = names.slice(0, 3);
+            let txt = '';
+            if (first.length === 1) txt = `${first[0]} liked this`;
+            else if (first.length === 2)
+              txt = `${first[0]} and ${first[1]} liked this`;
+            else txt = `${first[0]}, ${first[1]} and ${first[2]} liked this`;
+            if (names.length > 3) txt += ` and ${names.length - 3} others`;
+            likeSummary.textContent = txt;
+          };
+
           const liked =
             appState.currentUser &&
             p.likedBy &&
@@ -178,6 +214,9 @@
                 appState.likedPrompts = appState.likedPrompts.filter(
                   (id) => id !== p.id
                 );
+                likedBy = likedBy.filter(
+                  (id) => id !== appState.currentUser.uid
+                );
                 likeBtn.classList.remove('active');
               } else {
                 await likePrompt(p.id, appState.currentUser.uid);
@@ -185,6 +224,7 @@
                   parseInt(likeCount.textContent, 10) + 1
                 ).toString();
                 appState.likedPrompts.push(p.id);
+                likedBy.push(appState.currentUser.uid);
                 likeBtn.classList.add('active');
               }
               localStorage.setItem(
@@ -192,6 +232,7 @@
                 JSON.stringify(appState.likedPrompts)
               );
               updateLikeIcon();
+              await renderLikeSummary();
             } catch (err) {
               console.error('Failed to toggle like:', err);
             } finally {
@@ -248,6 +289,60 @@
           });
 
           updateLikeIcon();
+          await renderLikeSummary();
+
+          const commentsWrap = document.createElement('div');
+          commentsWrap.className = 'mt-2 space-y-1';
+          const commentList = document.createElement('div');
+          commentsWrap.appendChild(commentList);
+          const commentForm = document.createElement('form');
+          commentForm.className = 'flex items-center gap-2 mt-1';
+          const commentInput = document.createElement('input');
+          commentInput.type = 'text';
+          commentInput.placeholder = 'Add a comment...';
+          commentInput.className = 'flex-1 p-1 rounded-md bg-black/30';
+          const commentBtn = document.createElement('button');
+          commentBtn.type = 'submit';
+          commentBtn.className =
+            'px-2 py-1 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200';
+          commentBtn.textContent = 'Post';
+          commentForm.appendChild(commentInput);
+          commentForm.appendChild(commentBtn);
+          commentsWrap.appendChild(commentForm);
+
+          const renderComment = async (c) => {
+            const name = await fetchName(c.userId);
+            const d = document.createElement('div');
+            d.className = 'bg-white/5 rounded-md px-2 py-1 text-sm';
+            d.textContent = name ? `${name}: ${c.text}` : c.text;
+            commentList.appendChild(d);
+          };
+
+          const existingComments = await getComments(p.id);
+          for (const c of existingComments) {
+            await renderComment(c);
+          }
+
+          commentForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            if (!appState.currentUser) {
+              alert('Login required');
+              return;
+            }
+            const textVal = commentInput.value.trim();
+            if (!textVal) return;
+            commentBtn.disabled = true;
+            try {
+              await addComment(p.id, appState.currentUser.uid, textVal);
+              await renderComment({
+                text: textVal,
+                userId: appState.currentUser.uid,
+              });
+              commentInput.value = '';
+            } finally {
+              commentBtn.disabled = false;
+            }
+          });
 
           likeRow.appendChild(saveBtn);
           if (appState.currentUser && p.userId === appState.currentUser.uid) {
@@ -259,6 +354,9 @@
           card.appendChild(text);
           card.appendChild(nameEl);
           card.appendChild(likeRow);
+          card.appendChild(likeSummary);
+          card.appendChild(likeList);
+          card.appendChild(commentsWrap);
           list.appendChild(card);
         }
         window.lucide?.createIcons();

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -84,3 +84,19 @@ export const getUserSavedPrompts = async (userId) => {
 
 export const updatePromptText = (promptId, newText) =>
   updateDoc(doc(db, 'prompts', promptId), { text: newText });
+
+export const addComment = (promptId, userId, text) =>
+  addDoc(collection(db, `prompts/${promptId}/comments`), {
+    text,
+    userId,
+    createdAt: Timestamp.now(),
+  });
+
+export const getComments = async (promptId) => {
+  const q = query(
+    collection(db, `prompts/${promptId}/comments`),
+    orderBy('createdAt', 'asc')
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+};


### PR DESCRIPTION
## Summary
- allow comments in Firestore under each prompt
- show comments and like summaries on social feed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685810299888832fa4594dde7bf838dc