### PR TITLE
Sync user saved prompts on auth

### DIFF
--- a/src/init-app.js
+++ b/src/init-app.js
@@ -1,9 +1,20 @@
 import { initFirebase, firebaseConfig } from './firebase.js';
 import { onAuth } from './auth.js';
 import { appState } from './state.js';
+import { getUserSavedPrompts } from './prompt.js';
 
 initFirebase(firebaseConfig);
 
-onAuth((user) => {
+onAuth(async (user) => {
   appState.currentUser = user;
+  if (!user) return;
+  try {
+    const docs = await getUserSavedPrompts(user.uid);
+    const texts = docs.map((d) => d.text);
+    const merged = Array.from(new Set([...appState.savedPrompts, ...texts]));
+    localStorage.setItem('savedPrompts', JSON.stringify(merged));
+    appState.savedPrompts = merged;
+  } catch (err) {
+    console.error('Failed to sync saved prompts:', err);
+  }
 });


### PR DESCRIPTION
## Summary
- import `getUserSavedPrompts` into `init-app.js`
- fetch saved prompts in the auth callback and merge with local state
- persist merged prompts to `localStorage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858773c366c832faf0805ebc615daf8