### PR TITLE
Add leaderboard page and icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prompt templates are stored in small JSON files under the `prompts/` directory a
 - Light and dark themes
 - English, Turkish, Spanish, Hindi, French and Chinese interface
 - Twelve prompt categories with over 53M combinations per language (more than 318M across EN, TR, ES, HI, FR and ZH)
+- Quick access to Top 10 rankings via the award icon
 
 This **AI prompt generator** delivers **creative prompt ideas** in a lightweight web app that runs directly in your browser. An internet connection is required.
 

--- a/index.html
+++ b/index.html
@@ -292,6 +292,19 @@
             aria-label="Moon icon"
           ></i>
         </button>
+        <a
+          href="top.html"
+          class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Top Rankings"
+          aria-label="Top Rankings"
+        >
+          <i
+            data-lucide="award"
+            class="w-5 h-5"
+            role="img"
+            aria-label="Award icon"
+          ></i>
+        </a>
       </div>
 
       <!-- Language Switcher -->

--- a/top.html
+++ b/top.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Top Lists - Prompter</title>
+    <base href="./" />
+    <link rel="manifest" href="manifest.json?v=56" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link rel="stylesheet" href="css/tailwind.css?v=56" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=56"></script>
+    <link rel="stylesheet" href="css/app.css?v=56" />
+    <script type="module" src="src/init-app.js?v=56"></script>
+    <script nomodule src="dist/init-app.js?v=56"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=56" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/version.js?v=56"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto space-y-4">
+      <h1 class="text-2xl font-bold mb-4">Top Rankings</h1>
+      <ul class="list-disc pl-6 space-y-2">
+        <li><a href="top-creators.html" class="text-blue-400 underline">Top Creators</a></li>
+        <li><a href="top-collectors.html" class="text-blue-400 underline">Top Collectors</a></li>
+        <li><a href="top-prompts.html" class="text-blue-400 underline">Top Prompts</a></li>
+      </ul>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add new `top.html` page with links to Top 10 rankings
- link new page from theme toggle using Lucide `award` icon
- document award icon shortcut in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685adc7e1064832fb6ddc15db2f961dc