### PR TITLE
Fix user prompt filtering to check sharedBy

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "sharedBy", "arrayConfig": "CONTAINS" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -43,12 +43,17 @@ export const getUserPrompts = async (userId) => {
   const q = query(
     collection(db, 'prompts'),
     where('userId', '==', userId),
-    where('shared', '==', true)
+    where('sharedBy', 'array-contains', userId)
   );
-  const snap = await getDocs(q);
-  const prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-  prompts.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis());
-  return prompts;
+  try {
+    const snap = await getDocs(q);
+    const prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    prompts.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis());
+    return prompts;
+  } catch (err) {
+    console.error('Failed to load user prompts:', err);
+    return [];
+  }
 };
 
 export const getAllPrompts = async () => {


### PR DESCRIPTION
## Summary
- filter `getUserPrompts` so only prompts still shared by the user are returned
- handle Firestore query errors and provide index definition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68587bebff9c832fa1059a59c84e5cb2