### PR TITLE
Fix share button styling and unshare support

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -258,5 +258,5 @@ html {
 .share-toggle.active svg,
 .history-site-share.active svg {
   fill: currentColor;
-  stroke: none;
+  stroke: currentColor;
 }

--- a/social.html
+++ b/social.html
@@ -335,8 +335,10 @@
             const label = sharedByCurrent ? 'Unshare' : 'Share';
             shareToggleBtn.title = label;
             shareToggleBtn.setAttribute('aria-label', label);
-            if (icon)
+            if (icon) {
               icon.setAttribute('fill', sharedByCurrent ? 'currentColor' : 'none');
+              icon.setAttribute('stroke', 'currentColor');
+            }
           };
           updateShareToggle();
 

--- a/src/profile.js
+++ b/src/profile.js
@@ -431,11 +431,13 @@ const renderSavedPrompts = (prompts) => {
       }
       siteShareBtn.classList.toggle('active');
       const svg = siteShareBtn.querySelector('svg');
-      if (svg)
+      if (svg) {
         svg.setAttribute(
           'fill',
           siteShareBtn.classList.contains('active') ? 'currentColor' : 'none'
         );
+        svg.setAttribute('stroke', 'currentColor');
+      }
       siteShareBtn.disabled = true;
       try {
         await savePrompt(pEl.textContent || '', appState.currentUser.uid);
@@ -676,30 +678,36 @@ const renderSharedPrompts = (prompts) => {
 
     const siteShareBtn = document.createElement('button');
     siteShareBtn.className =
-      'history-site-share p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
-    siteShareBtn.title = 'Share on Prompter';
-    siteShareBtn.setAttribute('aria-label', 'Share on Prompter');
+      'history-site-share p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50 active';
+    siteShareBtn.title = 'Unshare from Prompter';
+    siteShareBtn.setAttribute('aria-label', 'Unshare from Prompter');
     siteShareBtn.innerHTML =
       '<i data-lucide="share-2" class="w-3 h-3" aria-hidden="true"></i>';
+
+    const updateSiteShareIcon = () => {
+      const svg = siteShareBtn.querySelector('svg');
+      if (svg) {
+        svg.setAttribute(
+          'fill',
+          siteShareBtn.classList.contains('active') ? 'currentColor' : 'none'
+        );
+        svg.setAttribute('stroke', 'currentColor');
+      }
+    };
+    updateSiteShareIcon();
 
     siteShareBtn.addEventListener('click', async () => {
       if (!appState.currentUser) {
         alert('Login required to share');
         return;
       }
-      siteShareBtn.classList.toggle('active');
-      const svg = siteShareBtn.querySelector('svg');
-      if (svg)
-        svg.setAttribute(
-          'fill',
-          siteShareBtn.classList.contains('active') ? 'currentColor' : 'none'
-        );
       siteShareBtn.disabled = true;
       try {
-        await savePrompt(text.textContent || '', appState.currentUser.uid);
+        await unsharePrompt(p.id, appState.currentUser.uid);
+        prompts.splice(idx, 1);
+        renderSharedPrompts(prompts);
       } catch (err) {
-        console.error(err);
-        alert('Failed to share prompt. Please try again.');
+        console.error('Failed to unshare:', err);
       } finally {
         siteShareBtn.disabled = false;
       }


### PR DESCRIPTION
## Summary
- keep share icon lines visible when active
- allow unsharing from profile page via the share icon
- make share icons use consistent stroke on social page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ecb2f6a8832fb0117dabedb970e4