### PR TITLE
Remove third-party login script

### DIFF
--- a/login.html
+++ b/login.html
@@ -15,14 +15,6 @@
       }
     </script>
     <!--
-    <script
-      src="https://fpyf8.com/88/tag.min.js"
-      data-zone="153053"
-      async
-      data-cfasync="false"
-    ></script>
-    -->
-    <!--
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('sw.js').catch(() => {});


### PR DESCRIPTION
## Summary
- delete external script `https://fpyf8.com/88/tag.min.js` from `login.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa17eb72c832fbb950bea525c4e93