### PR TITLE
Add full sentence random prompt toggle

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -12,6 +12,7 @@ const readLocal = (key, fallback) => {
 export const appState = {
   generatedPrompt: '',
   selectedCategory: 'random',
+  useFullSentenceNext: false,
   isGenerating: false,
   copySuccess: false,
   language: 'en',


### PR DESCRIPTION
## Summary
- allow toggling between combo and full-sentence prompts
- add loader for `fullsentenceprompts.<lang>.json`
- track next prompt type using `useFullSentenceNext` in state

## Testing
- `npm test`
- `npm run format` *(initial run changed many files; reverted unrelated changes)*

------
https://chatgpt.com/codex/tasks/task_e_685bc4036580832f99a5bec4a4adb51f