### PR TITLE
Add relative time display and update info texts

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -164,6 +164,7 @@
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { linkify } from './src/linkify.js';
+      import { timeAgo } from './src/timeago.js';
       const msgs = {
         en: { loginRequired: 'Login required' },
         tr: { loginRequired: 'Giriş gerekli' },
@@ -229,6 +230,13 @@
         nameEl.className = 'text-blue-200 text-xs mt-1 underline';
         nameEl.innerHTML = `<a href="user.html?uid=${p.userId}">${name}</a>`;
         card.appendChild(nameEl);
+
+        const timeEl = document.createElement('p');
+        timeEl.className = 'text-blue-200 text-xs';
+        if (p.createdAt && p.createdAt.toMillis) {
+          timeEl.textContent = timeAgo(p.createdAt.toMillis(), appState.language);
+        }
+        card.appendChild(timeEl);
 
         const likeRow = document.createElement('div');
         likeRow.className = 'flex items-center gap-2 mt-2';

--- a/intro.html
+++ b/intro.html
@@ -23,6 +23,7 @@
     <p class="mb-2">Use the <strong>copy</strong> and <strong>share</strong> buttons to reuse or publish prompts. Select the star icon to save favorites locally or online when signed in.</p>
     <p class="mb-2">Join the community WhatsApp group for updates and new ideas.</p>
     <p class="mb-2">Our vision is to spark creativity by making prompt generation quick, fun and accessible.</p>
+    <p class="mb-2">You can support Prompter by subscribing on the <a href="pro.html">Pro page</a> or by clicking the support button.</p>
     <p class="mb-2">Şu aşamada en iyi sonuçları <strong>Random</strong> kategorisi vermektedir çünkü en yüksek işlem gücü bu sekme için tahsis edilmiştir.</p>
     <a href="index.html" class="text-blue-400 underline">Return to Prompter</a>
   </body>

--- a/social.html
+++ b/social.html
@@ -225,6 +225,7 @@
       import { promptScore } from './src/scoring.js';
       import { appState } from './src/state.js';
       import { linkify } from './src/linkify.js';
+      import { timeAgo } from './src/timeago.js';
       import { categories } from './src/prompts.js?v=63';
       import {
         getUserProfile,
@@ -825,6 +826,12 @@
         card.appendChild(textWrap);
         card.appendChild(nameEl);
         card.appendChild(catEl);
+        const timeEl = document.createElement('p');
+        timeEl.className = 'text-blue-200 text-xs';
+        if (p.createdAt && p.createdAt.toMillis) {
+          timeEl.textContent = timeAgo(p.createdAt.toMillis(), appState.language);
+        }
+        card.appendChild(timeEl);
         card.appendChild(likeRow);
         card.appendChild(likeWrapper);
         card.appendChild(commentsWrap);

--- a/src/timeago.js
+++ b/src/timeago.js
@@ -1,0 +1,38 @@
+export function timeAgo(timestamp, lang = 'en') {
+  const now = Date.now();
+  const diff = now - timestamp;
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+  const month = 30 * day;
+  const year = 365 * day;
+  const tr = {
+    minute: 'dk',
+    hour: 'sa',
+    day: 'g',
+    week: 'hf',
+    month: 'ay',
+    year: 'yıl',
+    ago: 'önce',
+    now: 'az önce',
+  };
+  const en = {
+    minute: 'm',
+    hour: 'h',
+    day: 'd',
+    week: 'w',
+    month: 'mo',
+    year: 'y',
+    ago: 'ago',
+    now: 'just now',
+  };
+  const t = lang === 'tr' ? tr : en;
+  if (diff >= year) return `${Math.floor(diff / year)} ${t.year} ${t.ago}`;
+  if (diff >= month) return `${Math.floor(diff / month)} ${t.month} ${t.ago}`;
+  if (diff >= week) return `${Math.floor(diff / week)} ${t.week} ${t.ago}`;
+  if (diff >= day) return `${Math.floor(diff / day)} ${t.day} ${t.ago}`;
+  if (diff >= hour) return `${Math.floor(diff / hour)} ${t.hour} ${t.ago}`;
+  if (diff >= minute) return `${Math.floor(diff / minute)} ${t.minute} ${t.ago}`;
+  return t.now;
+}

--- a/tr/intro.html
+++ b/tr/intro.html
@@ -24,6 +24,7 @@
     <p class="mb-2">Kopyala ve paylaş düğmeleri komutlarınızı hızlıca başkalarına iletmenizi sağlar. Oturum açtığınızda yıldız simgesiyle favorilerinizi bulutta saklayabilirsiniz.</p>
     <p class="mb-2">Menüdeki ödül simgesinden en popüler 10 komuta ulaşabilir, güneş ve ay ikonlarıyla açık veya koyu temaya geçiş yapabilirsiniz.</p>
     <p class="mb-2">Güncellemeler için topluluk WhatsApp grubuna katılabilir veya sorularınız için <strong>prompterai@outlook.com</strong> adresine e‑posta gönderebilirsiniz.</p>
+    <p class="mb-2">Prompter'a destek olmak için <a href="pro.html">Pro sayfasından</a> abone olabilir ya da destek butonuna basabilirsiniz.</p>
     <p class="mb-2">Şu aşamada en iyi sonuçları <strong>Random</strong> kategorisi vermektedir çünkü en yüksek işlem gücü bu sekme için tahsis edilmiştir.</p>
     <a href="tr/index.html" class="text-blue-400 underline">Prompter'a dön</a>
     </body>


### PR DESCRIPTION
## Summary
- show time since creation for posts on Social and Space pages
- provide helper `timeAgo` in JS for Turkish and English
- mention Pro page subscription in intro pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d9b5e8338832fb5f8806a7da14831