### PR TITLE
Handle missing leaderboard stats

### DIFF
--- a/src/top-collectors.js
+++ b/src/top-collectors.js
@@ -30,13 +30,25 @@ const render = async (items) => {
   window.lucide?.createIcons();
 };
 
+const showMessage = (msg) => {
+  const list = document.getElementById('collector-list');
+  if (list) {
+    list.innerHTML = `<p class="text-center text-blue-200 text-sm">${msg}</p>`;
+  }
+};
+
 const load = async () => {
   try {
     const snap = await getDoc(doc(db, 'stats', 'topCollectors'));
-    if (!snap.exists()) return;
+    if (!snap.exists()) {
+      console.error('topCollectors document does not exist');
+      showMessage('Rankings are not available.');
+      return;
+    }
     await render(snap.data().list || []);
   } catch (err) {
     console.error('Failed to load rankings', err);
+    showMessage('Failed to load rankings.');
   }
 };
 

--- a/src/top-creators.js
+++ b/src/top-creators.js
@@ -30,13 +30,25 @@ const render = async (items) => {
   window.lucide?.createIcons();
 };
 
+const showMessage = (msg) => {
+  const list = document.getElementById('creator-list');
+  if (list) {
+    list.innerHTML = `<p class="text-center text-blue-200 text-sm">${msg}</p>`;
+  }
+};
+
 const load = async () => {
   try {
     const snap = await getDoc(doc(db, 'stats', 'topCreators'));
-    if (!snap.exists()) return;
+    if (!snap.exists()) {
+      console.error('topCreators document does not exist');
+      showMessage('Rankings are not available.');
+      return;
+    }
     await render(snap.data().list || []);
   } catch (err) {
     console.error('Failed to load rankings', err);
+    showMessage('Failed to load rankings.');
   }
 };
 

--- a/src/top-prompts.js
+++ b/src/top-prompts.js
@@ -29,13 +29,25 @@ const render = async (items) => {
   window.lucide?.createIcons();
 };
 
+const showMessage = (msg) => {
+  const list = document.getElementById('prompt-list');
+  if (list) {
+    list.innerHTML = `<p class="text-center text-blue-200 text-sm">${msg}</p>`;
+  }
+};
+
 const load = async () => {
   try {
     const snap = await getDoc(doc(db, 'stats', 'topPrompts'));
-    if (!snap.exists()) return;
+    if (!snap.exists()) {
+      console.error('topPrompts document does not exist');
+      showMessage('Rankings are not available.');
+      return;
+    }
     await render(snap.data().list || []);
   } catch (err) {
     console.error('Failed to load rankings', err);
+    showMessage('Failed to load rankings.');
   }
 };
 


### PR DESCRIPTION
## Summary
- check for missing `stats` documents when rendering top lists
- show user-facing message when no ranking data is found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bea263d78832f9aafb17c02098f12