### PR TITLE
Insert logo next to back button in blog header

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -118,6 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
+          <img src="icons/logo.svg?v=63" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
         <div class="ml-auto flex flex-col items-start gap-1">


### PR DESCRIPTION
## Summary
- add the Prompter logo beside the back button on `blog.html`

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dba07ee64832f87a68e844af4dd7d