### PR TITLE
Fix small save icon on bio section

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -250,7 +250,7 @@
           id="bio-update-btn"
           class="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50"
         >
-          <i data-lucide="save" class="w-3 h-3" aria-hidden="true"></i>
+          <i data-lucide="save" class="w-4 h-4" aria-hidden="true"></i>
         </button>
       </div>
       <div id="user-name-wrapper" class="mb-2 flex items-center justify-start gap-1">


### PR DESCRIPTION
## Summary
- match bio save button icon size with username save button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685be1d529f4832fbb79779b24cfe8ba