### PR TITLE
Add user profile page

### DIFF
--- a/social.html
+++ b/social.html
@@ -147,8 +147,8 @@
           text.textContent = p.text;
 
           const nameEl = document.createElement('p');
-          nameEl.className = 'text-blue-200 text-sm mt-1';
-          nameEl.textContent = names[i];
+          nameEl.className = 'text-blue-200 text-sm mt-1 underline';
+          nameEl.innerHTML = `<a href="user.html?uid=${p.userId}">${names[i]}</a>`;
 
           const likeRow = document.createElement('div');
           likeRow.className = 'flex items-center gap-2 mt-2';
@@ -209,7 +209,7 @@
               names.push(await fetchName(uid));
             }
             likeList.innerHTML = names
-              .map((n) => `<div class="px-2">${n}</div>`)
+              .map((n, idx) => `<div class="px-2"><a href="user.html?uid=${likedBy[idx]}" class="underline">${n}</a></div>`)
               .join('');
             const first = names.slice(0, 3);
             let txt = '';
@@ -371,7 +371,9 @@
             const name = await fetchName(c.userId);
             const d = document.createElement('div');
             d.className = 'bg-white/5 rounded-md px-2 py-1 text-sm';
-            d.textContent = name ? `${name}: ${c.text}` : c.text;
+            d.innerHTML = name
+              ? `<a href="user.html?uid=${c.userId}" class="underline">${name}</a>: ${c.text}`
+              : c.text;
             commentList.appendChild(d);
           };
 

--- a/src/user-page.js
+++ b/src/user-page.js
@@ -1,0 +1,69 @@
+import { getUserByName, getUserProfile } from './user.js';
+import { getUserPrompts } from './prompt.js';
+import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import { db } from './firebase.js';
+
+const getParam = (key) => new URLSearchParams(window.location.search).get(key);
+
+const fetchCommentsCount = async (promptId) => {
+  const snap = await getDocs(collection(db, `prompts/${promptId}/comments`));
+  return snap.size;
+};
+
+const renderPrompts = async (prompts) => {
+  const list = document.getElementById('prompt-list');
+  list.innerHTML = '';
+  let likes = 0;
+  let comments = 0;
+  let shares = 0;
+
+  for (const p of prompts) {
+    likes += p.likes || (Array.isArray(p.likedBy) ? p.likedBy.length : 0);
+    shares += Array.isArray(p.sharedBy) ? p.sharedBy.length : 0;
+    comments += await fetchCommentsCount(p.id);
+
+    const card = document.createElement('div');
+    card.className =
+      'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
+    const text = document.createElement('p');
+    text.textContent = p.text;
+    card.appendChild(text);
+    list.appendChild(card);
+  }
+
+  document.getElementById('stat-prompts').textContent = prompts.length.toString();
+  document.getElementById('stat-likes').textContent = likes.toString();
+  document.getElementById('stat-comments').textContent = comments.toString();
+  document.getElementById('stat-saves').textContent = '0';
+  document.getElementById('stat-shares').textContent = shares.toString();
+
+  window.lucide?.createIcons();
+};
+
+const init = async () => {
+  let uid = getParam('uid');
+  const nameQuery = getParam('name');
+  let name = '';
+
+  if (!uid && nameQuery) {
+    const user = await getUserByName(nameQuery);
+    if (user) {
+      uid = user.id;
+      name = user.name || nameQuery;
+    }
+  }
+
+  if (!uid) {
+    document.getElementById('user-name').textContent = 'User not found';
+    return;
+  }
+
+  const profile = await getUserProfile(uid);
+  if (profile && profile.name) name = profile.name;
+
+  document.getElementById('user-name').textContent = name || uid;
+  const prompts = await getUserPrompts(uid);
+  await renderPrompts(prompts);
+};
+
+document.addEventListener('DOMContentLoaded', init);

--- a/user.html
+++ b/user.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>User - Prompter</title>
+    <base href="./" />
+    <link rel="manifest" href="manifest.json?v=50" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link rel="stylesheet" href="css/tailwind.css?v=50" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=50"></script>
+    <link rel="stylesheet" href="css/app.css?v=50" />
+    <script type="module" src="src/init-app.js?v=50"></script>
+    <script nomodule src="dist/init-app.js?v=50"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=50" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/user-page.js?v=50"></script>
+    <script nomodule src="dist/user-page.js?v=50"></script>
+    <script type="module" src="src/version.js?v=50"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="max-w-xl mx-auto relative">
+      <div class="absolute top-4 left-4">
+        <a
+          href="social.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <div class="absolute top-4 right-4 flex items-center gap-2">
+        <button
+          id="theme-light"
+          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Light Theme"
+          aria-label="Light Theme"
+        >
+          <i data-lucide="sun" class="w-5 h-5" aria-hidden="true"></i>
+        </button>
+        <button
+          id="theme-dark"
+          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Dark Theme"
+          aria-label="Dark Theme"
+        >
+          <i data-lucide="moon" class="w-5 h-5" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="text-center mb-6 pt-16">
+        <img src="icons/logo.svg?v=50" alt="Prompter logo" class="mx-auto mb-4 w-16 h-16" />
+        <h1 id="user-name" class="text-2xl font-bold mb-2"></h1>
+        <div class="space-x-2 text-sm text-blue-200">
+          <span>Prompts: <span id="stat-prompts">0</span></span>
+          <span>Likes: <span id="stat-likes">0</span></span>
+          <span>Comments: <span id="stat-comments">0</span></span>
+          <span>Saves: <span id="stat-saves">0</span></span>
+          <span>Shares: <span id="stat-shares">0</span></span>
+        </div>
+      </div>
+      <div id="prompt-list" class="space-y-4"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add new `user.html` page to view users and shared prompts
- create `src/user-page.js` to load profile data from Firestore
- link usernames in `social.html` to the new profile page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68596fbca800832fa01d5d5442a9996a