### PR TITLE
Add credit card icon to payment link

### DIFF
--- a/pro.html
+++ b/pro.html
@@ -70,8 +70,23 @@
         <a
           id="payment-link"
           href="javascript:void(0)"
-          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
-          >PayTR güvenli ödeme</a>
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900 inline-flex items-center gap-1"
+          ><svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect width="20" height="14" x="2" y="5" rx="2" />
+            <line x1="2" y1="10" x2="22" y2="10" />
+          </svg>
+          3D Secure ile güvenli ödeme.
+        </a>
       </div>
     </div>
     <script>


### PR DESCRIPTION
## Summary
- tweak pro version page: modernize PayTR link with credit card icon and new text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685be699b7ec832f8f840ea4df0069ff