### PR TITLE
Add simple DM feature using Firestore

### DIFF
--- a/dm.html
+++ b/dm.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Direct Messages - Prompter</title>
+    <base href="./" />
+    <link rel="manifest" href="manifest.json?v=58" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link rel="stylesheet" href="css/tailwind.css?v=58" />
+    <link rel="stylesheet" href="css/app.css?v=58" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=58" />
+    <script type="module" src="src/init-app.js?v=58"></script>
+    <script nomodule src="dist/init-app.js?v=58"></script>
+    <script type="module" src="src/dm.js?v=58"></script>
+    <script nomodule src="dist/dm.js?v=58"></script>
+    <script type="module" src="src/version.js?v=58"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="w-full">
+      <header class="flex items-center justify-between w-full mt-4 mb-6">
+        <div class="flex items-center gap-2">
+          <a href="profile.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+            <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+          </a>
+          <img src="icons/logo.svg?v=58" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <div class="ml-1">
+            <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
+            <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>
+          </div>
+        </div>
+      </header>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <button id="create-conv" class="mb-2 bg-white/20 hover:bg-white/30 p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-full">New Conversation</button>
+          <ul id="conv-list" class="space-y-2"></ul>
+        </div>
+        <div class="flex-1">
+          <div id="messages" class="space-y-2 mb-2 h-80 overflow-y-auto border border-white/20 p-2 rounded-md bg-white/10"></div>
+          <form id="message-form" class="flex gap-2" data-conv-id="">
+            <input id="message-input" type="text" class="flex-1 p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50" placeholder="Type a message" />
+            <button type="submit" class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,14 @@
         { "fieldPath": "shared", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "members", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -34,5 +34,17 @@ service cloud.firestore {
         allow read, write: if request.auth != null && request.auth.uid == uid;
       }
     }
+
+    match /conversations/{convId} {
+      allow create: if request.auth != null &&
+        request.auth.uid in request.resource.data.members;
+      allow read, update: if request.auth != null &&
+        request.auth.uid in resource.data.members;
+
+      match /messages/{msgId} {
+        allow read, create: if request.auth != null &&
+          request.auth.uid in get(/databases/$(database)/documents/conversations/$(convId)).data.members;
+      }
+    }
   }
 }

--- a/profile.html
+++ b/profile.html
@@ -181,6 +181,14 @@
               <i data-lucide="bell" class="w-5 h-5" aria-hidden="true"></i>
               <span id="notification-count" class="hidden absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center"></span>
             </button>
+            <a
+              href="dm.html"
+              class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"
+              title="Messages"
+              aria-label="Messages"
+            >
+              <i data-lucide="message-circle" class="w-5 h-5" aria-hidden="true"></i>
+            </a>
           </div>
           <button
             id="logout"

--- a/src/dm.js
+++ b/src/dm.js
@@ -1,0 +1,100 @@
+import { onAuth } from './auth.js';
+import {
+  collection,
+  addDoc,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  serverTimestamp,
+} from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import { db } from './firebase.js';
+
+let currentUser = null;
+let unsubscribeMsgs = null;
+
+const convListEl = document.getElementById('conv-list');
+const messagesEl = document.getElementById('messages');
+const messageForm = document.getElementById('message-form');
+const messageInput = document.getElementById('message-input');
+const createConvBtn = document.getElementById('create-conv');
+
+const renderConversations = (convs) => {
+  convListEl.innerHTML = '';
+  convs.forEach((c) => {
+    const li = document.createElement('li');
+    li.textContent = c.name || c.id;
+    li.className = 'cursor-pointer p-1 rounded hover:bg-white/20';
+    li.addEventListener('click', () => openConversation(c.id));
+    convListEl.appendChild(li);
+  });
+};
+
+const listenConversations = (uid) => {
+  const q = query(
+    collection(db, 'conversations'),
+    where('members', 'array-contains', uid),
+    orderBy('createdAt', 'desc')
+  );
+  return onSnapshot(q, (snap) => {
+    const data = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    renderConversations(data);
+  });
+};
+
+const openConversation = (convId) => {
+  messageForm.dataset.convId = convId;
+  messagesEl.innerHTML = '';
+  unsubscribeMsgs?.();
+  const q = query(
+    collection(db, `conversations/${convId}/messages`),
+    orderBy('createdAt', 'asc')
+  );
+  unsubscribeMsgs = onSnapshot(q, (snap) => {
+    messagesEl.innerHTML = '';
+    snap.docs.forEach((d) => {
+      const m = d.data();
+      const div = document.createElement('div');
+      div.textContent = `${m.userId}: ${m.text}`;
+      messagesEl.appendChild(div);
+    });
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  });
+};
+
+messageForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const convId = messageForm.dataset.convId;
+  const text = messageInput.value.trim();
+  if (!convId || !text) return;
+  await addDoc(collection(db, `conversations/${convId}/messages`), {
+    text,
+    userId: currentUser.uid,
+    createdAt: serverTimestamp(),
+  });
+  messageInput.value = '';
+});
+
+createConvBtn.addEventListener('click', async () => {
+  if (!currentUser) return;
+  const name = prompt('Group name');
+  const membersRaw = prompt('Comma-separated user IDs');
+  if (!membersRaw) return;
+  const members = Array.from(
+    new Set(
+      [currentUser.uid, ...membersRaw.split(',').map((m) => m.trim()).filter(Boolean)]
+    )
+  );
+  await addDoc(collection(db, 'conversations'), {
+    name: name || '',
+    members,
+    createdBy: currentUser.uid,
+    createdAt: serverTimestamp(),
+  });
+});
+
+onAuth((user) => {
+  currentUser = user;
+  if (!user) return;
+  listenConversations(user.uid);
+});


### PR DESCRIPTION
## Summary
- add `dm.html` for basic direct message UI
- implement real-time conversation handling in `src/dm.js`
- link profile header to DM page
- secure conversations with new firestore rules and indexes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa6653298832f844254c18cb31ec7