### PR TITLE
Add prompt links in notifications

### DIFF
--- a/social.html
+++ b/social.html
@@ -229,11 +229,25 @@
         return display;
       };
 
+      const urlParams = new URLSearchParams(window.location.search);
+      const targetPromptId =
+        urlParams.get('prompt') || window.location.hash.replace('#', '');
+
       const sharePrompt = (prompt, baseUrl) => {
         if (!prompt) return;
         const link = ' https://prompterai.space';
         const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
         window.open(url, '_blank');
+      };
+
+      const highlightPrompt = (id) => {
+        const card = document.querySelector(`[data-id="${id}"]`);
+        if (!card) return;
+        card.classList.add('ring-2', 'ring-yellow-400');
+        card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        setTimeout(() => {
+          card.classList.remove('ring-2', 'ring-yellow-400');
+        }, 2000);
       };
 
       const createCard = async (p, name, commentsArr) => {
@@ -697,6 +711,7 @@
           }
         });
         window.scrollTo(0, scrollY);
+        if (targetPromptId) highlightPrompt(targetPromptId);
       }
 
       function init() {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -5,14 +5,25 @@ import {
   query,
   onSnapshot,
   serverTimestamp,
+  doc,
+  updateDoc,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { db } from './firebase.js';
 
-export const sendNotification = (uid, data) =>
-  addDoc(collection(db, `users/${uid}/notifications`), {
-    ...data,
+export const sendNotification = (uid, data) => {
+  const { promptId, target, targetId, ...rest } = data || {};
+  const payload = { ...rest };
+  if (promptId) payload.promptId = promptId;
+  else if (targetId) payload.promptId = targetId;
+  else if (target) payload.target = target;
+  return addDoc(collection(db, `users/${uid}/notifications`), {
+    ...payload,
     createdAt: serverTimestamp(),
   });
+};
+
+export const markNotificationRead = (uid, id) =>
+  updateDoc(doc(db, `users/${uid}/notifications/${id}`), { read: true });
 
 export const listenNotifications = (uid, cb) => {
   const q = query(

--- a/src/profile.js
+++ b/src/profile.js
@@ -10,7 +10,7 @@ import {
   incrementShareCount,
 } from './prompt.js';
 import { getUserProfile, setUserProfile } from './user.js';
-import { listenNotifications } from './notifications.js';
+import { listenNotifications, markNotificationRead } from './notifications.js';
 import { appState, THEMES } from './state.js';
 
 const uiText = {
@@ -290,15 +290,28 @@ const renderNotifications = () => {
   }
   notificationsPanel.innerHTML = '';
   notifications.forEach((n) => {
-    const div = document.createElement('div');
+    const link = document.createElement('a');
     let msg = '';
     if (n.type === 'like') msg = 'Your prompt received a like.';
     else if (n.type === 'comment') msg = 'New comment on your prompt.';
     else if (n.type === 'share') msg = 'Your prompt was shared.';
     else msg = 'New activity on your prompt.';
-    div.textContent = msg;
-    div.className = 'p-1 border-b border-white/20 last:border-b-0';
-    notificationsPanel.appendChild(div);
+    link.textContent = msg;
+    link.href = n.promptId ? `social.html#${n.promptId}` : 'social.html';
+    link.className =
+      'block p-1 border-b border-white/20 last:border-b-0 hover:bg-white/10';
+    link.addEventListener('click', async () => {
+      if (appState.currentUser) {
+        try {
+          await markNotificationRead(appState.currentUser.uid, n.id);
+        } catch (err) {
+          console.error('Failed to mark notification read:', err);
+        }
+      }
+      n.read = true;
+      renderNotifications();
+    });
+    notificationsPanel.appendChild(link);
   });
 };
 


### PR DESCRIPTION
## Summary
- extend notifications with promptId and mark as read
- link notifications to social page in profile
- highlight prompts linked from notifications on social page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa94d88f0832fbe747435c63142a1