### PR TITLE
Add blogPosts security rules

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -51,6 +51,22 @@
         { "fieldPath": "category", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "blogPosts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "shared", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "blogPosts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -21,6 +21,27 @@ service cloud.firestore {
       }
     }
 
+    // Blog posts have the same permissions as prompts
+    match /blogPosts/{postId} {
+      allow read: if true;
+      allow create: if request.auth != null;
+      allow update: if request.auth != null && (
+        request.resource.data
+          .diff(resource.data)
+          .changedKeys()
+          .hasOnly(['likes', 'likedBy', 'sharedBy', 'shared']) ||
+        (
+          request.auth.uid == resource.data.userId &&
+          request.resource.data.diff(resource.data).changedKeys().hasOnly(['text'])
+        )
+      );
+
+      match /comments/{commentId} {
+        allow read: if true;
+        allow create: if request.auth != null;
+      }
+    }
+
     match /users/{uid} {
       match /profile/{docId} {
         allow read, write: if request.auth != null && request.auth.uid == uid;


### PR DESCRIPTION
## Summary
- extend `firestore.rules` with a `/blogPosts/{postId}` block mirroring prompt permissions
- add indexes for `/blogPosts` queries in `firestore.indexes.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d536d21ac832fa44f9239bb51e465