### PR TITLE
Add follow system and filtering

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,6 +23,15 @@
         { "fieldPath": "members", "arrayConfig": "CONTAINS" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "shared", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,6 +33,15 @@ service cloud.firestore {
       match /notifications/{docId} {
         allow read, write: if request.auth != null && request.auth.uid == uid;
       }
+
+      match /following/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == uid;
+      }
+
+      match /followers/{docId} {
+        allow read: if true;
+        allow create, delete: if request.auth != null && request.auth.uid == docId;
+      }
     }
 
     match /conversations/{convId} {

--- a/social.html
+++ b/social.html
@@ -174,6 +174,10 @@
           >
             <i data-lucide="moon" class="w-5 h-5" aria-hidden="true"></i>
           </button>
+          <label class="text-sm inline-flex items-center gap-1">
+            <input id="following-filter" type="checkbox" class="form-checkbox" />
+            Following
+          </label>
         </div>
       </header>
         <div id="all-prompts" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
@@ -193,7 +197,7 @@
         incrementShareCount,
       } from './src/prompt.js';
       import { appState } from './src/state.js';
-      import { getUserProfile } from './src/user.js';
+      import { getUserProfile, getFollowingIds } from './src/user.js';
       import {
         collection,
         query,
@@ -202,6 +206,7 @@
         onSnapshot,
       } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
       import { db } from './src/firebase.js';
+      import { onAuth } from './src/auth.js';
 
       const setTheme = (theme) => {
         const linkEl = document.getElementById('theme-css');
@@ -218,6 +223,8 @@
         .addEventListener('click', () => setTheme('dark'));
 
       const profileCache = {};
+      let followingIds = [];
+      const followingFilter = document.getElementById('following-filter');
       const fetchName = async (uid) => {
         if (profileCache[uid]) return profileCache[uid];
         const prof = await getUserProfile(uid);
@@ -248,6 +255,14 @@
         setTimeout(() => {
           card.classList.remove('ring-2', 'ring-yellow-400');
         }, 2000);
+      };
+
+      const refreshFollowing = async () => {
+        if (!appState.currentUser) {
+          followingIds = [];
+          return;
+        }
+        followingIds = await getFollowingIds(appState.currentUser.uid);
       };
 
       const createCard = async (p, name, commentsArr) => {
@@ -736,13 +751,31 @@
         if (targetPromptId) highlightPrompt(targetPromptId);
       }
 
-      function init() {
-        const q = query(
-          collection(db, 'prompts'),
-          where('shared', '==', true),
-          orderBy('createdAt', 'desc'),
-        );
-        onSnapshot(
+      let unsubscribe = null;
+
+      const startListener = async () => {
+        if (unsubscribe) unsubscribe();
+        await refreshFollowing();
+        let q;
+        if (followingFilter?.checked && followingIds.length > 0) {
+          q = query(
+            collection(db, 'prompts'),
+            where('shared', '==', true),
+            where('userId', 'in', followingIds.slice(0, 10)),
+            orderBy('createdAt', 'desc'),
+          );
+        } else if (followingFilter?.checked) {
+          render([]);
+          return;
+        } else {
+          q = query(
+            collection(db, 'prompts'),
+            where('shared', '==', true),
+            orderBy('createdAt', 'desc'),
+          );
+        }
+
+        unsubscribe = onSnapshot(
           q,
           async (snap) => {
             const prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
@@ -761,6 +794,12 @@
             }
           },
         );
+      };
+
+      function init() {
+        followingFilter?.addEventListener('change', startListener);
+        onAuth(startListener);
+        startListener();
       }
 
       document.addEventListener('DOMContentLoaded', init);

--- a/user.html
+++ b/user.html
@@ -66,6 +66,10 @@
             >
               <i data-lucide="moon" class="w-5 h-5" aria-hidden="true"></i>
             </button>
+            <button
+              id="follow-btn"
+              class="p-1.5 rounded-md text-sm font-medium bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50 hidden"
+            ></button>
           </div>
         </header>
         <div class="max-w-xl mx-auto relative">


### PR DESCRIPTION
## Summary
- add Firestore subcollections for following and follower relationships
- display a follow/unfollow button on user pages
- allow social feed to filter posts from followed users
- expose follow helpers in user.js
- update Firestore rules and indexes for new queries

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab57688a8832f836c673aca98128a