### PR TITLE
Adjust header icon dimensions

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -237,8 +237,14 @@ html {
   line-height: 1.1;
 }
 /* Theme Toggle Styles */
-.theme-toggle-container button {
+.theme-toggle-container button,
+.theme-toggle-container a {
   transition: background-color 0.2s ease, color 0.2s ease;
+  width: 4rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* History panel */

--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
         <div class="theme-toggle-container flex items-center gap-2">
           <a
             href="intro.html"
-            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-8 flex items-center justify-center"
             title="Prompter overview"
             aria-label="Prompter overview"
           >
@@ -275,7 +275,7 @@
           </a>
           <button
             id="theme-light"
-            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-8 flex items-center justify-center"
             title="Light Theme"
             aria-label="Light Theme"
           >
@@ -288,7 +288,7 @@
           </button>
           <button
             id="theme-dark"
-            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-8 flex items-center justify-center"
             title="Dark Theme"
             aria-label="Dark Theme"
           >
@@ -301,7 +301,7 @@
           </button>
           <button
             id="notifications-btn"
-            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 relative"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 relative w-16 h-8 flex items-center justify-center"
             title="Notifications"
             aria-label="Notifications"
           >
@@ -313,7 +313,7 @@
           </button>
           <a
             href="dm.html"
-            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-8 flex items-center justify-center"
             title="Messages"
             aria-label="Messages"
           >


### PR DESCRIPTION
## Summary
- enlarge top-right header icons to match language selector
- apply consistent sizing to header icons via CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d57fb8454832f907b43e6f5363cb3