### PR TITLE
Fix Turkish blog header logo

### DIFF
--- a/tr/blog.html
+++ b/tr/blog.html
@@ -118,6 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
+          <img src="icons/logo.svg?v=61" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- show Prompter logo beside the back arrow in the Turkish blog page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8fcbed8c832fa809faf05d680214