### PR TITLE
Handle Firestore snapshot errors

### DIFF
--- a/social.html
+++ b/social.html
@@ -416,10 +416,18 @@
           where('shared', '==', true),
           orderBy('createdAt', 'desc')
         );
-        onSnapshot(q, async (snap) => {
-          const prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-          await render(prompts);
-        });
+        onSnapshot(
+          q,
+          async (snap) => {
+            const prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+            await render(prompts);
+          },
+          (err) => {
+            console.error('Failed to load prompts:', err);
+            document.getElementById('all-prompts').textContent =
+              'Failed to load prompts.';
+          }
+        );
       }
 
       document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- show Firestore snapshot errors on Social page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685881803568832fa8d14bd33ac37747