### PR TITLE
Add intro page with overview and help links

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -509,6 +509,13 @@
             alt="Logo de WhatsApp"
           />
         </a>
+        <a
+          href="../intro.html"
+          class="flex justify-center mt-2"
+          aria-label="Resumen de Prompter"
+        >
+          <i data-lucide="help-circle" class="w-6 h-6" aria-hidden="true"></i>
+        </a>
       </div>
     </div>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -643,6 +643,13 @@
             alt="WhatsApp logo"
           />
         </a>
+        <a
+          href="../intro.html"
+          class="flex justify-center mt-2"
+          aria-label="Aperçu de Prompter"
+        >
+          <i data-lucide="help-circle" class="w-6 h-6" aria-hidden="true"></i>
+        </a>
       </div>
     </div>
     <script type="module" src="src/init-app.js?v=56"></script>

--- a/hi/index.html
+++ b/hi/index.html
@@ -502,6 +502,13 @@
             alt="Logo de WhatsApp"
           />
         </a>
+        <a
+          href="../intro.html"
+          class="flex justify-center mt-2"
+          aria-label="Prompter के बारे में"
+        >
+          <i data-lucide="help-circle" class="w-6 h-6" aria-hidden="true"></i>
+        </a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -649,6 +649,13 @@
             alt="WhatsApp logo"
           />
         </a>
+        <a
+          href="intro.html"
+          class="flex justify-center mt-2"
+          aria-label="Prompter overview"
+        >
+          <i data-lucide="help-circle" class="w-6 h-6" aria-hidden="true"></i>
+        </a>
       </div>
     </div>
     <script type="module" src="src/init-app.js?v=56"></script>

--- a/intro.html
+++ b/intro.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Introduction - Prompter</title>
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=56" />
+    <link rel="manifest" href="manifest.json?v=56" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link rel="stylesheet" href="css/tailwind.css?v=56" />
+    <link rel="stylesheet" href="css/app.css?v=56" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=56" />
+    <link rel="canonical" href="https://prompterai.space/intro.html" />
+    <script type="module" src="src/version.js?v=56"></script>
+  </head>
+  <body class="bg-black text-white min-h-screen p-4">
+    <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>
+    <p class="mb-2">Prompter is a lightweight web app that generates creative prompts for AI models entirely in your browser.</p>
+    <p class="mb-2">It offers twelve prompt categories and six interface languages with more than 53 million combinations per language.</p>
+    <p class="mb-2">Use the <strong>copy</strong> and <strong>share</strong> buttons to reuse or publish prompts. Select the star icon to save favorites locally or online when signed in.</p>
+    <p class="mb-2">Join the community WhatsApp group for updates and new ideas.</p>
+    <p class="mb-2">Our vision is to spark creativity by making prompt generation quick, fun and accessible.</p>
+    <a href="index.html" class="text-blue-400 underline">Return to Prompter</a>
+  </body>
+</html>

--- a/tr/index.html
+++ b/tr/index.html
@@ -509,6 +509,13 @@
             alt="WhatsApp logosu"
           />
         </a>
+        <a
+          href="../intro.html"
+          class="flex justify-center mt-2"
+          aria-label="Prompter hakkında"
+        >
+          <i data-lucide="help-circle" class="w-6 h-6" aria-hidden="true"></i>
+        </a>
       </div>
     </div>
 

--- a/zh/index.html
+++ b/zh/index.html
@@ -643,6 +643,13 @@
             alt="WhatsApp logo"
           />
         </a>
+        <a
+          href="../intro.html"
+          class="flex justify-center mt-2"
+          aria-label="Prompter 介紹"
+        >
+          <i data-lucide="help-circle" class="w-6 h-6" aria-hidden="true"></i>
+        </a>
       </div>
     </div>
     <script type="module" src="src/init-app.js?v=56"></script>


### PR DESCRIPTION
## Summary
- create `intro.html` with a short overview of the app
- link the new page beside the WhatsApp icon on the main and translated index pages using a help icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c125cc750832f9b4aabbf653cc79a