### PR TITLE
Update prompt sharing logic

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,10 @@ service cloud.firestore {
       allow read: if true;
       allow create: if request.auth != null;
       allow update: if request.auth != null && (
-        request.resource.data.diff(resource.data).changedKeys().hasOnly(['likes', 'likedBy', 'sharedBy']) ||
+        request.resource.data
+          .diff(resource.data)
+          .changedKeys()
+          .hasOnly(['likes', 'likedBy', 'sharedBy', 'shared']) ||
         (
           request.auth.uid == resource.data.userId &&
           request.resource.data.diff(resource.data).changedKeys().hasOnly(['text'])

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -36,10 +36,15 @@ export const savePrompt = (text, userId) =>
     likes: 0,
     likedBy: [],
     sharedBy: [userId],
+    shared: true,
   });
 
 export const getUserPrompts = async (userId) => {
-  const q = query(collection(db, 'prompts'), where('userId', '==', userId));
+  const q = query(
+    collection(db, 'prompts'),
+    where('userId', '==', userId),
+    where('shared', '==', true)
+  );
   const snap = await getDocs(q);
   const prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
   prompts.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis());
@@ -47,7 +52,11 @@ export const getUserPrompts = async (userId) => {
 };
 
 export const getAllPrompts = async () => {
-  const q = query(collection(db, 'prompts'), orderBy('createdAt', 'desc'));
+  const q = query(
+    collection(db, 'prompts'),
+    where('shared', '==', true),
+    orderBy('createdAt', 'desc')
+  );
   const snap = await getDocs(q);
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 };
@@ -73,6 +82,7 @@ export const unlikePrompt = (promptId, userId) =>
 export const unsharePrompt = (promptId, userId) =>
   updateDoc(doc(db, 'prompts', promptId), {
     sharedBy: arrayRemove(userId),
+    shared: false,
   });
 
 export const saveUserPrompt = (text, userId) =>


### PR DESCRIPTION
## Summary
- store `shared: true` when saving prompts
- mark prompts as not shared when unsharing
- only fetch shared prompts in data queries
- update Firestore rules for the new `shared` field

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685873e2ab9c832fb6ac55058d44325c