### PR TITLE
Use Firestore server timestamps

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -4,14 +4,14 @@ import {
   orderBy,
   query,
   onSnapshot,
-  Timestamp,
+  serverTimestamp,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { db } from './firebase.js';
 
 export const sendNotification = (uid, data) =>
   addDoc(collection(db, `users/${uid}/notifications`), {
     ...data,
-    createdAt: Timestamp.now(),
+    createdAt: serverTimestamp(),
   });
 
 export const listenNotifications = (uid, cb) => {

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -6,7 +6,7 @@ import {
   getDocs,
   getDoc,
   orderBy,
-  Timestamp,
+  serverTimestamp,
   updateDoc,
   doc,
   increment,
@@ -32,7 +32,7 @@ export const savePrompt = (text, userId) =>
   addDoc(collection(db, 'prompts'), {
     text,
     userId,
-    createdAt: Timestamp.now(),
+    createdAt: serverTimestamp(),
     likes: 0,
     likedBy: [],
     sharedBy: [userId],
@@ -92,7 +92,7 @@ export const unsharePrompt = (promptId, userId) =>
 export const saveUserPrompt = (text, userId) =>
   addDoc(collection(db, `users/${userId}/savedPrompts`), {
     text,
-    createdAt: Timestamp.now(),
+    createdAt: serverTimestamp(),
   });
 
 export const getUserSavedPrompts = async (userId) => {
@@ -111,7 +111,7 @@ export const addComment = async (promptId, userId, text) => {
   await addDoc(collection(db, `prompts/${promptId}/comments`), {
     text,
     userId,
-    createdAt: Timestamp.now(),
+    createdAt: serverTimestamp(),
   });
   const snap = await getDoc(doc(db, 'prompts', promptId));
   const owner = snap.exists() ? snap.data().userId : null;


### PR DESCRIPTION
## Summary
- use `serverTimestamp` when creating prompts, saved prompts, comments and notifications
- remove unused `Timestamp` imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685879b69be4832fb831304d10f44bf3