### PR TITLE
Add Firestore composite index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -53,6 +53,16 @@
       ]
     },
     {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "shared", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "blogPosts",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Summary
- add index with `shared`, `category`, `userId`, `createdAt` for the `prompts` collection

## Testing
- `npm test`
- `npx -y firebase-tools deploy --only firestore:indexes` *(fails: No currently active project)*

------
https://chatgpt.com/codex/tasks/task_e_685d939d1aa4832fb90e514d39140b0c