### PR TITLE
Enable editing profile name

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -157,6 +157,19 @@
         <img id="app-logo" src="icons/logo.svg?v=46" alt="Prompter logo" class="mx-auto mb-4 w-16 h-16" />
         <h1 id="page-title" class="text-2xl font-bold mb-2">Profile</h1>
         <p id="user-name" class="text-blue-200 mb-2"></p>
+        <div class="flex justify-center gap-2 mb-2">
+          <input
+            id="name-input"
+            type="text"
+            class="p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          />
+          <button
+            id="name-update-btn"
+            class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50"
+          >
+            <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
+          </button>
+        </div>
         <p id="user-email" class="text-blue-200 mb-2"></p>
         <button
           id="logout"

--- a/src/profile.js
+++ b/src/profile.js
@@ -8,7 +8,7 @@ import {
   unsharePrompt,
   savePrompt,
 } from './prompt.js';
-import { getUserProfile } from './user.js';
+import { getUserProfile, setUserProfile } from './user.js';
 import { listenNotifications } from './notifications.js';
 import { appState, THEMES } from './state.js';
 
@@ -132,6 +132,8 @@ let langMenu;
 let currentLangLabel;
 let sharedPromptsData = [];
 let currentUserName = '';
+let nameInput;
+let nameUpdateBtn;
 let notificationBtn;
 let notificationCountEl;
 let notificationsPanel;
@@ -679,6 +681,28 @@ const init = () => {
     }
   }
 
+  nameInput = document.getElementById('name-input');
+  nameUpdateBtn = document.getElementById('name-update-btn');
+
+  nameUpdateBtn?.addEventListener('click', async () => {
+    if (!nameInput || !appState.currentUser) return;
+    const newName = nameInput.value.trim();
+    if (!newName) return;
+    nameUpdateBtn.disabled = true;
+    try {
+      await setUserProfile(appState.currentUser.uid, { name: newName });
+      currentUserName = newName;
+      const nameEl = document.getElementById('user-name');
+      if (nameEl) nameEl.textContent = currentUserName;
+      if (nameInput) nameInput.value = '';
+      renderSharedPrompts(sharedPromptsData);
+    } catch (err) {
+      console.error('Failed to update name:', err);
+    } finally {
+      nameUpdateBtn.disabled = false;
+    }
+  });
+
   langEnButton = document.getElementById('lang-en');
   langTrButton = document.getElementById('lang-tr');
   langEsButton = document.getElementById('lang-es');
@@ -779,6 +803,7 @@ const init = () => {
       document.getElementById('user-email').textContent = '';
       const nameEl = document.getElementById('user-name');
       if (nameEl) nameEl.textContent = '';
+      if (nameInput) nameInput.value = '';
       notifications = [];
       renderNotifications();
       unsubscribeNotifications?.();
@@ -797,6 +822,7 @@ const init = () => {
       currentUserName = name;
       const nameEl = document.getElementById('user-name');
       if (nameEl) nameEl.textContent = currentUserName;
+      if (nameInput) nameInput.value = currentUserName;
     } catch (err) {
       console.error('Failed to load profile:', err);
     }


### PR DESCRIPTION
## Summary
- add a textbox and save button beside the username in profile.html
- allow editing the profile name in `profile.js`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685867d7b328832f95372c935e63ddc6