### PR TITLE
Fix lucide icon insertion in edit row

### DIFF
--- a/social.html
+++ b/social.html
@@ -428,6 +428,8 @@
             editRow.appendChild(cancelEdit);
 
             card.replaceChild(editRow, likeRow);
+            // render icons for the temporary edit actions
+            window.lucide?.createIcons();
 
             cancelEdit.addEventListener('click', () => {
               card.replaceChild(text, textarea);


### PR DESCRIPTION
## Summary
- call `lucide.createIcons()` after swapping in the edit row

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ae6f9fa4832f99acc7934df7f2c3