### PR TITLE
Add version update banner

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -25,7 +25,23 @@ export const startVersionCheck = async () => {
       currentManifestVersion &&
       newVersion !== currentManifestVersion
     ) {
-      location.reload();
+      if (!document.getElementById('update-banner')) {
+        const banner = document.createElement('div');
+        banner.id = 'update-banner';
+        banner.textContent = 'A new version is available.';
+        banner.style.cssText =
+          'background:#fef08a;color:#000;padding:8px;text-align:center;font-size:14px;position:sticky;top:0;z-index:1000;';
+        const btn = document.createElement('button');
+        btn.textContent = 'Refresh';
+        btn.style.cssText =
+          'margin-left:8px;text-decoration:underline;font-weight:bold;background:transparent;border:none;cursor:pointer;color:inherit;';
+        btn.addEventListener('click', () => {
+          clearServiceWorkersAndCaches();
+          location.reload();
+        });
+        banner.appendChild(btn);
+        document.body.prepend(banner);
+      }
     }
   }, 5 * 60 * 1000);
 };


### PR DESCRIPTION
## Summary
- show banner when a new manifest version is detected
- let users refresh manually while clearing caches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599f7e1e78832fa2ca9af2d6137de1