### PR TITLE
Fix pro payment link

### DIFF
--- a/pro.html
+++ b/pro.html
@@ -70,7 +70,8 @@
       </div>
       <div class="flex gap-2 justify-center">
         <a
-          href="#"
+          id="payment-link"
+          href="javascript:void(0)"
           class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300"
           >Proceed to payment</a
         >
@@ -81,5 +82,10 @@
         >
       </div>
     </div>
+    <script>
+      document.getElementById('payment-link')?.addEventListener('click', () => {
+        window.open('https://example.com/pay', '_blank');
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent `pro.html` payment link from navigating
- add script to open the external payment page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599b8e3208832f9b386280f269645e