### PR TITLE
Add fallback loader to login

### DIFF
--- a/login.html
+++ b/login.html
@@ -22,8 +22,103 @@
   <link rel="stylesheet" href="css/app.css?v=46">
   <script type="module" src="src/init-app.js?v=46"></script>
   <script nomodule src="dist/init-app.js?v=46"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=46"></script>
+  <script>
+    (function () {
+      function addScript(src, onLoad) {
+        const s = document.createElement('script');
+        s.src = src;
+        s.async = true;
+        if (onLoad) {
+          s.addEventListener('load', onLoad, { once: true });
+        }
+        document.head.appendChild(s);
+        return s;
+      }
+
+      function fetchWithTimeout(url, timeout = 500) {
+        return Promise.race([
+          fetch(url, { method: 'HEAD', mode: 'no-cors' }),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('timeout')), timeout)
+          ),
+        ]);
+      }
+
+      function loadWithFallback(primary, local) {
+        let cdnScript = null;
+        let localScript = null;
+        let resolveLoad;
+        const loadPromise = new Promise((resolve) => {
+          resolveLoad = resolve;
+        });
+
+        if (!navigator.onLine) {
+          addLocal();
+          return { cdn: null, local: localScript, loadPromise };
+        }
+
+        const addLocal = () => {
+          if (!localScript) {
+            localScript = document.createElement('script');
+            localScript.src = local;
+            localScript.async = true;
+            localScript.addEventListener('load', resolveLoad, { once: true });
+            document.head.appendChild(localScript);
+          }
+        };
+
+        let fallbackTimer = null;
+        fallbackTimer = setTimeout(() => {
+          addLocal();
+          fallbackTimer = null;
+        }, 500);
+
+        fetchWithTimeout(primary).catch(() => {
+          if (fallbackTimer) {
+            clearTimeout(fallbackTimer);
+            fallbackTimer = null;
+          }
+          addLocal();
+        });
+
+        cdnScript = addScript(primary, () => {
+          if (fallbackTimer) {
+            clearTimeout(fallbackTimer);
+            fallbackTimer = null;
+          }
+          resolveLoad();
+        });
+
+        cdnScript.onerror = () => {
+          if (fallbackTimer) {
+            clearTimeout(fallbackTimer);
+            fallbackTimer = null;
+          }
+          addLocal();
+        };
+
+        return { cdn: cdnScript, local: localScript, loadPromise };
+      }
+
+      const tailwindScripts = loadWithFallback(
+        'https://cdn.tailwindcss.com',
+        'tailwind.js?v=46'
+      );
+      window.lucideScripts = loadWithFallback(
+        'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=46',
+        'lucide.min.js?v=46'
+      );
+      Promise.all([
+        tailwindScripts.loadPromise,
+        window.lucideScripts.loadPromise,
+      ]).finally(() => {
+        const appContainer = document.getElementById('app-container');
+        const loadingScreen = document.getElementById('loading-screen');
+        if (appContainer) appContainer.style.visibility = 'visible';
+        if (loadingScreen) loadingScreen.classList.add('hidden');
+      });
+    })();
+  </script>
   <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=46">
   <script>
     const theme = localStorage.getItem('theme');


### PR DESCRIPTION
## Summary
- replicate `loadWithFallback` from main page into `login.html`
- fallback loads `tailwind.js` and `lucide.min.js` locally when CDN fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858540c1bf8832f8f71a92cbb98b728