### PR TITLE
Update share button styles

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -254,3 +254,9 @@ html {
   fill: currentColor;
   stroke: none;
 }
+
+.share-toggle.active svg,
+.history-site-share.active svg {
+  fill: currentColor;
+  stroke: none;
+}

--- a/social.html
+++ b/social.html
@@ -311,9 +311,9 @@
 
           const shareToggleBtn = document.createElement('button');
           shareToggleBtn.className =
-            'share-toggle flex items-center gap-1 p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+            'share-toggle p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
           shareToggleBtn.innerHTML =
-            '<i data-lucide="share-2" class="w-4 h-4" aria-hidden="true"></i> <span></span>';
+            '<i data-lucide="share-2" class="w-4 h-4" aria-hidden="true"></i>';
 
           let sharedByCurrent =
             appState.currentUser &&
@@ -322,10 +322,12 @@
 
           const updateShareToggle = () => {
             const icon = shareToggleBtn.querySelector('svg');
-            const textEl = shareToggleBtn.querySelector('span');
+            shareToggleBtn.classList.toggle('active', sharedByCurrent);
+            const label = sharedByCurrent ? 'Unshare' : 'Share';
+            shareToggleBtn.title = label;
+            shareToggleBtn.setAttribute('aria-label', label);
             if (icon)
               icon.setAttribute('fill', sharedByCurrent ? 'currentColor' : 'none');
-            if (textEl) textEl.textContent = sharedByCurrent ? 'Unshare' : 'Share';
           };
           updateShareToggle();
 
@@ -356,6 +358,8 @@
           const twitterBtn = document.createElement('button');
           twitterBtn.className =
             'p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+          twitterBtn.title = 'Share on Twitter';
+          twitterBtn.setAttribute('aria-label', 'Share on Twitter');
           twitterBtn.innerHTML =
             '<i data-lucide="twitter" class="w-4 h-4" aria-hidden="true"></i>';
           twitterBtn.addEventListener('click', () => {

--- a/src/profile.js
+++ b/src/profile.js
@@ -350,12 +350,16 @@ const renderSavedPrompts = (prompts) => {
     const shareBtn = document.createElement('button');
     shareBtn.className =
       'history-share p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+    shareBtn.title = 'Share on Twitter';
+    shareBtn.setAttribute('aria-label', 'Share on Twitter');
     shareBtn.innerHTML =
       '<i data-lucide="twitter" class="w-3 h-3" aria-hidden="true"></i>';
 
     const siteShareBtn = document.createElement('button');
     siteShareBtn.className =
       'history-site-share p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+    siteShareBtn.title = 'Share on Prompter';
+    siteShareBtn.setAttribute('aria-label', 'Share on Prompter');
     siteShareBtn.innerHTML =
       '<i data-lucide="share-2" class="w-3 h-3" aria-hidden="true"></i>';
 
@@ -423,6 +427,13 @@ const renderSavedPrompts = (prompts) => {
         alert('Login required to share');
         return;
       }
+      siteShareBtn.classList.toggle('active');
+      const svg = siteShareBtn.querySelector('svg');
+      if (svg)
+        svg.setAttribute(
+          'fill',
+          siteShareBtn.classList.contains('active') ? 'currentColor' : 'none'
+        );
       siteShareBtn.disabled = true;
       try {
         await savePrompt(pEl.textContent || '', appState.currentUser.uid);
@@ -577,6 +588,8 @@ const renderSharedPrompts = (prompts) => {
     const shareBtn = document.createElement('button');
     shareBtn.className =
       'history-share p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+    shareBtn.title = 'Share on Twitter';
+    shareBtn.setAttribute('aria-label', 'Share on Twitter');
     shareBtn.innerHTML =
       '<i data-lucide="twitter" class="w-3 h-3" aria-hidden="true"></i>';
 
@@ -649,6 +662,8 @@ const renderSharedPrompts = (prompts) => {
     const siteShareBtn = document.createElement('button');
     siteShareBtn.className =
       'history-site-share p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
+    siteShareBtn.title = 'Share on Prompter';
+    siteShareBtn.setAttribute('aria-label', 'Share on Prompter');
     siteShareBtn.innerHTML =
       '<i data-lucide="share-2" class="w-3 h-3" aria-hidden="true"></i>';
 
@@ -657,6 +672,13 @@ const renderSharedPrompts = (prompts) => {
         alert('Login required to share');
         return;
       }
+      siteShareBtn.classList.toggle('active');
+      const svg = siteShareBtn.querySelector('svg');
+      if (svg)
+        svg.setAttribute(
+          'fill',
+          siteShareBtn.classList.contains('active') ? 'currentColor' : 'none'
+        );
       siteShareBtn.disabled = true;
       try {
         await savePrompt(text.textContent || '', appState.currentUser.uid);

--- a/src/ui.js
+++ b/src/ui.js
@@ -916,6 +916,15 @@ const setupEventListeners = () => {
   });
 
   if (shareButton) {
+    const updateShareIcon = () => {
+      const svg = shareButton.querySelector('svg');
+      if (svg)
+        svg.setAttribute(
+          'fill',
+          shareButton.classList.contains('active') ? 'currentColor' : 'none'
+        );
+    };
+    updateShareIcon();
     shareButton.addEventListener('click', async () => {
       if (!appState.generatedPrompt) return;
       if (!appState.currentUser) {
@@ -923,6 +932,8 @@ const setupEventListeners = () => {
         return;
       }
       shareButton.classList.add('button-pop');
+      shareButton.classList.toggle('active');
+      updateShareIcon();
       shareMessage?.classList.remove('hidden');
       setTimeout(() => {
         shareMessage?.classList.add('hidden');


### PR DESCRIPTION
## Summary
- style share buttons like like/save buttons
- show tooltip titles
- add active state coloring for share icons
- tweak profile page share handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599748fb68832faed3e5bff71b0400