### PR TITLE
Enable inline editing for user name

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -180,8 +180,10 @@
           class="mx-auto mb-4 w-16 h-16"
         />
         <h1 id="page-title" class="text-2xl font-bold mb-2">Profile</h1>
-        <p id="user-name" class="text-blue-200 mb-2"></p>
-        <div class="flex justify-center gap-2 mb-2">
+        <div id="user-name-wrapper" class="mb-2">
+          <p id="user-name" class="text-blue-200 cursor-pointer"></p>
+        </div>
+        <div id="name-edit-row" class="flex justify-center gap-2 mb-2 hidden">
           <input
             id="name-input"
             type="text"

--- a/src/profile.js
+++ b/src/profile.js
@@ -132,6 +132,8 @@ let langMenu;
 let currentLangLabel;
 let sharedPromptsData = [];
 let currentUserName = '';
+let nameWrapper;
+let nameEditRow;
 let nameInput;
 let nameUpdateBtn;
 let notificationBtn;
@@ -681,8 +683,18 @@ const init = () => {
     }
   }
 
+  nameWrapper = document.getElementById('user-name-wrapper');
+  nameEditRow = document.getElementById('name-edit-row');
   nameInput = document.getElementById('name-input');
   nameUpdateBtn = document.getElementById('name-update-btn');
+
+  nameWrapper?.addEventListener('click', () => {
+    if (!nameWrapper || !nameEditRow || !nameInput) return;
+    nameInput.value = currentUserName;
+    nameWrapper.classList.add('hidden');
+    nameEditRow.classList.remove('hidden');
+    nameInput.focus();
+  });
 
   nameUpdateBtn?.addEventListener('click', async () => {
     if (!nameInput || !appState.currentUser) return;
@@ -694,7 +706,8 @@ const init = () => {
       currentUserName = newName;
       const nameEl = document.getElementById('user-name');
       if (nameEl) nameEl.textContent = currentUserName;
-      if (nameInput) nameInput.value = '';
+      nameEditRow?.classList.add('hidden');
+      nameWrapper?.classList.remove('hidden');
       renderSharedPrompts(sharedPromptsData);
     } catch (err) {
       console.error('Failed to update name:', err);
@@ -804,6 +817,8 @@ const init = () => {
       const nameEl = document.getElementById('user-name');
       if (nameEl) nameEl.textContent = '';
       if (nameInput) nameInput.value = '';
+      nameEditRow?.classList.add('hidden');
+      nameWrapper?.classList.remove('hidden');
       notifications = [];
       renderNotifications();
       unsubscribeNotifications?.();
@@ -823,6 +838,8 @@ const init = () => {
       const nameEl = document.getElementById('user-name');
       if (nameEl) nameEl.textContent = currentUserName;
       if (nameInput) nameInput.value = currentUserName;
+      nameEditRow?.classList.add('hidden');
+      nameWrapper?.classList.remove('hidden');
     } catch (err) {
       console.error('Failed to load profile:', err);
     }


### PR DESCRIPTION
## Summary
- wrap displayed username in `#user-name-wrapper`
- show a hidden edit input `#name-edit-row` for editing
- toggle editing when clicking the name and save changes with `setUserProfile`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68596e264b58832f9ce6b2639109215d