### PR TITLE
Add bio field to profile pages

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -217,6 +217,22 @@
             <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
           </button>
         </div>
+        <div id="bio-wrapper" class="mb-2">
+          <p id="user-bio" class="text-blue-200 whitespace-pre-line cursor-pointer"></p>
+        </div>
+        <div id="bio-edit-row" class="flex flex-col items-center gap-2 mb-2 hidden">
+          <textarea
+            id="bio-input"
+            rows="3"
+            class="p-1 rounded-md w-full max-w-sm bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          ></textarea>
+          <button
+            id="bio-update-btn"
+            class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50"
+          >
+            <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
+          </button>
+        </div>
         <p id="user-email" class="text-blue-200 mb-2"></p>
         <div class="space-x-2 text-sm text-blue-200 my-4 text-center">
           <span>Prompts: <span id="stat-prompts">0</span></span>

--- a/src/profile.js
+++ b/src/profile.js
@@ -146,10 +146,15 @@ let langHiButton;
 let currentLangLabel;
 let sharedPromptsData = [];
 let currentUserName = '';
+let currentUserBio = '';
 let nameWrapper;
 let nameEditRow;
 let nameInput;
 let nameUpdateBtn;
+let bioWrapper;
+let bioEditRow;
+let bioInput;
+let bioUpdateBtn;
 let notificationBtn;
 let notificationCountEl;
 let notificationsPanel;
@@ -930,6 +935,10 @@ const init = () => {
   nameEditRow = document.getElementById('name-edit-row');
   nameInput = document.getElementById('name-input');
   nameUpdateBtn = document.getElementById('name-update-btn');
+  bioWrapper = document.getElementById('bio-wrapper');
+  bioEditRow = document.getElementById('bio-edit-row');
+  bioInput = document.getElementById('bio-input');
+  bioUpdateBtn = document.getElementById('bio-update-btn');
 
   nameWrapper?.addEventListener('click', () => {
     if (!nameWrapper || !nameEditRow || !nameInput) return;
@@ -956,6 +965,32 @@ const init = () => {
       console.error('Failed to update name:', err);
     } finally {
       nameUpdateBtn.disabled = false;
+    }
+  });
+
+  bioWrapper?.addEventListener('click', () => {
+    if (!bioWrapper || !bioEditRow || !bioInput) return;
+    bioInput.value = currentUserBio;
+    bioWrapper.classList.add('hidden');
+    bioEditRow.classList.remove('hidden');
+    bioInput.focus();
+  });
+
+  bioUpdateBtn?.addEventListener('click', async () => {
+    if (!bioInput || !appState.currentUser) return;
+    const newBio = bioInput.value.trim();
+    bioUpdateBtn.disabled = true;
+    try {
+      await setUserProfile(appState.currentUser.uid, { bio: newBio });
+      currentUserBio = newBio;
+      const bioEl = document.getElementById('user-bio');
+      if (bioEl) bioEl.textContent = currentUserBio;
+      bioEditRow?.classList.add('hidden');
+      bioWrapper?.classList.remove('hidden');
+    } catch (err) {
+      console.error('Failed to update bio:', err);
+    } finally {
+      bioUpdateBtn.disabled = false;
     }
   });
 
@@ -1019,6 +1054,11 @@ const init = () => {
       const nameEl = document.getElementById('user-name');
       if (nameEl) nameEl.textContent = '';
       if (nameInput) nameInput.value = '';
+      const bioEl = document.getElementById('user-bio');
+      if (bioEl) bioEl.textContent = '';
+      if (bioInput) bioInput.value = '';
+      bioEditRow?.classList.add('hidden');
+      bioWrapper?.classList.remove('hidden');
       nameEditRow?.classList.add('hidden');
       nameWrapper?.classList.remove('hidden');
       notifications = [];
@@ -1042,6 +1082,13 @@ const init = () => {
       if (nameInput) nameInput.value = currentUserName;
       nameEditRow?.classList.add('hidden');
       nameWrapper?.classList.remove('hidden');
+      const bio = profile && typeof profile.bio === 'string' ? profile.bio : '';
+      currentUserBio = bio;
+      const bioEl = document.getElementById('user-bio');
+      if (bioEl) bioEl.textContent = currentUserBio;
+      if (bioInput) bioInput.value = currentUserBio;
+      bioEditRow?.classList.add('hidden');
+      bioWrapper?.classList.remove('hidden');
     } catch (err) {
       console.error('Failed to load profile:', err);
     }

--- a/src/user-page.js
+++ b/src/user-page.js
@@ -70,8 +70,11 @@ const init = async () => {
 
   const profile = await getUserProfile(uid);
   if (profile && profile.name) name = profile.name;
+  const bio = profile && typeof profile.bio === 'string' ? profile.bio : '';
 
   document.getElementById('user-name').textContent = name || uid;
+  const bioEl = document.getElementById('user-bio');
+  if (bioEl) bioEl.textContent = bio;
 
   const followBtn = document.getElementById('follow-btn');
   let currentUserId = null;

--- a/src/user.js
+++ b/src/user.js
@@ -13,8 +13,13 @@ import { db } from './firebase.js';
 
 export const setUserProfile = async (uid, profile) => {
   await setDoc(doc(db, 'users', uid, 'profile', 'info'), profile);
-  if (profile && profile.name) {
-    await setDoc(doc(db, 'users', uid), { name: profile.name }, { merge: true });
+  const update = {};
+  if (profile && profile.name) update.name = profile.name;
+  if (profile && Object.prototype.hasOwnProperty.call(profile, 'bio')) {
+    update.bio = profile.bio;
+  }
+  if (Object.keys(update).length) {
+    await setDoc(doc(db, 'users', uid), update, { merge: true });
   }
 };
 

--- a/user.html
+++ b/user.html
@@ -73,6 +73,7 @@
           </div>
         </header>
         <div class="max-w-xl mx-auto relative">
+          <p id="user-bio" class="text-blue-200 whitespace-pre-line mb-4 text-center"></p>
           <div class="space-x-2 text-sm text-blue-200 mb-6 text-center">
             <span>Prompts: <span id="stat-prompts">0</span></span>
             <span>Likes: <span id="stat-likes">0</span></span>


### PR DESCRIPTION
## Summary
- support bio info in Firestore via `setUserProfile`
- allow editing bio in `profile.html`
- load and update bio in `profile.js`
- display bio on public profile page and user page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad375b46c832f83f251d1856fc99d