### PR TITLE
Fix bio edit icon and icon refresh

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -250,7 +250,7 @@
           id="bio-update-btn"
           class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50"
         >
-          <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
+          <i data-lucide="save" class="w-3 h-3" aria-hidden="true"></i>
         </button>
       </div>
       <div id="user-name-wrapper" class="mb-2 flex items-center justify-center gap-1">

--- a/src/profile.js
+++ b/src/profile.js
@@ -1034,6 +1034,7 @@ const init = () => {
     editBioHint?.classList.add('hidden');
     bioEditRow.classList.remove('hidden');
     bioInput.focus();
+    window.lucide?.createIcons();
   });
 
   bioUpdateBtn?.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- update bio save button size on profile page
- re-render lucide icons after toggling the bio edit row

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd85b1504832f90b1bc56e5b42e99