### PR TITLE
Add leaderboard computation and pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,14 +9,30 @@
     "sourceType": "module"
   },
   "rules": {
-    "semi": ["error", "always"],
-    "quotes": ["error", "single", { "avoidEscape": true }]
+    "semi": [
+      "error",
+      "always"
+    ],
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true
+      }
+    ]
   },
   "overrides": [
     {
-      "files": ["scripts/*.js"],
-      "env": {"node": true},
-      "parserOptions": {"sourceType": "script"}
+      "files": [
+        "scripts/*.js",
+        "functions/*.js"
+      ],
+      "env": {
+        "node": true
+      },
+      "parserOptions": {
+        "sourceType": "script"
+      }
     }
   ]
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -55,5 +55,8 @@ service cloud.firestore {
           request.auth.uid in get(/databases/$(database)/documents/conversations/$(convId)).data.members;
       }
     }
+    match /stats/{docId} {
+      allow read: if true;
+    }
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,66 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+const db = admin.firestore();
+const promptScore = (d = {}) => (d.likes || 0) + (d.saveCount || 0) + (d.shareCount || 0);
+const collectorScore = ({likes=0,saves=0,shares=0}={}) => likes + saves + shares;
+
+
+const computeRankings = async () => {
+  const snap = await db.collection('prompts').get();
+  const promptScores = [];
+  const userScores = {};
+
+  snap.forEach((doc) => {
+    const data = doc.data();
+    const score = promptScore(data);
+    promptScores.push({ id: doc.id, userId: data.userId, score });
+    userScores[data.userId] = (userScores[data.userId] || 0) + score;
+  });
+
+  promptScores.sort((a, b) => b.score - a.score);
+  const topPrompts = promptScores.slice(0, 20);
+  await db.doc('stats/topPrompts').set({ list: topPrompts });
+
+  const creators = Object.entries(userScores).map(([userId, score]) => ({
+    userId,
+    score,
+  }));
+  creators.sort((a, b) => b.score - a.score);
+  const topCreators = creators.slice(0, 20);
+  await db.doc('stats/topCreators').set({ list: topCreators });
+
+  // collectors
+  const usersSnap = await db.collection('users').get();
+  const collectorArr = [];
+  for (const userDoc of usersSnap.docs) {
+    const uid = userDoc.id;
+    const saved = await db.collection(`users/${uid}/savedPrompts`).get();
+    const liked = await db
+      .collection('prompts')
+      .where('likedBy', 'array-contains', uid)
+      .get();
+    const shared = await db
+      .collection('prompts')
+      .where('sharedBy', 'array-contains', uid)
+      .get();
+    const score = collectorScore({
+      likes: liked.size,
+      saves: saved.size,
+      shares: shared.size,
+    });
+    collectorArr.push({ userId: uid, score });
+  }
+  collectorArr.sort((a, b) => b.score - a.score);
+  await db.doc('stats/topCollectors').set({ list: collectorArr.slice(0, 20) });
+};
+
+exports.scheduledComputeRankings = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(computeRankings);
+
+exports.computeRankings = functions.https.onRequest(async (req, res) => {
+  await computeRankings();
+  res.json({ status: 'ok' });
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "prompter-functions",
+  "private": true,
+  "engines": {
+    "node": "18"
+  },
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,0 +1,5 @@
+export const promptScore = ({ likes = 0, saveCount = 0, shareCount = 0 } = {}) =>
+  likes + saveCount + shareCount;
+
+export const collectorScore = ({ likes = 0, saves = 0, shares = 0 } = {}) =>
+  likes + saves + shares;

--- a/src/top-collectors.js
+++ b/src/top-collectors.js
@@ -1,0 +1,43 @@
+import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import { db } from './firebase.js';
+import { getUserProfile } from './user.js';
+
+const fetchName = async (uid) => {
+  try {
+    const profile = await getUserProfile(uid);
+    return profile && profile.name ? profile.name : uid;
+  } catch {
+    return uid;
+  }
+};
+
+const render = async (items) => {
+  const list = document.getElementById('collector-list');
+  list.innerHTML = '';
+  for (const item of items) {
+    const name = await fetchName(item.userId);
+    const el = document.createElement('div');
+    el.className = 'bg-white/10 p-2 rounded-lg flex justify-between';
+    const spanName = document.createElement('span');
+    spanName.textContent = name;
+    const spanScore = document.createElement('span');
+    spanScore.className = 'text-xs text-blue-200';
+    spanScore.textContent = `Score: ${item.score}`;
+    el.appendChild(spanName);
+    el.appendChild(spanScore);
+    list.appendChild(el);
+  }
+  window.lucide?.createIcons();
+};
+
+const load = async () => {
+  try {
+    const snap = await getDoc(doc(db, 'stats', 'topCollectors'));
+    if (!snap.exists()) return;
+    await render(snap.data().list || []);
+  } catch (err) {
+    console.error('Failed to load rankings', err);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', load);

--- a/src/top-creators.js
+++ b/src/top-creators.js
@@ -1,0 +1,43 @@
+import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import { db } from './firebase.js';
+import { getUserProfile } from './user.js';
+
+const fetchName = async (uid) => {
+  try {
+    const profile = await getUserProfile(uid);
+    return profile && profile.name ? profile.name : uid;
+  } catch {
+    return uid;
+  }
+};
+
+const render = async (items) => {
+  const list = document.getElementById('creator-list');
+  list.innerHTML = '';
+  for (const item of items) {
+    const name = await fetchName(item.userId);
+    const el = document.createElement('div');
+    el.className = 'bg-white/10 p-2 rounded-lg flex justify-between';
+    const spanName = document.createElement('span');
+    spanName.textContent = name;
+    const spanScore = document.createElement('span');
+    spanScore.className = 'text-xs text-blue-200';
+    spanScore.textContent = `Score: ${item.score}`;
+    el.appendChild(spanName);
+    el.appendChild(spanScore);
+    list.appendChild(el);
+  }
+  window.lucide?.createIcons();
+};
+
+const load = async () => {
+  try {
+    const snap = await getDoc(doc(db, 'stats', 'topCreators'));
+    if (!snap.exists()) return;
+    await render(snap.data().list || []);
+  } catch (err) {
+    console.error('Failed to load rankings', err);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', load);

--- a/src/top-prompts.js
+++ b/src/top-prompts.js
@@ -1,0 +1,42 @@
+import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import { db } from './firebase.js';
+
+const fetchPromptText = async (id) => {
+  try {
+    const snap = await getDoc(doc(db, 'prompts', id));
+    return snap.exists() ? snap.data().text : id;
+  } catch {
+    return id;
+  }
+};
+
+const render = async (items) => {
+  const list = document.getElementById('prompt-list');
+  list.innerHTML = '';
+  for (const item of items) {
+    const text = await fetchPromptText(item.id);
+    const card = document.createElement('div');
+    card.className = 'bg-white/10 p-3 rounded-lg';
+    const p = document.createElement('p');
+    p.textContent = text;
+    const score = document.createElement('p');
+    score.className = 'text-xs text-blue-200';
+    score.textContent = `Score: ${item.score}`;
+    card.appendChild(p);
+    card.appendChild(score);
+    list.appendChild(card);
+  }
+  window.lucide?.createIcons();
+};
+
+const load = async () => {
+  try {
+    const snap = await getDoc(doc(db, 'stats', 'topPrompts'));
+    if (!snap.exists()) return;
+    await render(snap.data().list || []);
+  } catch (err) {
+    console.error('Failed to load rankings', err);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', load);

--- a/top-collectors.html
+++ b/top-collectors.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Top Collectors - Prompter</title>
+    <base href="./" />
+    <link rel="manifest" href="manifest.json?v=56" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link rel="stylesheet" href="css/tailwind.css?v=56" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=56"></script>
+    <link rel="stylesheet" href="css/app.css?v=56" />
+    <script type="module" src="src/init-app.js?v=56"></script>
+    <script nomodule src="dist/init-app.js?v=56"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=56" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/top-collectors.js?v=56"></script>
+    <script nomodule src="dist/top-collectors.js?v=56"></script>
+    <script type="module" src="src/version.js?v=56"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto">
+      <h1 class="text-2xl font-bold mb-4">Top Prompt Collectors</h1>
+      <div id="collector-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/top-creators.html
+++ b/top-creators.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Top Creators - Prompter</title>
+    <base href="./" />
+    <link rel="manifest" href="manifest.json?v=56" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link rel="stylesheet" href="css/tailwind.css?v=56" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=56"></script>
+    <link rel="stylesheet" href="css/app.css?v=56" />
+    <script type="module" src="src/init-app.js?v=56"></script>
+    <script nomodule src="dist/init-app.js?v=56"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=56" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/top-creators.js?v=56"></script>
+    <script nomodule src="dist/top-creators.js?v=56"></script>
+    <script type="module" src="src/version.js?v=56"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto">
+      <h1 class="text-2xl font-bold mb-4">Top Creators</h1>
+      <div id="creator-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/top-prompts.html
+++ b/top-prompts.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Top Prompts - Prompter</title>
+    <base href="./" />
+    <link rel="manifest" href="manifest.json?v=56" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link rel="stylesheet" href="css/tailwind.css?v=56" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=56"></script>
+    <link rel="stylesheet" href="css/app.css?v=56" />
+    <script type="module" src="src/init-app.js?v=56"></script>
+    <script nomodule src="dist/init-app.js?v=56"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=56" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/top-prompts.js?v=56"></script>
+    <script nomodule src="dist/top-prompts.js?v=56"></script>
+    <script type="module" src="src/version.js?v=56"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto">
+      <h1 class="text-2xl font-bold mb-4">Top Prompts</h1>
+      <div id="prompt-list" class="space-y-4"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add scoring helpers
- implement Cloud Function to compute top prompts, creators and collectors
- expose `stats` in firestore rules
- add pages to display leaderboards
- tweak eslint config for functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac6ae89e0832f874c89f0fbcc7435