### PR TITLE
Ensure consistent cache meta tags

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,21 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Cache-Control"
-      content="no-cache, no-store, must-revalidate"
-    />
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('sw.js').catch(() => {});
       }
     </script>
-    <meta http-equiv="Pragma" content="no-cache" />
-    <meta http-equiv="Expires" content="0" />
     <title>404 - Page Not Found</title>
     <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=47" />
     <link rel="manifest" href="manifest.json?v=47" />
     <meta name="theme-color" content="#000000" />
+      <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
     <link rel="stylesheet" href="css/app.css?v=47" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=47" />
     <script>

--- a/login.html
+++ b/login.html
@@ -29,6 +29,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Prompter Login</title>
     <base href="./" />
+    <link rel="manifest" href="manifest.json?v=47" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link rel="stylesheet" href="css/tailwind.css?v=47" />
     <link rel="stylesheet" href="css/app.css?v=47" />
     <script type="module" src="src/init-app.js?v=47"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -7,17 +7,14 @@
     <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=47" />
     <link rel="manifest" href="manifest.json?v=47" />
     <meta name="theme-color" content="#000000" />
+      <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('sw.js').catch(() => {});
       }
     </script>
-    <meta
-      http-equiv="Cache-Control"
-      content="no-cache, no-store, must-revalidate"
-    />
-    <meta http-equiv="Pragma" content="no-cache" />
-    <meta http-equiv="Expires" content="0" />
     <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=47" />
     <link rel="stylesheet" href="css/app.css?v=47" />

--- a/pro.html
+++ b/pro.html
@@ -7,6 +7,9 @@
     <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=47" />
     <link rel="manifest" href="manifest.json?v=47" />
     <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link rel="stylesheet" href="css/app.css?v=47" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=47" />
     <script>

--- a/profile.html
+++ b/profile.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Profile - Prompter</title>
     <base href="./" />
+    <link rel="manifest" href="manifest.json?v=47" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link rel="stylesheet" href="css/tailwind.css?v=47" />
     <link rel="stylesheet" href="css/app.css?v=47" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=47"></script>

--- a/social.html
+++ b/social.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Prompter Social</title>
     <base href="./" />
+    <link rel="manifest" href="manifest.json?v=47" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link rel="stylesheet" href="css/tailwind.css?v=47" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=47"></script>
     <link rel="stylesheet" href="css/app.css?v=47" />

--- a/sw.js
+++ b/sw.js
@@ -8,11 +8,15 @@ self.addEventListener('activate', (event) => {
     try {
       const keys = await caches.keys();
       await Promise.all(keys.map((k) => caches.delete(k)));
-    } catch {}
+    } catch {
+      // ignore
+    }
 
     try {
       await self.registration.unregister();
-    } catch {}
+    } catch {
+      // ignore
+    }
 
     const clients = await self.clients.matchAll({
       type: 'window',


### PR DESCRIPTION
## Summary
- add cache control meta tags to all site pages
- insert missing manifest and theme-color tags
- fix ESLint warnings in `sw.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685944e52d08832f806a8095cd6eb919