### PR TITLE
Update Firestore rules for user collections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,5 +17,19 @@ service cloud.firestore {
         allow create: if request.auth != null;
       }
     }
+
+    match /users/{uid} {
+      match /profile {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+
+      match /savedPrompts/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+
+      match /notifications/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- restrict access to user profile, saved prompts and notifications in Firestore rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585a2eae50832fa6504f74a529463a