### PR TITLE
Integrate Elon Musk Simulator game

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ node_modules/
 css/
 
 prompts.js
+elonmusksimulator-main/**

--- a/elonmusksimulator-main/index.html
+++ b/elonmusksimulator-main/index.html
@@ -17,6 +17,9 @@
     <link rel="manifest" href="manifest.json">
 </head>
 <body>
+    <a href="../index.html" class="back-button" title="Back" aria-label="Back">
+        &larr;
+    </a>
     <div class="container">
         <div class="top-bar">
             <div class="language-toggle"><span id="btn-en">EN</span> | <span id="btn-tr">TR</span></div>

--- a/elonmusksimulator-main/style.css
+++ b/elonmusksimulator-main/style.css
@@ -16,6 +16,26 @@ body {
     padding-bottom: 20px;
 }
 
+.back-button {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    font-size: 20px;
+}
+
+.back-button:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
 .container {
     position: relative;
     width: 90vw;

--- a/index.html
+++ b/index.html
@@ -317,6 +317,11 @@
             >Top</a
           >
         </div>
+        <a
+          href="elonmusksimulator-main/index.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          >Game</a
+        >
         <div
           id="notifications-panel"
           class="hidden absolute right-0 mt-10 bg-black/80 backdrop-blur-md p-2 rounded-md border border-white/20 text-sm w-64 max-h-60 overflow-y-auto"


### PR DESCRIPTION
## Summary
- ignore `elonmusksimulator-main` code in ESLint
- add a **Game** link in the top-right controls
- provide a back button in the game
- style back button for the simulator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bb950d2b0832fb304e8131e229b10