### PR TITLE
Handle empty social prompt list

### DIFF
--- a/social.html
+++ b/social.html
@@ -108,6 +108,13 @@
         const list = document.getElementById('all-prompts');
         const prompts = await getAllPrompts();
         list.innerHTML = '';
+        if (!prompts || prompts.length === 0) {
+          const msg = document.createElement('p');
+          msg.className = 'text-blue-200 text-sm text-center';
+          msg.textContent = 'No shared prompts yet.';
+          list.appendChild(msg);
+          return;
+        }
         for (const p of prompts) {
           const card = document.createElement('div');
           card.className =


### PR DESCRIPTION
## Summary
- show a short informational notice on Social page when no prompts are available

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68586290e50c832f9c1c11c5f93d9832