### PR TITLE
Fix user profile path in Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To backfill older accounts with a root-level name field run:
 node scripts/migrate-user-names.js
 ```
 
-This script copies the `name` from `users/{uid}/profile` into the parent
+This script copies the `name` from `users/{uid}/profile/info` into the parent
 `users/{uid}` document when missing.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full setup instructions and the pull

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,7 +22,7 @@ service cloud.firestore {
     }
 
     match /users/{uid} {
-      match /profile {
+      match /profile/{docId} {
         allow read, write: if request.auth != null && request.auth.uid == uid;
       }
 

--- a/scripts/migrate-user-names.js
+++ b/scripts/migrate-user-names.js
@@ -10,7 +10,7 @@ async function migrate() {
   const usersSnap = await db.collection('users').get();
   for (const user of usersSnap.docs) {
     if (user.get('name')) continue;
-    const profileSnap = await db.doc(`users/${user.id}/profile`).get();
+    const profileSnap = await db.doc(`users/${user.id}/profile/info`).get();
     const profile = profileSnap.exists ? profileSnap.data() : null;
     if (profile && profile.name) {
       await user.ref.set({ name: profile.name }, { merge: true });

--- a/src/user.js
+++ b/src/user.js
@@ -10,14 +10,14 @@ import {
 import { db } from './firebase.js';
 
 export const setUserProfile = async (uid, profile) => {
-  await setDoc(doc(db, 'users', uid, 'profile'), profile);
+  await setDoc(doc(db, 'users', uid, 'profile', 'info'), profile);
   if (profile && profile.name) {
     await setDoc(doc(db, 'users', uid), { name: profile.name }, { merge: true });
   }
 };
 
 export const getUserProfile = async (uid) => {
-  const snap = await getDoc(doc(db, 'users', uid, 'profile'));
+  const snap = await getDoc(doc(db, 'users', uid, 'profile', 'info'));
   return snap.exists() ? snap.data() : null;
 };
 


### PR DESCRIPTION
## Summary
- save profiles under a valid document
- read profile data with the corrected path in the migration script
- update security rules for new subcollection path
- clarify profile path in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591f74c4c4832fa61c9ad6178af40f