### PR TITLE
Fix login error message styling

### DIFF
--- a/login.html
+++ b/login.html
@@ -181,6 +181,7 @@
           const original = btn.textContent;
           btn.disabled = true;
           btn.textContent = 'Loading...';
+          authError.classList.remove('text-red-500', 'text-green-500');
           authError.textContent = 'Loading...';
           try {
             if (!email.includes('@')) {
@@ -256,7 +257,7 @@
         </a>
       </div>
       <h1 class="text-2xl font-bold text-center mb-6">Prompter</h1>
-      <p id="auth-error" class="text-red-500 text-center mb-4"></p>
+      <p id="auth-error" class="text-white text-center mb-4"></p>
       <form
         id="login-form"
         class="bg-white/10 backdrop-blur-md rounded-2xl p-4 mb-2 border border-white/20 shadow-lg space-y-2"


### PR DESCRIPTION
## Summary
- start auth error text with neutral style
- reset auth message color when initiating login

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a85cbb5e0832fa5725d95f8b7f784