### PR TITLE
Move email to profile header and add username edit button

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -218,6 +218,7 @@
             <i data-lucide="log-out" class="w-4 h-4" aria-hidden="true"></i>
             <span>Logout</span>
           </button>
+          <p id="user-email" class="text-blue-200 text-xs"></p>
           <div
             id="notifications-panel"
             class="hidden absolute right-0 mt-10 bg-black/80 backdrop-blur-md p-2 rounded-md border border-white/20 text-sm w-64 max-h-60 overflow-y-auto"
@@ -225,22 +226,6 @@
         </div>
       </header>
       <div class="mb-4"></div>
-      <div id="user-name-wrapper" class="mb-2">
-        <p id="user-name" class="text-blue-200 cursor-pointer"></p>
-      </div>
-      <div id="name-edit-row" class="flex justify-center gap-2 mb-2 hidden">
-        <input
-          id="name-input"
-          type="text"
-          class="p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
-        />
-        <button
-          id="name-update-btn"
-          class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50"
-        >
-          <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
-        </button>
-      </div>
       <div id="bio-wrapper" class="mb-2">
         <p
           id="user-bio"
@@ -268,7 +253,29 @@
           <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
         </button>
       </div>
-      <p id="user-email" class="text-blue-200 mb-2"></p>
+      <div id="user-name-wrapper" class="mb-2 flex items-center justify-center gap-1">
+        <p id="user-name" class="text-blue-200 cursor-pointer"></p>
+        <button
+          id="edit-name-btn"
+          class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50"
+          title="Edit username"
+        >
+          <i data-lucide="pencil" class="w-4 h-4" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div id="name-edit-row" class="flex justify-center gap-2 mb-2 hidden">
+        <input
+          id="name-input"
+          type="text"
+          class="p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+        />
+        <button
+          id="name-update-btn"
+          class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50"
+        >
+          <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
+        </button>
+      </div>
       <div class="space-x-2 text-sm text-blue-200 my-4 text-center">
         <span>Prompts: <span id="stat-prompts">0</span></span>
         <span>Likes: <span id="stat-likes">0</span></span>

--- a/src/profile.js
+++ b/src/profile.js
@@ -151,6 +151,7 @@ let nameWrapper;
 let nameEditRow;
 let nameInput;
 let nameUpdateBtn;
+let editNameBtn;
 let bioWrapper;
 let bioEditRow;
 let bioInput;
@@ -988,19 +989,23 @@ const init = () => {
   nameEditRow = document.getElementById('name-edit-row');
   nameInput = document.getElementById('name-input');
   nameUpdateBtn = document.getElementById('name-update-btn');
+  editNameBtn = document.getElementById('edit-name-btn');
   bioWrapper = document.getElementById('bio-wrapper');
   bioEditRow = document.getElementById('bio-edit-row');
   bioInput = document.getElementById('bio-input');
   bioUpdateBtn = document.getElementById('bio-update-btn');
   editBioHint = document.getElementById('edit-bio-hint');
 
-  nameWrapper?.addEventListener('click', () => {
+  const showNameEdit = () => {
     if (!nameWrapper || !nameEditRow || !nameInput) return;
     nameInput.value = currentUserName;
     nameWrapper.classList.add('hidden');
     nameEditRow.classList.remove('hidden');
     nameInput.focus();
-  });
+  };
+
+  nameWrapper?.addEventListener('click', showNameEdit);
+  editNameBtn?.addEventListener('click', showNameEdit);
 
   nameUpdateBtn?.addEventListener('click', async () => {
     if (!nameInput || !appState.currentUser) return;


### PR DESCRIPTION
## Summary
- relocate user email to top header area
- show username where email used to be
- add pencil button for editing the username
- update JavaScript to support new `edit-name-btn`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bccc6a3ac832f9cc4e49b65f11838