### PR TITLE
Trigger css build when style changes

### DIFF
--- a/scripts/run-build-if-needed.js
+++ b/scripts/run-build-if-needed.js
@@ -13,12 +13,24 @@ function hasRelevantChanges(files) {
     (f) =>
       f.endsWith('.html') ||
       f.startsWith('prompts/') ||
-      (f.startsWith('src/') && f.endsWith('.js'))
+      (f.startsWith('src/') && f.endsWith('.js')) ||
+      f === 'src/styles.css' ||
+      f === 'tailwind.config.js'
   );
+}
+
+function hasCssChanges(files) {
+  return files.some((f) => f === 'src/styles.css' || f === 'tailwind.config.js');
 }
 
 const changed = getChangedFiles();
 if (hasRelevantChanges(changed)) {
-  console.log('HTML, prompts, or JavaScript changes detected. Running build...');
+  const cssChanged = hasCssChanges(changed);
+  console.log(
+    'HTML, prompts, JavaScript, or CSS changes detected. Running build...'
+  );
+  if (cssChanged) {
+    execSync('npm run build:css', { stdio: 'inherit' });
+  }
   execSync('npm run build', { stdio: 'inherit' });
 }


### PR DESCRIPTION
## Summary
- update hasRelevantChanges to watch src/styles.css and tailwind.config.js
- run `npm run build:css` before the main build when style files change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685938d0baec832fa396d6f2d0dff12f