### PR TITLE
Add Firestore indexes for social category filter

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -32,6 +32,25 @@
         { "fieldPath": "shared", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "shared", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "shared", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- add composite indexes to support queries filtering by `category`, `shared`, `userId` and `createdAt`
- deploy indexes with `firebase deploy --only firestore:indexes`

## Testing
- `npm test`
- `firebase deploy --only firestore:indexes` *(fails: No currently active project)*

------
https://chatgpt.com/codex/tasks/task_e_685bdf0e598c832f90238402b7c3f16e