### PR TITLE
Rename Blog to Space

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog - Prompter</title>
+    <title>Space - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=61" />
     <meta name="theme-color" content="#000000" />
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Blog</h1>
+          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>
       <div class="mb-4">

--- a/es/blog.html
+++ b/es/blog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog - Prompter</title>
+    <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=61" />
     <meta name="theme-color" content="#000000" />
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Blog</h1>
+          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>
       <div class="mb-4">

--- a/es/index.html
+++ b/es/index.html
@@ -262,7 +262,7 @@
       <a
         href="es/blog.html"
         class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Blog</a
+        >Space</a
       >
 
       <!-- Language Switcher -->

--- a/fr/blog.html
+++ b/fr/blog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog - Prompter</title>
+    <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=61" />
     <meta name="theme-color" content="#000000" />
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Blog</h1>
+          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>
       <div class="mb-4">

--- a/fr/index.html
+++ b/fr/index.html
@@ -282,7 +282,7 @@
       <a
         href="fr/blog.html"
         class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Blog</a
+        >Space</a
       >
 
       <!-- Language Switcher -->

--- a/hi/blog.html
+++ b/hi/blog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog - Prompter</title>
+    <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=61" />
     <meta name="theme-color" content="#000000" />
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Blog</h1>
+          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>
       <div class="mb-4">

--- a/hi/index.html
+++ b/hi/index.html
@@ -262,7 +262,7 @@
       <a
         href="hi/blog.html"
         class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Blog</a
+        >Space</a
       >
 
       <!-- Language Switcher -->

--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
         <a
           href="blog.html"
           class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-          >Blog</a
+          >Space</a
         >
         <div
           id="notifications-panel"

--- a/tr/blog.html
+++ b/tr/blog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog - Prompter</title>
+    <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=61" />
     <meta name="theme-color" content="#000000" />
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Blog</h1>
+          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>
       <div class="mb-4">

--- a/tr/index.html
+++ b/tr/index.html
@@ -262,7 +262,7 @@
       <a
         href="tr/blog.html"
         class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Blog</a
+        >Space</a
       >
 
       <!-- Language Switcher -->

--- a/zh/blog.html
+++ b/zh/blog.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blog - Prompter</title>
+    <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=61" />
     <meta name="theme-color" content="#000000" />
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Blog</h1>
+          <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>
       <div class="mb-4">

--- a/zh/index.html
+++ b/zh/index.html
@@ -282,7 +282,7 @@
       <a
         href="zh/blog.html"
         class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Blog</a
+        >Space</a
       >
 
       <!-- Language Switcher -->


### PR DESCRIPTION
## Summary
- rename the blog navigation label to "Space"
- update `<title>` and heading text in `blog.html`
- update translations to use "Space" as well

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c356f1a1c832f9505afaf6157e4f5