### PR TITLE
Enable click-to-edit on prompt text

### DIFF
--- a/social.html
+++ b/social.html
@@ -360,6 +360,13 @@
           editBtn.innerHTML =
             '<i data-lucide="pencil" class="w-4 h-4" aria-hidden="true"></i>';
 
+          // allow clicking the text itself to start editing
+          text.addEventListener('click', () => {
+            if (appState.currentUser && p.userId === appState.currentUser.uid) {
+              editBtn.click();
+            }
+          });
+
           const unshareBtn = document.createElement('button');
           unshareBtn.className =
             'p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';

--- a/src/profile.js
+++ b/src/profile.js
@@ -311,6 +311,10 @@ const renderSavedPrompts = (prompts) => {
     editBtn.innerHTML =
       '<i data-lucide="pencil" class="w-4 h-4" aria-hidden="true"></i>';
 
+
+    // allow direct click on the prompt text to start editing
+    pEl.addEventListener('click', () => editBtn.click());
+
     const copyBtn = document.createElement('button');
     copyBtn.className =
       'history-copy p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
@@ -534,6 +538,8 @@ const renderSharedPrompts = (prompts) => {
       'p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
     editBtn.innerHTML =
       '<i data-lucide="pencil" class="w-4 h-4" aria-hidden="true"></i>';
+    // clicking the prompt text also starts editing
+    text.addEventListener('click', () => editBtn.click());
 
     const copyBtn = document.createElement('button');
     copyBtn.className =


### PR DESCRIPTION
## Summary
- allow clicking prompt text in Social and Profile pages to trigger editing
- wire saved prompt cards to use the same edit action on text click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685978cc0038832f99535f11821f3c47