### PR TITLE
Add category tracking for shared prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,6 +471,10 @@
             Your Prompt ↓
           </h3>
           <div class="flex gap-2">
+            <select
+              id="share-category"
+              class="bg-black/20 border border-white/20 rounded-md text-sm px-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+            ></select>
             <button
               id="copy-button"
               class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50"

--- a/scripts/migrate-categories.js
+++ b/scripts/migrate-categories.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+const db = admin.firestore();
+
+async function migrate() {
+  const snap = await db.collection('prompts').get();
+  for (const doc of snap.docs) {
+    if (!doc.get('category')) {
+      await doc.ref.set({ category: 'random' }, { merge: true });
+      console.log(`Updated ${doc.id}`);
+    }
+  }
+}
+
+migrate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/social.html
+++ b/social.html
@@ -197,6 +197,7 @@
         incrementShareCount,
       } from './src/prompt.js';
       import { appState } from './src/state.js';
+      import { categories } from './src/prompts.js';
       import { getUserProfile, getFollowingIds } from './src/user.js';
       import {
         collection,
@@ -223,6 +224,9 @@
         .addEventListener('click', () => setTheme('dark'));
 
       const profileCache = {};
+      const categoryMap = Object.fromEntries(
+        categories.map((c) => [c.id, c.name[appState.language] || c.id])
+      );
       let followingIds = [];
       const followingFilter = document.getElementById('following-filter');
       const fetchName = async (uid) => {
@@ -322,6 +326,10 @@
         const nameEl = document.createElement('p');
         nameEl.className = 'text-blue-200 text-sm mt-1 underline';
         nameEl.innerHTML = `<a href="user.html?uid=${p.userId}">${name}</a>`;
+
+        const catEl = document.createElement('p');
+        catEl.className = 'text-blue-200 text-xs';
+        catEl.textContent = categoryMap[p.category] || p.category || 'random';
 
         const likeRow = document.createElement('div');
         likeRow.className = 'flex items-center gap-2 mt-2';
@@ -696,6 +704,7 @@
 
         card.appendChild(textWrap);
         card.appendChild(nameEl);
+        card.appendChild(catEl);
         card.appendChild(likeRow);
         card.appendChild(likeSummary);
         card.appendChild(likeList);

--- a/src/profile.js
+++ b/src/profile.js
@@ -14,6 +14,7 @@ import {
 import { getUserProfile, setUserProfile } from './user.js';
 import { listenNotifications, markNotificationRead } from './notifications.js';
 import { appState, THEMES } from './state.js';
+import { categories } from './prompts.js';
 
 const uiText = {
   en: {
@@ -497,7 +498,11 @@ const renderSavedPrompts = (prompts) => {
       }
       siteShareBtn.disabled = true;
       try {
-        await savePrompt(pEl.textContent || '', appState.currentUser.uid);
+        await savePrompt(
+          pEl.textContent || '',
+          appState.currentUser.uid,
+          appState.selectedCategory
+        );
       } catch (err) {
         console.error(err);
         alert('Failed to share prompt. Please try again.');
@@ -600,6 +605,13 @@ const renderSharedPrompts = async (prompts) => {
     const nameEl = document.createElement('p');
     nameEl.className = 'text-blue-200 text-sm mt-1';
     nameEl.textContent = currentUserName;
+
+    const catEl = document.createElement('p');
+    catEl.className = 'text-blue-200 text-xs';
+    catEl.textContent =
+      categories.find((c) => c.id === p.category)?.name[appState.language] ||
+      p.category ||
+      'random';
 
     const likeRow = document.createElement('div');
     likeRow.className = 'flex items-center gap-2 mt-2';
@@ -886,6 +898,7 @@ const renderSharedPrompts = async (prompts) => {
 
     item.appendChild(textWrap);
     item.appendChild(nameEl);
+    item.appendChild(catEl);
     item.appendChild(likeRow);
     item.appendChild(commentsWrap);
     list.appendChild(item);

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -28,10 +28,11 @@ export const generatePrompt = () => {
   return samplePrompts[idx];
 };
 
-export const savePrompt = (text, userId) =>
+export const savePrompt = (text, userId, category = 'random') =>
   addDoc(collection(db, 'prompts'), {
     text,
     userId,
+    category,
     createdAt: serverTimestamp(),
     likes: 0,
     likedBy: [],
@@ -50,7 +51,11 @@ export const getUserPrompts = async (userId) => {
   );
   try {
     const snap = await getDocs(q);
-    const prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const prompts = snap.docs.map((d) => ({
+      id: d.id,
+      category: d.get('category') || 'random',
+      ...d.data(),
+    }));
     prompts.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis());
     return prompts;
   } catch (err) {
@@ -67,7 +72,11 @@ export const getAllPrompts = async () => {
   );
   const snap = await getDocs(q);
   return snap.docs
-    .map((d) => ({ id: d.id, ...d.data() }))
+    .map((d) => ({
+      id: d.id,
+      category: d.get('category') || 'random',
+      ...d.data(),
+    }))
     .filter(
       (p) => Array.isArray(p.sharedBy) && p.sharedBy.length > 0
     );

--- a/src/ui.js
+++ b/src/ui.js
@@ -202,6 +202,7 @@ let copyButton;
 let shareButton;
 let saveButton;
 let shareTwitterButton;
+let categorySelect;
 let copySuccessMessage;
 let saveSuccessMessage;
 let saveErrorMessage;
@@ -363,6 +364,12 @@ const setLanguage = (lang) => {
       button.setAttribute('aria-label', `${category.name[lang]} category`);
     }
   });
+  if (categorySelect) {
+    Array.from(categorySelect.options).forEach((opt) => {
+      const cat = categories.find((c) => c.id === opt.value);
+      if (cat) opt.textContent = cat.name[lang];
+    });
+  }
 
   if (lang === 'en') {
     langEnButton.classList.add(
@@ -941,7 +948,11 @@ const setupEventListeners = () => {
       }, 2000);
       try {
         const { savePrompt } = await import('./prompt.js');
-        await savePrompt(appState.generatedPrompt, appState.currentUser.uid);
+        await savePrompt(
+          appState.generatedPrompt,
+          appState.currentUser.uid,
+          categorySelect ? categorySelect.value : appState.selectedCategory
+        );
       } catch (err) {
         console.error(err);
         alert('Failed to share prompt. Please try again.');
@@ -1091,7 +1102,11 @@ const setupEventListeners = () => {
       if (appState.currentUser) {
         try {
           const { savePrompt } = await import('./prompt.js');
-          await savePrompt(text, appState.currentUser.uid);
+          await savePrompt(
+            text,
+            appState.currentUser.uid,
+            categorySelect ? categorySelect.value : appState.selectedCategory
+          );
         } catch (err) {
           console.error(err);
           saved = false;
@@ -1155,7 +1170,11 @@ const setupEventListeners = () => {
       }, 300);
       try {
         const { savePrompt } = await import('./prompt.js');
-        await savePrompt(text, appState.currentUser.uid);
+        await savePrompt(
+          text,
+          appState.currentUser.uid,
+          categorySelect ? categorySelect.value : appState.selectedCategory
+        );
       } catch (err) {
         console.error(err);
         alert('Failed to share prompt. Please try again.');
@@ -1248,6 +1267,7 @@ export const initializeApp = () => {
   shareButton = document.getElementById('share-button');
   saveButton = document.getElementById('save-button');
   shareTwitterButton = document.getElementById('share-twitter');
+  categorySelect = document.getElementById('share-category');
   copySuccessMessage = document.getElementById('copy-success-message');
   saveSuccessMessage = document.getElementById('save-success-message');
   saveErrorMessage = document.getElementById('save-error-message');
@@ -1275,6 +1295,16 @@ export const initializeApp = () => {
   historyPanel = document.getElementById('history-panel');
   historyList = document.getElementById('history-list');
   clearHistoryButton = document.getElementById('clear-history');
+  if (categorySelect) {
+    categorySelect.innerHTML = '';
+    categories.forEach((c) => {
+      const opt = document.createElement('option');
+      opt.value = c.id;
+      opt.textContent = c.name[appState.language];
+      categorySelect.appendChild(opt);
+    });
+    categorySelect.value = appState.selectedCategory;
+  }
 
   const runLucide = () => {
     if (window.lucide && typeof window.lucide.createIcons === 'function') {

--- a/src/user-page.js
+++ b/src/user-page.js
@@ -7,6 +7,9 @@ import {
 } from './user.js';
 import { onAuth } from './auth.js';
 import { getUserPrompts } from './prompt.js';
+import { categories } from './prompts.js';
+
+const categoryMap = Object.fromEntries(categories.map((c) => [c.id, c.name.en]));
 
 
 const getParam = (key) => new URLSearchParams(window.location.search).get(key);
@@ -30,7 +33,11 @@ const renderPrompts = async (prompts) => {
       'bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg';
     const text = document.createElement('p');
     text.textContent = p.text;
+    const cat = document.createElement('p');
+    cat.className = 'text-blue-200 text-xs mt-1';
+    cat.textContent = categoryMap[p.category] || p.category || 'random';
     card.appendChild(text);
+    card.appendChild(cat);
     list.appendChild(card);
   }
 


### PR DESCRIPTION
## Summary
- store prompt category in Firestore
- let users choose a category when saving or sharing
- show the category of each prompt on social feed and profile pages
- migrate old prompts without a category

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac1084980832f858e1b4fa0b692fe