### PR TITLE
Improve pro page payment button

### DIFF
--- a/pro.html
+++ b/pro.html
@@ -35,9 +35,7 @@
   <body class="min-h-screen p-4">
     <div class="max-w-md mx-auto relative mt-16">
       <div class="absolute top-4 left-4">
-        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back" aria-label="Back">
-          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
-        </a>
+        <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" title="Back">Back</a>
       </div>
     <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
       <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
@@ -68,11 +66,12 @@
           </button>
         </div>
         <div class="flex gap-2 justify-center">
-        <a
+        <button
           id="payment-link"
-          href="javascript:void(0)"
-          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900 inline-flex items-center gap-1"
-          ><svg
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900 flex items-center justify-center gap-1"
+        >
+          <svg
             xmlns="http://www.w3.org/2000/svg"
             class="w-4 h-4"
             viewBox="0 0 24 24"
@@ -87,7 +86,7 @@
             <line x1="2" y1="10" x2="22" y2="10" />
           </svg>
           3D Secure ile güvenli ödeme.
-        </a>
+        </button>
       </div>
     </div>
     <script>


### PR DESCRIPTION
## Summary
- remove giant back icon
- style the payment section button using Tailwind

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf63cf6ec832fab50b7443c86d29c