### PR TITLE
Add post deletion UI

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -136,6 +136,7 @@
         unsharePostByUser,
         addComment,
         getComments,
+        deletePost,
       } from './src/blog.js';
       import { getUserProfile } from './src/user.js';
       import { onAuth } from './src/auth.js';
@@ -266,6 +267,25 @@
         likeRow.appendChild(likeCount);
         likeRow.appendChild(shareBtn);
         likeRow.appendChild(commentContainer);
+        if (appState?.currentUser && appState.currentUser.uid === p.userId) {
+          const delBtn = document.createElement('button');
+          delBtn.className =
+            'delete-post p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all focus:outline-none focus:ring-2 focus:ring-white/50';
+          delBtn.innerHTML =
+            '<i data-lucide="trash" class="w-4 h-4" aria-hidden="true"></i>';
+          delBtn.addEventListener('click', async () => {
+            delBtn.disabled = true;
+            try {
+              await deletePost(p.id);
+              card.classList.add('fade-out');
+              setTimeout(() => card.remove(), 300);
+            } catch (err) {
+              console.error('Failed to delete post:', err);
+              delBtn.disabled = false;
+            }
+          });
+          likeRow.appendChild(delBtn);
+        }
         card.appendChild(likeRow);
 
         const commentsWrap = document.createElement('div');

--- a/src/blog.js
+++ b/src/blog.js
@@ -10,6 +10,7 @@ import {
   increment,
   arrayUnion,
   arrayRemove,
+  deleteDoc,
   getDoc,
   serverTimestamp,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
@@ -97,3 +98,5 @@ export const getComments = async (postId) => {
 
 export const updatePostText = (postId, newText) =>
   updateDoc(doc(db, 'blogPosts', postId), { text: newText });
+
+export const deletePost = (postId) => deleteDoc(doc(db, 'blogPosts', postId));


### PR DESCRIPTION
## Summary
- show delete button on blog posts for the owner
- enable deleting a post from Firestore

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c372608e4832fa9b29a5eb2e6b903