### PR TITLE
Adjust language menu positioning

### DIFF
--- a/css/theme-dark.css
+++ b/css/theme-dark.css
@@ -94,7 +94,7 @@ body {
   background-color: rgba(0, 0, 0, 0.8) !important;
   color: white !important;
   width: 4rem;
-  z-index: 20;
+  z-index: 50;
 }
 #lang-menu button:hover {
   background-color: rgba(255, 255, 255, 0.1) !important;

--- a/css/theme-light.css
+++ b/css/theme-light.css
@@ -100,7 +100,7 @@ body {
   background-color: rgba(255, 255, 255, 0.5) !important;
   color: #334155 !important;
   width: 4rem;
-  z-index: 20;
+  z-index: 50;
 }
 #lang-menu button:hover {
   background-color: rgba(0, 0, 0, 0.1) !important;

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
       <div class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10">
         <div
           id="lang-container"
-          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16"
+          class="relative flex items-center bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 w-16 z-40"
         >
           <button
             id="lang-toggle"
@@ -390,6 +390,13 @@
               EN
             </button>
             <button
+              id="lang-hi"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Hindi"
+            >
+              HI
+            </button>
+            <button
               id="lang-tr"
               class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
               aria-label="Switch to Turkish"
@@ -416,13 +423,6 @@
               aria-label="Switch to Chinese"
             >
               ZH
-            </button>
-            <button
-              id="lang-hi"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Hindi"
-            >
-              HI
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move HI before TR in the language switcher
- raise language menu z-index so it overlays other controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d94ce001c832fb12ca656f54da2ef