### PR TITLE
Add DM link on user page

### DIFF
--- a/src/user-page.js
+++ b/src/user-page.js
@@ -54,6 +54,7 @@ const init = async () => {
   let uid = getParam('uid');
   const nameQuery = getParam('name');
   let name = '';
+  const dmLink = document.getElementById('dm-link');
 
   if (!uid && nameQuery) {
     const user = await getUserByName(nameQuery);
@@ -78,6 +79,18 @@ const init = async () => {
 
   const followBtn = document.getElementById('follow-btn');
   let currentUserId = null;
+
+  const updateDmLink = () => {
+    if (!dmLink) return;
+    if (currentUserId && currentUserId !== uid) {
+      dmLink.href = `dm.html?uid=${encodeURIComponent(uid)}`;
+      dmLink.classList.remove('hidden');
+    } else {
+      dmLink.classList.add('hidden');
+    }
+  };
+
+  updateDmLink();
 
   const updateFollowBtn = async () => {
     if (!followBtn || !currentUserId || currentUserId === uid) {
@@ -107,6 +120,7 @@ const init = async () => {
   onAuth(async (u) => {
     currentUserId = u ? u.uid : null;
     await updateFollowBtn();
+    updateDmLink();
   });
 
   const prompts = await getUserPrompts(uid);

--- a/user.html
+++ b/user.html
@@ -49,6 +49,7 @@
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>
             </div>
           </div>
+        <div class="flex flex-col items-end gap-2">
           <div class="flex items-center gap-2">
             <button
               id="theme-light"
@@ -70,7 +71,17 @@
               id="follow-btn"
               class="p-1.5 rounded-md text-sm font-medium bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50 hidden"
             ></button>
+            <a
+              id="dm-link"
+              href="dm.html"
+              class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 hidden"
+              title="Messages"
+              aria-label="Messages"
+            >
+              <i data-lucide="message-circle" class="w-5 h-5" aria-hidden="true"></i>
+            </a>
           </div>
+        </div>
         </header>
         <div class="max-w-xl mx-auto relative">
           <p id="user-bio" class="text-blue-200 whitespace-pre-line mb-4 text-center"></p>


### PR DESCRIPTION
## Summary
- sync user page header with profile page styling
- add DM link so users can send direct messages
- expose DM link logic in `user-page.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8ab400c0832fb6d02749cbefd2c1