### PR TITLE
Re-align home page icons

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -39,7 +39,6 @@ html {
 #app-logo {
   width: 4.5rem;
   height: 4.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .category-button {

--- a/dm.html
+++ b/dm.html
@@ -26,7 +26,7 @@
           <a href="profile.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <img id="app-logo" src="icons/logo.svg?v=58" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <img src="icons/logo.svg?v=58" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <div class="ml-1">
             <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
             <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>

--- a/index.html
+++ b/index.html
@@ -264,9 +264,7 @@
     >
       <!-- Theme Toggle -->
       <div class="absolute top-4 right-0 flex flex-col items-end gap-2 z-10">
-        <div
-          class="theme-toggle-container flex flex-col items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20"
-        >
+        <div class="theme-toggle-container flex items-center gap-2">
           <button
             id="theme-light"
             class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"

--- a/social.html
+++ b/social.html
@@ -155,7 +155,6 @@
             >
           </a>
           <img
-            id="app-logo"
             src="icons/logo.svg?v=56"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"

--- a/user.html
+++ b/user.html
@@ -43,7 +43,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img id="app-logo" src="icons/logo.svg?v=56" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="icons/logo.svg?v=56" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>


### PR DESCRIPTION
## Summary
- align top-right icons horizontally like the profile page

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b0491e278832fadb971e20e4c8c91