### PR TITLE
Implement login/register toggle

### DIFF
--- a/login.html
+++ b/login.html
@@ -137,6 +137,20 @@
       const loginForm = document.getElementById('login-form');
       const registerForm = document.getElementById('register-form');
       const authError = document.getElementById('auth-error');
+      const showRegister = document.getElementById('show-register');
+      const showLogin = document.getElementById('show-login');
+
+      showRegister.addEventListener('click', (e) => {
+        e.preventDefault();
+        loginForm.classList.add('hidden');
+        registerForm.classList.remove('hidden');
+      });
+
+      showLogin.addEventListener('click', (e) => {
+        e.preventDefault();
+        registerForm.classList.add('hidden');
+        loginForm.classList.remove('hidden');
+      });
 
       onAuth((user) => {
         if (user) {
@@ -218,18 +232,20 @@
     </div>
     <h1 class="text-2xl font-bold text-center mb-6">Prompter</h1>
     <p id="auth-error" class="text-red-500 text-center mb-4"></p>
-    <form id="login-form" class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-4 border border-white/20 shadow-lg space-y-2">
+    <form id="login-form" class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-2 border border-white/20 shadow-lg space-y-2">
       <h2 class="text-lg font-semibold mb-2">Giriş</h2>
       <input id="login-email" type="email" placeholder="E-posta" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
       <input id="login-password" type="password" placeholder="Şifre" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
       <button type="submit" class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 rounded-lg transition-all duration-300 ease-in-out">Giriş Yap</button>
+      <p class="text-center text-sm mt-2"><a href="#" id="show-register" class="underline">Kayıt Ol</a></p>
     </form>
-    <form id="register-form" class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-4 border border-white/20 shadow-lg space-y-2">
+    <form id="register-form" class="hidden bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-2 border border-white/20 shadow-lg space-y-2">
       <h2 class="text-lg font-semibold mb-2">Kayıt</h2>
       <input id="register-email" type="email" placeholder="E-posta" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
       <input id="register-name" type="text" placeholder="Name" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
       <input id="register-password" type="password" placeholder="Şifre" required class="w-full p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50">
       <button type="submit" class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 rounded-lg transition-all duration-300 ease-in-out">Kayıt Ol</button>
+      <p class="text-center text-sm mt-2"><a href="#" id="show-login" class="underline">Girişe Dön</a></p>
     </form>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- default to showing the login form only
- allow switching between login and registration forms via links
- hide the inactive form to keep the layout clean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858570b21bc832f90f5dbeaf8f0c1e5