### PR TITLE
Set Turkish as default language

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -1066,7 +1066,7 @@ const init = () => {
     if (wasHidden) markAllNotificationsRead();
   });
 
-  const savedLang = localStorage.getItem('language') || 'en';
+  const savedLang = localStorage.getItem('language') || 'tr';
   setLanguage(savedLang);
 
   const currentTheme = localStorage.getItem('theme') || THEMES.DARK;

--- a/src/ui.js
+++ b/src/ui.js
@@ -1345,7 +1345,7 @@ export const initializeApp = () => {
     return false;
   };
 
-  const savedLanguage = localStorage.getItem('language') || 'en';
+  const savedLanguage = localStorage.getItem('language') || 'tr';
   setLanguage(savedLanguage);
 
   const savedTheme = localStorage.getItem('theme') || THEMES.DARK;


### PR DESCRIPTION
## Summary
- use Turkish as the default language in `ui.js` and `profile.js`

## Testing
- `npm test`
- `node test-language-switch.js` (ensures language toggle works)

------
https://chatgpt.com/codex/tasks/task_e_685d524128ec832fab9f05d44bc23d19