### PR TITLE
Improve Firestore error messages in social page

### DIFF
--- a/social.html
+++ b/social.html
@@ -425,8 +425,16 @@
           },
           (err) => {
             console.error('Failed to load prompts:', err);
-            document.getElementById('all-prompts').textContent =
-              'Failed to load prompts.';
+            const list = document.getElementById('all-prompts');
+            if (err.code === 'failed-precondition') {
+              list.textContent =
+                'Firestore indexes are still building. Please refresh later.';
+            } else if (err.code === 'permission-denied') {
+              list.textContent =
+                'You don’t have permission to read prompts.';
+            } else {
+              list.textContent = err.message;
+            }
           }
         );
       }


### PR DESCRIPTION
## Summary
- handle Firestore `onSnapshot` errors in `social.html`
- show tailored messages for `failed-precondition` and `permission-denied`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589ac64ba8832fa6c991322d118d19