### PR TITLE
Add username-based login

### DIFF
--- a/login.html
+++ b/login.html
@@ -131,7 +131,7 @@
   <script type="module">
 
     import { login, register, onAuth } from './src/auth.js';
-    import { setUserProfile } from './src/user.js';
+    import { setUserProfile, getUserByName } from './src/user.js';
 
     function init() {
       const loginForm = document.getElementById('login-form');
@@ -146,7 +146,7 @@
 
       loginForm.addEventListener('submit', async (e) => {
         e.preventDefault();
-        const email = document.getElementById('login-email').value;
+        let email = document.getElementById('login-email').value.trim();
         const password = document.getElementById('login-password').value;
         const btn = loginForm.querySelector('button[type="submit"]');
         const original = btn.textContent;
@@ -154,6 +154,13 @@
         btn.textContent = 'Loading...';
         authError.textContent = 'Loading...';
         try {
+          if (!email.includes('@')) {
+            const user = await getUserByName(email);
+            if (!user || !user.email) {
+              throw new Error('User not found');
+            }
+            email = user.email;
+          }
           await login(email, password);
           authError.classList.remove('text-red-500');
           authError.classList.add('text-green-500');

--- a/src/user.js
+++ b/src/user.js
@@ -1,4 +1,12 @@
-import { doc, setDoc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import {
+  doc,
+  setDoc,
+  getDoc,
+  collection,
+  query,
+  where,
+  getDocs,
+} from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { db } from './firebase.js';
 
 export const setUserProfile = (uid, profile) =>
@@ -7,4 +15,12 @@ export const setUserProfile = (uid, profile) =>
 export const getUserProfile = async (uid) => {
   const snap = await getDoc(doc(db, 'users', uid, 'profile'));
   return snap.exists() ? snap.data() : null;
+};
+
+export const getUserByName = async (name) => {
+  const q = query(collection(db, 'users'), where('name', '==', name));
+  const snap = await getDocs(q);
+  if (snap.empty) return null;
+  const d = snap.docs[0];
+  return { id: d.id, ...d.data() };
 };


### PR DESCRIPTION
## Summary
- look up users by name via Firestore
- allow login with either email or username

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685855e12d0c832fa054856fa2e619dc