### PR TITLE
Improve profile name handling

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -743,7 +743,11 @@ const init = () => {
     initNotifications(user.uid);
     try {
       const profile = await getUserProfile(user.uid);
-      currentUserName = profile?.name || '';
+      const name = profile && typeof profile.name === 'string' ? profile.name.trim() : '';
+      if (!name) {
+        console.warn('User profile is missing a name. Check registration logic.');
+      }
+      currentUserName = name;
       const nameEl = document.getElementById('user-name');
       if (nameEl) nameEl.textContent = currentUserName;
     } catch (err) {


### PR DESCRIPTION
## Summary
- check `name` from `getUserProfile` in `onAuth`
- warn if profile name missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585c751694832f90deae2745a6e9b6