### PR TITLE
Exclude prompts missing sharedBy

### DIFF
--- a/src/prompt.js
+++ b/src/prompt.js
@@ -58,7 +58,11 @@ export const getAllPrompts = async () => {
     orderBy('createdAt', 'desc')
   );
   const snap = await getDocs(q);
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  return snap.docs
+    .map((d) => ({ id: d.id, ...d.data() }))
+    .filter(
+      (p) => Array.isArray(p.sharedBy) && p.sharedBy.length > 0
+    );
 };
 
 export const likePrompt = async (promptId, userId) => {


### PR DESCRIPTION
## Summary
- filter out prompts where `sharedBy` is empty in `getAllPrompts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685878e07eec832fb58cd7cb24cc773c