### PR TITLE
Fix header link in DM pages

### DIFF
--- a/dm.html
+++ b/dm.html
@@ -23,7 +23,7 @@
     <div id="app-container" class="w-full">
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
-          <a href="profile.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+          <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
           <img src="icons/logo.svg?v=61" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />

--- a/tr/dm.html
+++ b/tr/dm.html
@@ -23,7 +23,7 @@
     <div id="app-container" class="w-full">
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
-          <a href="profile.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+          <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
           <img src="icons/logo.svg?v=61" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />


### PR DESCRIPTION
## Summary
- point the DM back-arrow to `index.html` instead of `profile.html`

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d76515ae4832f92b2f8d44f919bed