### PR TITLE
Add back navigation to top pages

### DIFF
--- a/top-collectors.html
+++ b/top-collectors.html
@@ -32,8 +32,13 @@
     <script type="module" src="src/version.js?v=56"></script>
   </head>
   <body class="min-h-screen p-4">
-    <div class="max-w-xl mx-auto">
-      <h1 class="text-2xl font-bold mb-4">Top Prompt Collectors</h1>
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompt Collectors</h1>
       <div id="collector-list" class="space-y-2"></div>
     </div>
   </body>

--- a/top-creators.html
+++ b/top-creators.html
@@ -32,8 +32,13 @@
     <script type="module" src="src/version.js?v=56"></script>
   </head>
   <body class="min-h-screen p-4">
-    <div class="max-w-xl mx-auto">
-      <h1 class="text-2xl font-bold mb-4">Top Creators</h1>
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Creators</h1>
       <div id="creator-list" class="space-y-2"></div>
     </div>
   </body>

--- a/top-prompts.html
+++ b/top-prompts.html
@@ -32,8 +32,13 @@
     <script type="module" src="src/version.js?v=56"></script>
   </head>
   <body class="min-h-screen p-4">
-    <div class="max-w-xl mx-auto">
-      <h1 class="text-2xl font-bold mb-4">Top Prompts</h1>
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompts</h1>
       <div id="prompt-list" class="space-y-4"></div>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- add a back arrow link to index.html on Top Creators, Top Collectors, and Top Prompts pages
- style the new back buttons to match top.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685be5af7804832fa4d3613e8121cf41