### PR TITLE
Use grid layout for saved and shared lists

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -131,7 +131,7 @@
             >0</span
           >)
         </h2>
-        <div id="saved-list" class="space-y-4"></div>
+        <div id="saved-list" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
       </section>
 
       <section class="mb-6">
@@ -141,7 +141,7 @@
             >0</span
           >)
         </h2>
-        <div id="shared-list" class="space-y-4"></div>
+        <div id="shared-list" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
       </section>
     </div>
   </body>

--- a/social.html
+++ b/social.html
@@ -79,7 +79,7 @@
           </button>
         </div>
       </header>
-        <div id="all-prompts" class="space-y-4"></div>
+        <div id="all-prompts" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
       </div>
     <script type="module">
       import {
@@ -154,7 +154,7 @@
           const p = prompts[i];
           const card = document.createElement('div');
           card.className =
-            'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
+            'col-span-1 bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
 
           const text = document.createElement('p');
           text.textContent = p.text;

--- a/src/profile.js
+++ b/src/profile.js
@@ -317,7 +317,7 @@ const renderSavedPrompts = (prompts) => {
   prompts.forEach((text, idx) => {
     const item = document.createElement('div');
     item.className =
-      'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
+      'col-span-1 bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
 
     const pEl = document.createElement('p');
     pEl.textContent = text;
@@ -476,7 +476,7 @@ const renderSharedPrompts = (prompts) => {
   prompts.forEach((p, idx) => {
     const item = document.createElement('div');
     item.className =
-      'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
+      'col-span-1 bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
 
     const text = document.createElement('p');
     text.textContent = p.text;


### PR DESCRIPTION
## Summary
- use a responsive grid layout for saved and shared prompts
- style JS generated items as grid cells

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685995f13d68832f84745010777d6ab1