### PR TITLE
Fix language menu z-index

### DIFF
--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -93,6 +93,7 @@ body {
 #lang-menu {
   background-color: rgba(0, 0, 0, 0.8) !important;
   color: white !important;
+  z-index: 20;
 }
 #lang-menu button:hover {
   background-color: rgba(255, 255, 255, 0.1) !important;

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -99,6 +99,7 @@ body {
 #lang-menu {
   background-color: rgba(255, 255, 255, 0.5) !important;
   color: #334155 !important;
+  z-index: 20;
 }
 #lang-menu button:hover {
   background-color: rgba(0, 0, 0, 0.1) !important;


### PR DESCRIPTION
## Summary
- keep dropdown menu clickable in both themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d4da4a510832f8dab2cdc54bfa96d