### PR TITLE
Show ads on more category buttons

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -868,7 +868,9 @@ const setupEventListeners = () => {
     const button = document.getElementById(`category-${category.id}`);
     if (button) {
       button.addEventListener('click', () => {
-        if (category.id === 'random') {
+        if (
+          ['random', 'hellprompts', 'ai', 'educational'].includes(category.id)
+        ) {
           window.open('https://otieu.com/4/9472472', '_blank');
         }
         appState.selectedCategory = category.id;


### PR DESCRIPTION
## Summary
- show ad link when clicking hellprompts, AI, or educational categories just like the Random button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859868cbe5c832f891a3b9b1486fb77