### PR TITLE
Align menu widths and shrink language icon

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -258,7 +258,7 @@
       <div class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10">
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16"
         >
           <button
             id="lang-toggle"
@@ -267,7 +267,7 @@
           >
             <i
               data-lucide="languages"
-              class="w-5 h-5 text-blue-300"
+              class="w-4 h-4 text-blue-300"
               role="img"
               aria-label="Languages icon"
             ></i>
@@ -342,13 +342,13 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Iniciar sesión</a
         >
         <a
           id="profile-link"
           href="profile.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Profile</a
         >
       </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -278,7 +278,7 @@
       <div class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10">
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16"
         >
           <button
             id="lang-toggle"
@@ -287,7 +287,7 @@
           >
             <i
               data-lucide="languages"
-              class="w-5 h-5 text-blue-300"
+              class="w-4 h-4 text-blue-300"
               role="img"
               aria-label="Languages icon"
             ></i>
@@ -362,13 +362,13 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Se connecter</a
         >
         <a
           id="profile-link"
           href="profile.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Profile</a
         >
       </div>

--- a/hi/index.html
+++ b/hi/index.html
@@ -258,7 +258,7 @@
       <div class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10">
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16"
         >
           <button
             id="lang-toggle"
@@ -267,7 +267,7 @@
           >
             <i
               data-lucide="languages"
-              class="w-5 h-5 text-blue-300"
+              class="w-4 h-4 text-blue-300"
               role="img"
               aria-label="Languages icon"
             ></i>
@@ -335,13 +335,13 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >लॉग इन</a
         >
         <a
           id="profile-link"
           href="profile.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Profile</a
         >
       </div>

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
       <div class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10">
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16"
         >
           <button
             id="lang-toggle"
@@ -341,7 +341,7 @@
           >
             <i
               data-lucide="languages"
-              class="w-5 h-5 text-blue-300"
+              class="w-4 h-4 text-blue-300"
               role="img"
               aria-label="Languages icon"
             ></i>
@@ -416,19 +416,19 @@
         <a
           id="login-link"
           href="login.html"
-          class="hidden px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="hidden px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Login</a
         >
         <a
           id="profile-link"
           href="profile.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Profile</a
         >
         <a
           id="explore-link"
           href="social.html"
-          class="relative px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="relative px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Social
           <span
             id="social-new-badge"
@@ -438,7 +438,7 @@
         <a
           id="pro-link"
           href="pro.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Pro</a
         >
       </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -258,7 +258,7 @@
       <div class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10">
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16"
         >
           <button
             id="lang-toggle"
@@ -267,7 +267,7 @@
           >
             <i
               data-lucide="languages"
-              class="w-5 h-5 text-blue-300"
+              class="w-4 h-4 text-blue-300"
               role="img"
               aria-label="Languages icon"
             ></i>
@@ -342,13 +342,13 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Giriş Yap</a
         >
         <a
           id="profile-link"
           href="profile.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Profile</a
         >
       </div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -278,7 +278,7 @@
       <div class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10">
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-full"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16"
         >
           <button
             id="lang-toggle"
@@ -287,7 +287,7 @@
           >
             <i
               data-lucide="languages"
-              class="w-5 h-5 text-blue-300"
+              class="w-4 h-4 text-blue-300"
               role="img"
               aria-label="Languages icon"
             ></i>
@@ -362,13 +362,13 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >登录</a
         >
         <a
           id="profile-link"
           href="profile.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-full text-center"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
           >Profile</a
         >
       </div>


### PR DESCRIPTION
## Summary
- standardize menu link width to `w-16`
- shrink language icon to `w-4 h-4`

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bf295c884832f835989f94631cd66