### PR TITLE
Fix like list hover behavior

### DIFF
--- a/social.html
+++ b/social.html
@@ -431,18 +431,35 @@
         likeWrapper.appendChild(likeSummary);
         likeWrapper.appendChild(likeList);
         let listToggled = false;
+        let wrapperHover = false;
+        let listHover = false;
         const showList = () => {
           likeList.classList.remove('hidden');
         };
-        const hideList = () => {
-          if (!listToggled) likeList.classList.add('hidden');
+        const maybeHideList = () => {
+          if (!listToggled && !wrapperHover && !listHover) {
+            likeList.classList.add('hidden');
+          }
         };
-        likeWrapper.addEventListener('mouseenter', showList);
-        likeWrapper.addEventListener('mouseleave', hideList);
+        likeWrapper.addEventListener('mouseenter', () => {
+          wrapperHover = true;
+          showList();
+        });
+        likeWrapper.addEventListener('mouseleave', () => {
+          wrapperHover = false;
+          maybeHideList();
+        });
+        likeList.addEventListener('mouseenter', () => {
+          listHover = true;
+        });
+        likeList.addEventListener('mouseleave', () => {
+          listHover = false;
+          maybeHideList();
+        });
         const toggleList = () => {
           listToggled = !listToggled;
           if (listToggled) showList();
-          else likeList.classList.add('hidden');
+          else maybeHideList();
         };
 
         const renderLikeSummary = async () => {


### PR DESCRIPTION
## Summary
- keep likes list visible when hovering between the trigger and the list
- only hide likes list when the cursor leaves both elements

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b0e2eb9c4832f9e2433bedc4a8ceb