### PR TITLE
Update README for new Tailwind build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,14 @@ across contributions. To serve the application locally during development run:
 npm start
 ```
 
-After editing `src/styles.css` generate the compiled file with:
+After editing `src/styles.css`, build the final Tailwind stylesheet by running:
 
 ```bash
 npm run build:css
 ```
+
+This command invokes the Tailwind CLI to compile `src/styles.css` into
+`css/tailwind.css`.
 
 To backfill older accounts with a root-level name field run:
 


### PR DESCRIPTION
## Summary
- clarify that `npm run build:css` compiles Tailwind CSS

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685937ab00c4832f9dbc6f5e81f13f3c