### PR TITLE
Add prompt interaction stats

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -143,6 +143,13 @@
           <i data-lucide="log-out" class="w-4 h-4" aria-hidden="true"></i>
           <span>Logout</span>
         </button>
+        <div class="space-x-2 text-sm text-blue-200 my-4 text-center">
+          <span>Prompts: <span id="stat-prompts">0</span></span>
+          <span>Likes: <span id="stat-likes">0</span></span>
+          <span>Comments: <span id="stat-comments">0</span></span>
+          <span>Saves: <span id="stat-saves">0</span></span>
+          <span>Shares: <span id="stat-shares">0</span></span>
+        </div>
       </div>
       <section class="mb-6">
         <h2 class="text-xl font-semibold mb-2">

--- a/social.html
+++ b/social.html
@@ -92,6 +92,8 @@
         saveUserPrompt,
         sharePromptByUser,
         unsharePromptByUser,
+        incrementSaveCount,
+        incrementShareCount,
       } from './src/prompt.js';
       import { appState } from './src/state.js';
       import { getUserProfile } from './src/user.js';
@@ -176,6 +178,7 @@
               );
               if (appState.currentUser) {
                 await saveUserPrompt(p.text, appState.currentUser.uid);
+                await incrementSaveCount(p.id);
               }
               alert('Prompt saved!');
             } catch (err) {
@@ -332,9 +335,11 @@
             try {
               if (sharedByCurrent) {
                 await unsharePromptByUser(p.id, appState.currentUser.uid);
+                await incrementShareCount(p.id, -1);
                 sharedByCurrent = false;
               } else {
                 await sharePromptByUser(p.id, appState.currentUser.uid);
+                await incrementShareCount(p.id, 1);
                 sharedByCurrent = true;
               }
               updateShareToggle();
@@ -352,6 +357,7 @@
             '<i data-lucide="twitter" class="w-4 h-4" aria-hidden="true"></i>';
           twitterBtn.addEventListener('click', () => {
             sharePrompt(p.text, 'https://twitter.com/intent/tweet?text=');
+            incrementShareCount(p.id);
           });
 
           const editBtn = document.createElement('button');

--- a/src/profile.js
+++ b/src/profile.js
@@ -7,6 +7,7 @@ import {
   updatePromptText,
   unsharePrompt,
   savePrompt,
+  incrementShareCount,
 } from './prompt.js';
 import { getUserProfile, setUserProfile } from './user.js';
 import { listenNotifications } from './notifications.js';
@@ -247,6 +248,27 @@ const updateCount = (id, count) => {
   if (el) el.textContent = count.toString();
 };
 
+const updateStats = (prompts) => {
+  const totals = {
+    prompts: prompts.length,
+    likes: 0,
+    comments: 0,
+    saves: 0,
+    shares: 0,
+  };
+  prompts.forEach((p) => {
+    totals.likes += p.likes || (Array.isArray(p.likedBy) ? p.likedBy.length : 0);
+    totals.comments += p.commentCount || 0;
+    totals.saves += p.saveCount || 0;
+    totals.shares += p.shareCount || (Array.isArray(p.sharedBy) ? p.sharedBy.length : 0);
+  });
+  updateCount('stat-prompts', totals.prompts);
+  updateCount('stat-likes', totals.likes);
+  updateCount('stat-comments', totals.comments);
+  updateCount('stat-saves', totals.saves);
+  updateCount('stat-shares', totals.shares);
+};
+
 const renderNotifications = () => {
   if (!notificationCountEl || !notificationsPanel) return;
   const unread = notifications.filter((n) => !n.read);
@@ -446,6 +468,7 @@ const renderSharedPrompts = (prompts) => {
   const list = document.getElementById('shared-list');
   list.innerHTML = '';
   updateCount('shared-count', prompts.length);
+  updateStats(prompts);
   if (!prompts || prompts.length === 0) {
     const p = document.createElement('p');
     p.textContent = uiText[appState.language].noPrompts;
@@ -649,6 +672,7 @@ const renderSharedPrompts = (prompts) => {
 
     shareBtn.addEventListener('click', () => {
       sharePrompt(text.textContent || '', 'https://twitter.com/intent/tweet?text=');
+      incrementShareCount(p.id);
     });
 
     delBtn.addEventListener('click', async () => {

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -37,6 +37,9 @@ export const savePrompt = (text, userId) =>
     likedBy: [],
     sharedBy: [userId],
     shared: true,
+    saveCount: 0,
+    shareCount: 1,
+    commentCount: 0,
   });
 
 export const getUserPrompts = async (userId) => {
@@ -98,11 +101,13 @@ export const sharePromptByUser = (promptId, userId) =>
   updateDoc(doc(db, 'prompts', promptId), {
     sharedBy: arrayUnion(userId),
     shared: true,
+    shareCount: increment(1),
   });
 
 export const unsharePromptByUser = (promptId, userId) =>
   updateDoc(doc(db, 'prompts', promptId), {
     sharedBy: arrayRemove(userId),
+    shareCount: increment(-1),
   });
 
 export const saveUserPrompt = (text, userId) =>
@@ -110,6 +115,12 @@ export const saveUserPrompt = (text, userId) =>
     text,
     createdAt: serverTimestamp(),
   });
+
+export const incrementSaveCount = (promptId) =>
+  updateDoc(doc(db, 'prompts', promptId), { saveCount: increment(1) });
+
+export const incrementShareCount = (promptId, delta = 1) =>
+  updateDoc(doc(db, 'prompts', promptId), { shareCount: increment(delta) });
 
 export const getUserSavedPrompts = async (userId) => {
   const q = query(
@@ -128,6 +139,9 @@ export const addComment = async (promptId, userId, text) => {
     text,
     userId,
     createdAt: serverTimestamp(),
+  });
+  await updateDoc(doc(db, 'prompts', promptId), {
+    commentCount: increment(1),
   });
   const snap = await getDoc(doc(db, 'prompts', promptId));
   const owner = snap.exists() ? snap.data().userId : null;

--- a/src/user-page.js
+++ b/src/user-page.js
@@ -1,14 +1,8 @@
 import { getUserByName, getUserProfile } from './user.js';
 import { getUserPrompts } from './prompt.js';
-import { collection, getDocs } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+
 
 const getParam = (key) => new URLSearchParams(window.location.search).get(key);
-
-const fetchCommentsCount = async (promptId) => {
-  const snap = await getDocs(collection(db, `prompts/${promptId}/comments`));
-  return snap.size;
-};
 
 const renderPrompts = async (prompts) => {
   const list = document.getElementById('prompt-list');
@@ -16,11 +10,13 @@ const renderPrompts = async (prompts) => {
   let likes = 0;
   let comments = 0;
   let shares = 0;
+  let saves = 0;
 
   for (const p of prompts) {
     likes += p.likes || (Array.isArray(p.likedBy) ? p.likedBy.length : 0);
-    shares += Array.isArray(p.sharedBy) ? p.sharedBy.length : 0;
-    comments += await fetchCommentsCount(p.id);
+    shares += p.shareCount || (Array.isArray(p.sharedBy) ? p.sharedBy.length : 0);
+    saves += p.saveCount || 0;
+    comments += p.commentCount || 0;
 
     const card = document.createElement('div');
     card.className =
@@ -34,7 +30,7 @@ const renderPrompts = async (prompts) => {
   document.getElementById('stat-prompts').textContent = prompts.length.toString();
   document.getElementById('stat-likes').textContent = likes.toString();
   document.getElementById('stat-comments').textContent = comments.toString();
-  document.getElementById('stat-saves').textContent = '0';
+  document.getElementById('stat-saves').textContent = saves.toString();
   document.getElementById('stat-shares').textContent = shares.toString();
 
   window.lucide?.createIcons();


### PR DESCRIPTION
## Summary
- track saves/shares/comments in `prompts` documents
- update counts when users save, share or comment
- show total stats on profile and user pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597c5cea90832fa3fd2c0fe536d3f1