### PR TITLE
Fix theme version reuse

### DIFF
--- a/login.html
+++ b/login.html
@@ -121,10 +121,15 @@
   </script>
   <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=47">
   <script>
-    const theme = localStorage.getItem('theme');
-    if (theme) {
-      document.getElementById('theme-css').href = `css/theme-${theme}.css?v=31`;
-    }
+    (function () {
+      const linkEl = document.getElementById('theme-css');
+      if (!linkEl) return;
+      const version = linkEl.getAttribute('href').split('?')[1];
+      const theme = localStorage.getItem('theme');
+      if (theme) {
+        linkEl.href = `css/theme-${theme}.css${version ? `?${version}` : ''}`;
+      }
+    })();
   </script>
   <script type="module" src="src/auth.js?v=47"></script>
   <script nomodule src="dist/auth.js?v=47"></script>

--- a/profile.html
+++ b/profile.html
@@ -15,9 +15,10 @@
       (function () {
         const linkEl = document.getElementById('theme-css');
         if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
         const savedTheme = localStorage.getItem('theme');
         if (savedTheme) {
-          linkEl.href = `css/theme-${savedTheme}.css?v=31`;
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- reuse the current `theme-css` version when changing themes in login and profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589c0eb21c832f881b307f7913ab86