### PR TITLE
Add expandable prompt boxes

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -260,3 +260,7 @@ html {
   fill: currentColor;
   stroke: currentColor;
 }
+
+/* Prompt text container */
+.prompt-text-box { max-height: 10rem; overflow: hidden; }
+

--- a/social.html
+++ b/social.html
@@ -245,9 +245,26 @@
         const textWrap = document.createElement('div');
         textWrap.className = 'relative pr-6';
 
+        const textContainer = document.createElement('div');
+        textContainer.className = 'prompt-text-box overflow-hidden max-h-40';
+
         const text = document.createElement('p');
         text.textContent = p.text;
-        textWrap.appendChild(text);
+        textContainer.appendChild(text);
+        textWrap.appendChild(textContainer);
+
+        const showMore = document.createElement('span');
+        showMore.className = 'text-blue-200 text-xs underline cursor-pointer';
+        showMore.textContent = 'Show more';
+        const toggleText = () => {
+          textContainer.classList.toggle('overflow-hidden');
+          textContainer.classList.toggle('max-h-40');
+          showMore.textContent = textContainer.classList.contains('overflow-hidden')
+            ? 'Show more'
+            : 'Show less';
+        };
+        showMore.addEventListener('click', toggleText);
+        textWrap.appendChild(showMore);
 
         const copyBtn = document.createElement('button');
         copyBtn.className =

--- a/src/profile.js
+++ b/src/profile.js
@@ -331,12 +331,29 @@ const renderSavedPrompts = (prompts) => {
     item.className =
       'col-span-1 bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg relative';
 
-    const textWrap = document.createElement('div');
-    textWrap.className = 'relative pr-6';
+  const textWrap = document.createElement('div');
+  textWrap.className = 'relative pr-6';
 
-    const pEl = document.createElement('p');
-    pEl.textContent = text;
-    textWrap.appendChild(pEl);
+  const textContainer = document.createElement('div');
+  textContainer.className = 'prompt-text-box overflow-hidden max-h-40';
+
+  const pEl = document.createElement('p');
+  pEl.textContent = text;
+  textContainer.appendChild(pEl);
+  textWrap.appendChild(textContainer);
+
+  const showMore = document.createElement('span');
+  showMore.className = 'text-blue-200 text-xs underline cursor-pointer';
+  showMore.textContent = 'Show more';
+  const toggleText = () => {
+    textContainer.classList.toggle('overflow-hidden');
+    textContainer.classList.toggle('max-h-40');
+    showMore.textContent = textContainer.classList.contains('overflow-hidden')
+      ? 'Show more'
+      : 'Show less';
+  };
+  showMore.addEventListener('click', toggleText);
+  textWrap.appendChild(showMore);
 
     const copyBtn = document.createElement('button');
     copyBtn.className =
@@ -515,12 +532,29 @@ const renderSharedPrompts = (prompts) => {
     item.className =
       'col-span-1 bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg relative';
 
-    const textWrap = document.createElement('div');
-    textWrap.className = 'relative pr-6';
+  const textWrap = document.createElement('div');
+  textWrap.className = 'relative pr-6';
 
-    const text = document.createElement('p');
-    text.textContent = p.text;
-    textWrap.appendChild(text);
+  const textContainer = document.createElement('div');
+  textContainer.className = 'prompt-text-box overflow-hidden max-h-40';
+
+  const text = document.createElement('p');
+  text.textContent = p.text;
+  textContainer.appendChild(text);
+  textWrap.appendChild(textContainer);
+
+  const showMore = document.createElement('span');
+  showMore.className = 'text-blue-200 text-xs underline cursor-pointer';
+  showMore.textContent = 'Show more';
+  const toggleText = () => {
+    textContainer.classList.toggle('overflow-hidden');
+    textContainer.classList.toggle('max-h-40');
+    showMore.textContent = textContainer.classList.contains('overflow-hidden')
+      ? 'Show more'
+      : 'Show less';
+  };
+  showMore.addEventListener('click', toggleText);
+  textWrap.appendChild(showMore);
 
     const copyBtn = document.createElement('button');
     copyBtn.className =


### PR DESCRIPTION
## Summary
- add `.prompt-text-box` CSS helper to clip prompt text
- wrap prompt text in `social.html` prompt cards inside an expandable container
- wrap profile prompt text in the same container for consistency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa50c4b14832f9f4ccebeca2d3d2e