### PR TITLE
Fix notification read status

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,16 +311,16 @@
           >
             <i data-lucide="message-circle" class="w-5 h-5" aria-hidden="true"></i>
           </a>
-          <a
-            href="top.html"
-            class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
-            >Top</a
-          >
         </div>
         <a
           href="elonmusksimulator-main/index.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center"
           >Game</a
+        >
+        <a
+          href="top.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center"
+          >Top</a
         >
         <div
           id="notifications-panel"

--- a/src/main.js
+++ b/src/main.js
@@ -56,6 +56,23 @@ const initNotifications = (uid) => {
   });
 };
 
+const markAllNotificationsRead = async () => {
+  if (!appState.currentUser) return;
+  const unread = notifications.filter((n) => !n.read);
+  if (!unread.length) return;
+  await Promise.all(
+    unread.map((n) =>
+      markNotificationRead(appState.currentUser.uid, n.id).catch((err) => {
+        console.error('Failed to mark notification read:', err);
+      })
+    )
+  );
+  unread.forEach((n) => {
+    n.read = true;
+  });
+  renderNotifications();
+};
+
 
 const hideEmptyAdSlots = () => {
   const slots = document.querySelectorAll('.ad-slot');
@@ -99,7 +116,9 @@ document.addEventListener('DOMContentLoaded', () => {
   notificationsPanel = document.getElementById('notifications-panel');
 
   notificationBtn?.addEventListener('click', () => {
+    const wasHidden = notificationsPanel?.classList.contains('hidden');
     notificationsPanel?.classList.toggle('hidden');
+    if (wasHidden) markAllNotificationsRead();
   });
 
   checkForNewPrompts();

--- a/src/profile.js
+++ b/src/profile.js
@@ -346,6 +346,23 @@ const initNotifications = (uid) => {
   });
 };
 
+const markAllNotificationsRead = async () => {
+  if (!appState.currentUser) return;
+  const unread = notifications.filter((n) => !n.read);
+  if (!unread.length) return;
+  await Promise.all(
+    unread.map((n) =>
+      markNotificationRead(appState.currentUser.uid, n.id).catch((err) => {
+        console.error('Failed to mark notification read:', err);
+      })
+    )
+  );
+  unread.forEach((n) => {
+    n.read = true;
+  });
+  renderNotifications();
+};
+
 const sharePrompt = (prompt, baseUrl) => {
   if (!prompt) return;
   const url = `${baseUrl}${encodeURIComponent(prompt)}`;
@@ -1038,7 +1055,9 @@ const init = () => {
   notificationsPanel = document.getElementById('notifications-panel');
 
   notificationBtn?.addEventListener('click', () => {
+    const wasHidden = notificationsPanel?.classList.contains('hidden');
     notificationsPanel?.classList.toggle('hidden');
+    if (wasHidden) markAllNotificationsRead();
   });
 
   const savedLang = localStorage.getItem('language') || 'en';


### PR DESCRIPTION
## Summary
- mark all notifications as read when opening the panel
- align 'Game' and 'Top' buttons and rearrange order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bc7830f4c832faeb2e5d57c0d6638