### PR TITLE
Store user emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,11 @@ npm run build:css
 This command invokes the Tailwind CLI to compile `src/styles.css` into
 `css/tailwind.css`.
 
-To backfill older accounts with a root-level name field run:
+To backfill older accounts with root-level name and email fields run:
 
 ```bash
 node scripts/migrate-user-names.js
+node scripts/migrate-user-emails.js
 ```
 
 This script copies the `name` from `users/{uid}/profile/info` into the parent

--- a/login.html
+++ b/login.html
@@ -213,7 +213,7 @@
           authError.textContent = 'Loading...';
           try {
             const cred = await register(email, password);
-            await setUserProfile(cred.user.uid, { name });
+            await setUserProfile(cred.user.uid, { name, email });
             authError.classList.remove('text-red-500');
             authError.classList.add('text-green-500');
             authError.textContent = 'Registration successful';

--- a/scripts/migrate-user-emails.js
+++ b/scripts/migrate-user-emails.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const admin = require('firebase-admin');
+
+// Initialize using default credentials
+admin.initializeApp();
+
+const db = admin.firestore();
+const auth = admin.auth();
+
+async function migrate() {
+  const usersSnap = await db.collection('users').get();
+  for (const user of usersSnap.docs) {
+    if (user.get('email')) continue;
+    const profileRef = db.doc(`users/${user.id}/profile/info`);
+    const profileSnap = await profileRef.get();
+    const profile = profileSnap.exists ? profileSnap.data() : null;
+    let email = profile && profile.email ? profile.email : null;
+    if (!email) {
+      try {
+        const authUser = await auth.getUser(user.id);
+        email = authUser.email || null;
+      } catch (err) {
+        console.error(`Failed to fetch auth for ${user.id}:`, err.message);
+      }
+    }
+    if (email) {
+      await user.ref.set({ email }, { merge: true });
+      await profileRef.set({ email }, { merge: true });
+      console.log(`Updated user ${user.id}`);
+    }
+  }
+}
+
+migrate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/user.js
+++ b/src/user.js
@@ -15,6 +15,7 @@ export const setUserProfile = async (uid, profile) => {
   await setDoc(doc(db, 'users', uid, 'profile', 'info'), profile);
   const update = {};
   if (profile && profile.name) update.name = profile.name;
+  if (profile && profile.email) update.email = profile.email;
   if (profile && Object.prototype.hasOwnProperty.call(profile, 'bio')) {
     update.bio = profile.bio;
   }


### PR DESCRIPTION
## Summary
- store user email addresses in Firestore user profiles
- propagate emails to the root `users/{uid}` docs via new migration script
- allow registration to save email along with username
- document how to backfill email data

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d38c7f0f0832f8bb6ba8932468b73