### PR TITLE
Add read rule for user documents

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,6 +43,7 @@ service cloud.firestore {
     }
 
     match /users/{uid} {
+      allow read: if request.auth != null && request.auth.uid == uid;
       match /profile/{docId} {
         allow read, write: if request.auth != null && request.auth.uid == uid;
       }


### PR DESCRIPTION
## Summary
- allow users to read their own `/users/{uid}` document

## Testing
- `npm install -g firebase-tools`
- `firebase deploy --only firestore:rules` *(fails: No currently active project)*

------
https://chatgpt.com/codex/tasks/task_e_685d55172534832f86abd36724c3ea5d