### PR TITLE
Enhance pro and top pages

### DIFF
--- a/pro.html
+++ b/pro.html
@@ -32,20 +32,14 @@
     </script>
     <script type="module" src="src/version.js?v=56"></script>
   </head>
-  <body class="bg-black text-white min-h-screen p-4">
+  <body class="min-h-screen p-4">
+    <div class="max-w-md mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
     <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
-      <a
-        href="index.html"
-        class="inline-block mb-4 p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
-        title="Back"
-        aria-label="Back"
-      >
-        <span
-          class="w-6 h-6 inline-flex items-center justify-center text-3xl"
-          aria-hidden="true"
-          >&larr;</span
-        >
-      </a>
       <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
       <p class="mb-2 text-center">
         Unlock all features for only <strong>79 TL / 2 USD</strong>.
@@ -57,8 +51,8 @@
         <li>Premium promptlara erişim</li>
         <li>Prompter WhatsApp kanalına üyelik</li>
         <li>Günlük yapay zeka bülteni</li>
-        <li>Prompter’ın geleceği hakkında oy kullanma hakkı</li>
-        <li>Prompter fikri ve gelişimine destek olma</li>
+        <li>Prompter’ın geleceği hakkında oy kullanma</li>
+        <li>Prompter fikri ve gelişimine destek</li>
       </ul>
         <div class="flex gap-2 mb-4">
           <input
@@ -77,13 +71,7 @@
           id="payment-link"
           href="javascript:void(0)"
           class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
-          >PayTR güvenli ödeme</a
-        >
-        <a
-          href="index.html"
-          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
-          >Back</a
-        >
+          >PayTR güvenli ödeme</a>
       </div>
     </div>
     <script>
@@ -91,5 +79,6 @@
         window.open('https://example.com/pay', '_blank');
       });
     </script>
+  </div>
   </body>
 </html>

--- a/top.html
+++ b/top.html
@@ -30,13 +30,32 @@
     <script type="module" src="src/version.js?v=56"></script>
   </head>
   <body class="min-h-screen p-4">
-    <div class="max-w-xl mx-auto space-y-4">
-      <h1 class="text-2xl font-bold mb-4">Top Rankings</h1>
-      <ul class="list-disc pl-6 space-y-2">
-        <li><a href="top-creators.html" class="text-blue-400 underline">Top Creators</a></li>
-        <li><a href="top-collectors.html" class="text-blue-400 underline">Top Collectors</a></li>
-        <li><a href="top-prompts.html" class="text-blue-400 underline">Top Prompts</a></li>
-      </ul>
+    <div class="max-w-4xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
+        <h1 class="text-2xl font-bold mb-4 text-center">Top Rankings</h1>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <h2 class="text-lg font-semibold mb-2 text-center">Top Creators</h2>
+            <div id="creator-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-2 text-center">Top Collectors</h2>
+            <div id="collector-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-2 text-center">Top Prompts</h2>
+            <div id="prompt-list" class="space-y-2"></div>
+          </div>
+        </div>
+      </div>
     </div>
+    <script type="module" src="src/top-creators.js?v=56"></script>
+    <script type="module" src="src/top-collectors.js?v=56"></script>
+    <script type="module" src="src/top-prompts.js?v=56"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add back-arrow navigation and cleaner layout to `pro.html`
- style `top.html` with a container and show three ranking lists side by side
- include scripts to load ranking data
- remove redundant back button and tweak feature text on pro page

## Testing
- `npm test` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b26910a78832f9776314e12e82dfe