### PR TITLE
Move help link near theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,14 @@
       <!-- Theme Toggle -->
       <div class="absolute top-4 right-0 flex flex-col items-end gap-2 z-10">
         <div class="theme-toggle-container flex items-center gap-2">
+          <a
+            href="intro.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Prompter overview"
+            aria-label="Prompter overview"
+          >
+            <i data-lucide="help-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
           <button
             id="theme-light"
             class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
@@ -648,13 +656,6 @@
             class="w-6 h-6"
             alt="WhatsApp logo"
           />
-        </a>
-        <a
-          href="intro.html"
-          class="flex justify-center mt-2"
-          aria-label="Prompter overview"
-        >
-          <i data-lucide="help-circle" class="w-6 h-6" aria-hidden="true"></i>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- relocate the help link from the footer to the theme toggle buttons

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c4d0d9650832f81dbe7db48b0d408