### PR TITLE
Store user profile info on save

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,14 +11,14 @@
     </script>
     -->
     <title>404 - Page Not Found</title>
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -30,7 +30,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body
     class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"

--- a/blog.html
+++ b/blog.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Space - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -74,8 +74,8 @@
           return { cdn: cdnScript, local: localScript, loadPromise };
         }
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -85,11 +85,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -101,7 +101,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <img src="icons/logo.svg?v=63" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <img src="icons/logo.svg?v=64" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
         <div class="ml-auto flex flex-col items-start gap-1">
@@ -462,8 +462,6 @@
           await createPost(
             text,
             appState.currentUser.uid,
-            appState.currentUser.displayName || '',
-            appState.currentUser.email || ''
           );
           blogInput.value = '';
         } finally {

--- a/dm.html
+++ b/dm.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Direct Messages - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/dm.js?v=63"></script>
-    <script nomodule src="dist/dm.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/dm.js?v=64"></script>
+    <script nomodule src="dist/dm.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -26,7 +26,7 @@
           <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <img src="icons/logo.svg?v=63" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <img src="icons/logo.svg?v=64" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <div class="ml-1">
             <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
             <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>

--- a/elonmusksimulator-main/index.html
+++ b/elonmusksimulator-main/index.html
@@ -8,13 +8,13 @@
     <title>Elon Musk Simulator</title>
     <meta property="og:title" content="Elon Musk Simulator">
     <meta property="og:description" content="Elon Musk Simulator is a parody browser game where your decisions keep his ventures afloat.">
-    <meta property="og:image" content="elon_musk_cartoon.png?v=63">
+    <meta property="og:image" content="elon_musk_cartoon.png?v=64">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Elon Musk Simulator">
     <meta name="twitter:description" content="Elon Musk Simulator is a parody browser game where your decisions keep his ventures afloat.">
-    <meta name="twitter:image" content="elon_musk_cartoon.png?v=63">
-    <link rel="stylesheet" href="style.css?v=63">
-    <link rel="manifest" href="manifest.json?v=63">
+    <meta name="twitter:image" content="elon_musk_cartoon.png?v=64">
+    <link rel="stylesheet" href="style.css?v=64">
+    <link rel="manifest" href="manifest.json?v=64">
 </head>
 <body>
     <a href="../index.html" class="back-button" title="Back" aria-label="Back">
@@ -56,7 +56,7 @@
         </div>
     </div>
     <!-- Question data will be loaded lazily from JSON files -->
-    <script type="module" src="translations.js?v=63"></script>
-    <script type="module" src="main.js?v=63"></script>
+    <script type="module" src="translations.js?v=64"></script>
+    <script type="module" src="main.js?v=64"></script>
 </body>
 </html>

--- a/es/blog.html
+++ b/es/blog.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -74,8 +74,8 @@
           return { cdn: cdnScript, local: localScript, loadPromise };
         }
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -85,11 +85,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -101,7 +101,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -306,8 +306,6 @@
           await createPost(
             text,
             appState.currentUser.uid,
-            appState.currentUser.displayName || '',
-            appState.currentUser.email || ''
           );
           blogInput.value = '';
         } finally {

--- a/es/index.html
+++ b/es/index.html
@@ -16,9 +16,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="preload" href="icons/logo.svg?v=63" as="image" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="preload" href="icons/logo.svg?v=64" as="image" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -40,7 +40,7 @@
       property="og:description"
       content="Generador de prompts creativos para IA que requiere conexión a Internet."
     />
-    <meta property="og:image" content="icons/logo.svg?v=63" />
+    <meta property="og:image" content="icons/logo.svg?v=64" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -49,7 +49,7 @@
       name="twitter:description"
       content="Generador de prompts creativos para IA que requiere conexión a Internet."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=63" />
+    <meta name="twitter:image" content="icons/logo.svg?v=64" />
     <meta property="og:url" content="https://prompterai.space/es/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -185,8 +185,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63',
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64',
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -196,9 +196,9 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -210,7 +210,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -367,7 +367,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="icons/logo.svg?v=63"
+          src="icons/logo.svg?v=64"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -491,7 +491,7 @@
           aria-label="Grupo de WhatsApp"
         >
           <img
-            src="icons/whatsapp.svg?v=63"
+            src="icons/whatsapp.svg?v=64"
             class="w-6 h-6"
             alt="Logo de WhatsApp"
           />
@@ -506,10 +506,10 @@
       </div>
     </div>
 
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/main.js?v=63"></script>
-    <script nomodule src="dist/main.js?v=63"></script>
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/main.js?v=64"></script>
+    <script nomodule src="dist/main.js?v=64"></script>
     <script type="module">
       import { app } from './src/firebase.js';
       import { onAuth } from './src/auth.js';

--- a/es/intro.html
+++ b/es/intro.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Introduction - Prompter</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Bienvenido a Prompter</h1>

--- a/fr/blog.html
+++ b/fr/blog.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -74,8 +74,8 @@
           return { cdn: cdnScript, local: localScript, loadPromise };
         }
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -85,11 +85,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -101,7 +101,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -306,8 +306,6 @@
           await createPost(
             text,
             appState.currentUser.uid,
-            appState.currentUser.displayName || '',
-            appState.currentUser.email || ''
           );
           blogInput.value = '';
         } finally {

--- a/fr/index.html
+++ b/fr/index.html
@@ -21,9 +21,9 @@
     />
     <title>PROMPTER</title>
     <base href="./" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="preload" href="icons/logo.svg?v=63" as="image" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="preload" href="icons/logo.svg?v=64" as="image" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -45,7 +45,7 @@
       property="og:description"
       content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet."
     />
-    <meta property="og:image" content="icons/logo.svg?v=63" />
+    <meta property="og:image" content="icons/logo.svg?v=64" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -54,7 +54,7 @@
       name="twitter:description"
       content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=63" />
+    <meta name="twitter:image" content="icons/logo.svg?v=64" />
     <meta property="og:url" content="https://prompterai.space/fr/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -190,8 +190,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63',
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64',
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -201,9 +201,9 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -215,7 +215,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <script
@@ -387,7 +387,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="icons/logo.svg?v=63"
+          src="icons/logo.svg?v=64"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -633,7 +633,7 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=63"
+            src="icons/whatsapp.svg?v=64"
             class="w-6 h-6"
             alt="WhatsApp logo"
           />
@@ -647,10 +647,10 @@
         </a>
       </div>
     </div>
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/main.js?v=63"></script>
-    <script nomodule src="dist/main.js?v=63"></script>
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/main.js?v=64"></script>
+    <script nomodule src="dist/main.js?v=64"></script>
     <script type="module">
       import { app } from './src/firebase.js';
       import { onAuth } from './src/auth.js';

--- a/fr/intro.html
+++ b/fr/intro.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Introduction - Prompter</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Bienvenue sur Prompter</h1>

--- a/hi/blog.html
+++ b/hi/blog.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -74,8 +74,8 @@
           return { cdn: cdnScript, local: localScript, loadPromise };
         }
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -85,11 +85,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -101,7 +101,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -306,8 +306,6 @@
           await createPost(
             text,
             appState.currentUser.uid,
-            appState.currentUser.displayName || '',
-            appState.currentUser.email || ''
           );
           blogInput.value = '';
         } finally {

--- a/hi/index.html
+++ b/hi/index.html
@@ -16,9 +16,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="preload" href="icons/logo.svg?v=63" as="image" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="preload" href="icons/logo.svg?v=64" as="image" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -40,7 +40,7 @@
       property="og:description"
       content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर."
     />
-    <meta property="og:image" content="icons/logo.svg?v=63" />
+    <meta property="og:image" content="icons/logo.svg?v=64" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -49,7 +49,7 @@
       name="twitter:description"
       content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=63" />
+    <meta name="twitter:image" content="icons/logo.svg?v=64" />
     <meta property="og:url" content="https://prompterai.space/hi/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -185,8 +185,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63',
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64',
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -196,9 +196,9 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -210,7 +210,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -360,7 +360,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="icons/logo.svg?v=63"
+          src="icons/logo.svg?v=64"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -484,7 +484,7 @@
           aria-label="Grupo de WhatsApp"
         >
           <img
-            src="icons/whatsapp.svg?v=63"
+            src="icons/whatsapp.svg?v=64"
             class="w-6 h-6"
             alt="Logo de WhatsApp"
           />
@@ -499,10 +499,10 @@
       </div>
     </div>
 
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/main.js?v=63"></script>
-    <script nomodule src="dist/main.js?v=63"></script>
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/main.js?v=64"></script>
+    <script nomodule src="dist/main.js?v=64"></script>
     <script type="module">
       import { app } from './src/firebase.js';
       import { onAuth } from './src/auth.js';

--- a/hi/intro.html
+++ b/hi/intro.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Introduction - Prompter</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Prompter में आपका स्वागत है</h1>

--- a/index.html
+++ b/index.html
@@ -29,9 +29,9 @@
     />
     <title>PROMPTER</title>
     <base href="./" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="preload" href="icons/logo.svg?v=63" as="image" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="preload" href="icons/logo.svg?v=64" as="image" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -53,7 +53,7 @@
       property="og:description"
       content="Creative AI prompt generator that requires an internet connection."
     />
-    <meta property="og:image" content="icons/logo.svg?v=63" />
+    <meta property="og:image" content="icons/logo.svg?v=64" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -62,7 +62,7 @@
       name="twitter:description"
       content="Creative AI prompt generator that requires an internet connection."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=63" />
+    <meta name="twitter:image" content="icons/logo.svg?v=64" />
     <meta property="og:url" content="https://prompterai.space/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -198,8 +198,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63',
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64',
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -209,9 +209,9 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -223,7 +223,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -459,7 +459,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="icons/logo.svg?v=63"
+          src="icons/logo.svg?v=64"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -647,17 +647,17 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=63"
+            src="icons/whatsapp.svg?v=64"
             class="w-6 h-6"
             alt="WhatsApp logo"
           />
         </a>
       </div>
     </div>
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/main.js?v=63"></script>
-    <script nomodule src="dist/main.js?v=63"></script>
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/main.js?v=64"></script>
+    <script nomodule src="dist/main.js?v=64"></script>
     <script type="module">
       import { app } from './src/firebase.js';
       import { onAuth } from './src/auth.js';

--- a/intro.html
+++ b/intro.html
@@ -4,17 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Introduction - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>

--- a/login.html
+++ b/login.html
@@ -25,15 +25,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Prompter Login</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
     <script>
       (function () {
         function addScript(src, onLoad) {
@@ -113,8 +113,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63',
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64',
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -124,7 +124,7 @@
         });
       })();
     </script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -136,8 +136,8 @@
         }
       })();
     </script>
-    <script type="module" src="src/auth.js?v=63"></script>
-    <script nomodule src="dist/auth.js?v=63"></script>
+    <script type="module" src="src/auth.js?v=64"></script>
+    <script nomodule src="dist/auth.js?v=64"></script>
     <script type="module">
       import { login, register, onAuth } from './src/auth.js';
       import { setUserProfile, getUserByName } from './src/user.js';
@@ -232,7 +232,7 @@
 
       document.addEventListener('DOMContentLoaded', init);
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-md mx-auto relative mt-16">

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "theme_color": "#000000",
   "background_color": "#000000",
   "display": "standalone",
-  "version": "63",
+  "version": "64",
   "start_url": "./",
   "icons": [
     {

--- a/privacy.html
+++ b/privacy.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Legal - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -18,9 +18,9 @@
     </script>
     -->
     <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/privacy.html" />
     <meta property="og:url" content="https://prompterai.space/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
@@ -29,7 +29,7 @@
     <meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta name="twitter:url" content="https://prompterai.space/privacy.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Legal</h1>

--- a/pro.html
+++ b/pro.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Prompter Pro</title>
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -30,7 +30,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-md mx-auto relative mt-16">

--- a/profile.html
+++ b/profile.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Profil - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -92,8 +92,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -103,11 +103,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -128,9 +128,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/profile.js?v=63"></script>
-    <script nomodule src="dist/profile.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/profile.js?v=64"></script>
+    <script nomodule src="dist/profile.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -154,7 +154,7 @@
           </a>
           <img
             id="app-logo"
-            src="icons/logo.svg?v=63"
+            src="icons/logo.svg?v=64"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/social.html
+++ b/social.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Prompter Social</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -97,8 +97,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -108,10 +108,10 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -119,7 +119,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -133,7 +133,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -155,7 +155,7 @@
             >
           </a>
           <img
-            src="icons/logo.svg?v=63"
+            src="icons/logo.svg?v=64"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -226,7 +226,7 @@
       import { appState } from './src/state.js';
       import { linkify } from './src/linkify.js';
       import { timeAgo } from './src/timeago.js';
-      import { categories } from './src/prompts.js?v=63';
+      import { categories } from './src/prompts.js?v=64';
       import {
         getUserProfile,
         getFollowingIds,

--- a/src/blog.js
+++ b/src/blog.js
@@ -16,14 +16,24 @@ import {
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { db } from './firebase.js';
 import { sendNotification } from './notifications.js';
+import { getUserProfile } from './user.js';
 
-export const createPost = (
+export const createPost = async (
   text,
-  userId,
-  userName = '',
-  userEmail = ''
-) =>
-  addDoc(collection(db, 'blogPosts'), {
+  userId
+) => {
+  let userName = '';
+  let userEmail = '';
+  try {
+    const profile = await getUserProfile(userId);
+    if (profile) {
+      userName = profile.name || '';
+      userEmail = profile.email || '';
+    }
+  } catch (err) {
+    console.error('Failed to fetch user profile:', err);
+  }
+  return addDoc(collection(db, 'blogPosts'), {
     text,
     userId,
     userName,
@@ -36,6 +46,7 @@ export const createPost = (
     shareCount: 1,
     commentCount: 0,
   });
+};
 
 export const getAllPosts = async () => {
   const q = query(

--- a/src/profile.js
+++ b/src/profile.js
@@ -578,8 +578,6 @@ const renderSavedPrompts = (prompts) => {
           pEl.textContent || '',
           appState.currentUser.uid,
           appState.selectedCategory,
-          appState.currentUser.displayName || '',
-          appState.currentUser.email || ''
         );
       } catch (err) {
         console.error(err);

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -16,6 +16,7 @@ import {
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { db } from './firebase.js';
 import { sendNotification } from './notifications.js';
+import { getUserProfile } from './user.js';
 
 const samplePrompts = [
   'Describe a futuristic city where nature and technology coexist.',
@@ -29,14 +30,23 @@ export const generatePrompt = () => {
   return samplePrompts[idx];
 };
 
-export const savePrompt = (
+export const savePrompt = async (
   text,
   userId,
-  category = 'random',
-  userName = '',
-  userEmail = ''
-) =>
-  addDoc(collection(db, 'prompts'), {
+  category = 'random'
+) => {
+  let userName = '';
+  let userEmail = '';
+  try {
+    const profile = await getUserProfile(userId);
+    if (profile) {
+      userName = profile.name || '';
+      userEmail = profile.email || '';
+    }
+  } catch (err) {
+    console.error('Failed to fetch user profile:', err);
+  }
+  return addDoc(collection(db, 'prompts'), {
     text,
     userId,
     userName,
@@ -51,6 +61,7 @@ export const savePrompt = (
     shareCount: 1,
     commentCount: 0,
   });
+};
 
 export const getUserPrompts = async (userId) => {
   const q = query(

--- a/src/ui.js
+++ b/src/ui.js
@@ -1005,8 +1005,6 @@ const setupEventListeners = () => {
           appState.generatedPrompt,
           appState.currentUser.uid,
           categorySelect ? categorySelect.value : appState.selectedCategory,
-          appState.currentUser.displayName || '',
-          appState.currentUser.email || ''
         );
       } catch (err) {
         console.error(err);
@@ -1161,8 +1159,6 @@ const setupEventListeners = () => {
             text,
             appState.currentUser.uid,
             categorySelect ? categorySelect.value : appState.selectedCategory,
-            appState.currentUser.displayName || '',
-            appState.currentUser.email || ''
           );
         } catch (err) {
           console.error(err);
@@ -1237,8 +1233,6 @@ const setupEventListeners = () => {
           text,
           appState.currentUser.uid,
           categorySelect ? categorySelect.value : appState.selectedCategory,
-          appState.currentUser.displayName || '',
-          appState.currentUser.email || ''
         );
       } catch (err) {
         console.error(err);

--- a/top-collectors.html
+++ b/top-collectors.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Top Collectors - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/top-collectors.js?v=63"></script>
-    <script nomodule src="dist/top-collectors.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/top-collectors.js?v=64"></script>
+    <script nomodule src="dist/top-collectors.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/top-creators.html
+++ b/top-creators.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Top Creators - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/top-creators.js?v=63"></script>
-    <script nomodule src="dist/top-creators.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/top-creators.js?v=64"></script>
+    <script nomodule src="dist/top-creators.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/top-prompts.html
+++ b/top-prompts.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Top Prompts - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/top-prompts.js?v=63"></script>
-    <script nomodule src="dist/top-prompts.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/top-prompts.js?v=64"></script>
+    <script nomodule src="dist/top-prompts.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/top.html
+++ b/top.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Top Lists - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -13,12 +13,12 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -32,7 +32,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-4xl mx-auto relative mt-16">
@@ -99,10 +99,10 @@
         </a>
       </div>
     </div>
-    <script type="module" src="src/top-creators.js?v=63"></script>
-    <script type="module" src="src/top-collectors.js?v=63"></script>
-    <script type="module" src="src/top-prompts.js?v=63"></script>
-    <script type="module" src="src/top-supporters.js?v=63"></script>
-    <script type="module" src="src/top-pro.js?v=63"></script>
+    <script type="module" src="src/top-creators.js?v=64"></script>
+    <script type="module" src="src/top-collectors.js?v=64"></script>
+    <script type="module" src="src/top-prompts.js?v=64"></script>
+    <script type="module" src="src/top-supporters.js?v=64"></script>
+    <script type="module" src="src/top-pro.js?v=64"></script>
   </body>
 </html>

--- a/tr/blog.html
+++ b/tr/blog.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -74,8 +74,8 @@
           return { cdn: cdnScript, local: localScript, loadPromise };
         }
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -85,11 +85,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -101,7 +101,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -118,7 +118,7 @@
           >
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <img src="icons/logo.svg?v=63" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <img src="icons/logo.svg?v=64" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <h1 class="text-xl sm:text-2xl font-bold leading-tight ml-1">Space</h1>
         </div>
       </header>
@@ -307,8 +307,6 @@
           await createPost(
             text,
             appState.currentUser.uid,
-            appState.currentUser.displayName || '',
-            appState.currentUser.email || ''
           );
           blogInput.value = '';
         } finally {

--- a/tr/dm.html
+++ b/tr/dm.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Direkt Mesajlar - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/dm.js?v=63"></script>
-    <script nomodule src="dist/dm.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/dm.js?v=64"></script>
+    <script nomodule src="dist/dm.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -26,7 +26,7 @@
           <a href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <img src="icons/logo.svg?v=63" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <img src="icons/logo.svg?v=64" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <div class="ml-1">
             <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
             <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>

--- a/tr/index.html
+++ b/tr/index.html
@@ -16,9 +16,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="preload" href="icons/logo.svg?v=63" as="image" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="preload" href="icons/logo.svg?v=64" as="image" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -40,7 +40,7 @@
       property="og:description"
       content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi."
     />
-    <meta property="og:image" content="icons/logo.svg?v=63" />
+    <meta property="og:image" content="icons/logo.svg?v=64" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -49,7 +49,7 @@
       name="twitter:description"
       content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=63" />
+    <meta name="twitter:image" content="icons/logo.svg?v=64" />
     <meta property="og:url" content="https://prompterai.space/tr/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -185,8 +185,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63',
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64',
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -196,9 +196,9 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -210,7 +210,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -367,7 +367,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="icons/logo.svg?v=63"
+          src="icons/logo.svg?v=64"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -493,7 +493,7 @@
           aria-label="WhatsApp Grubu"
         >
           <img
-            src="icons/whatsapp.svg?v=63"
+            src="icons/whatsapp.svg?v=64"
             class="w-6 h-6"
             alt="WhatsApp logosu"
           />
@@ -508,10 +508,10 @@
       </div>
     </div>
 
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/main.js?v=63"></script>
-    <script nomodule src="dist/main.js?v=63"></script>
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/main.js?v=64"></script>
+    <script nomodule src="dist/main.js?v=64"></script>
     <script type="module">
       import { app } from './src/firebase.js';
       import { onAuth } from './src/auth.js';

--- a/tr/intro.html
+++ b/tr/intro.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tanıtım - Prompter</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Prompter'a hoş geldiniz</h1>

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Yasal - Prompter</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -19,9 +19,9 @@
     </script>
     -->
     <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/tr/privacy.html" />
     <meta property="og:url" content="https://prompterai.space/tr/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
@@ -30,7 +30,7 @@
     <meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta name="twitter:url" content="https://prompterai.space/tr/privacy.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Yasal</h1>

--- a/tr/profile.html
+++ b/tr/profile.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Profil - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -92,8 +92,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -103,11 +103,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -128,9 +128,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/profile.js?v=63"></script>
-    <script nomodule src="dist/profile.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/profile.js?v=64"></script>
+    <script nomodule src="dist/profile.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -154,7 +154,7 @@
           </a>
           <img
             id="app-logo"
-            src="icons/logo.svg?v=63"
+            src="icons/logo.svg?v=64"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/tr/social.html
+++ b/tr/social.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Prompter Sosyal</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -97,8 +97,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -108,10 +108,10 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -119,7 +119,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -133,7 +133,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -155,7 +155,7 @@
             >
           </a>
           <img
-            src="icons/logo.svg?v=63"
+            src="icons/logo.svg?v=64"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -216,7 +216,7 @@
       } from './src/prompt.js';
       import { promptScore } from './src/scoring.js';
       import { appState } from './src/state.js';
-      import { categories } from './src/prompts.js?v=63';
+      import { categories } from './src/prompts.js?v=64';
       import {
         getUserProfile,
         getFollowingIds,

--- a/tr/top-collectors.html
+++ b/tr/top-collectors.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>En İyi Koleksiyoncular - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/top-collectors.js?v=63"></script>
-    <script nomodule src="dist/top-collectors.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/top-collectors.js?v=64"></script>
+    <script nomodule src="dist/top-collectors.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/tr/top-creators.html
+++ b/tr/top-creators.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>En İyi Üreticiler - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/top-creators.js?v=63"></script>
-    <script nomodule src="dist/top-creators.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/top-creators.js?v=64"></script>
+    <script nomodule src="dist/top-creators.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/tr/top-prompts.html
+++ b/tr/top-prompts.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>En İyi Promptlar - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/top-prompts.js?v=63"></script>
-    <script nomodule src="dist/top-prompts.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/top-prompts.js?v=64"></script>
+    <script nomodule src="dist/top-prompts.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/tr/top.html
+++ b/tr/top.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>En İyi Listeler - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -13,12 +13,12 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -32,7 +32,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-4xl mx-auto relative mt-16">
@@ -96,8 +96,8 @@
         </a>
       </div>
     </div>
-    <script type="module" src="src/top-creators.js?v=63"></script>
-    <script type="module" src="src/top-collectors.js?v=63"></script>
-    <script type="module" src="src/top-prompts.js?v=63"></script>
+    <script type="module" src="src/top-creators.js?v=64"></script>
+    <script type="module" src="src/top-collectors.js?v=64"></script>
+    <script type="module" src="src/top-prompts.js?v=64"></script>
   </body>
 </html>

--- a/tr/user.html
+++ b/tr/user.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kullanıcı - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/user-page.js?v=63"></script>
-    <script nomodule src="dist/user-page.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/user-page.js?v=64"></script>
+    <script nomodule src="dist/user-page.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -43,7 +43,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="icons/logo.svg?v=63" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="icons/logo.svg?v=64" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>

--- a/user.html
+++ b/user.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>User - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63"></script>
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64"></script>
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -27,9 +27,9 @@
         }
       })();
     </script>
-    <script type="module" src="src/user-page.js?v=63"></script>
-    <script nomodule src="dist/user-page.js?v=63"></script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/user-page.js?v=64"></script>
+    <script nomodule src="dist/user-page.js?v=64"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -43,7 +43,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="icons/logo.svg?v=63" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="icons/logo.svg?v=64" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>

--- a/zh/blog.html
+++ b/zh/blog.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -74,8 +74,8 @@
           return { cdn: cdnScript, local: localScript, loadPromise };
         }
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63'
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64'
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -85,11 +85,11 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -101,7 +101,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -306,8 +306,6 @@
           await createPost(
             text,
             appState.currentUser.uid,
-            appState.currentUser.displayName || '',
-            appState.currentUser.email || ''
           );
           blogInput.value = '';
         } finally {

--- a/zh/index.html
+++ b/zh/index.html
@@ -21,9 +21,9 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="preload" href="icons/logo.svg?v=63" as="image" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="preload" href="icons/logo.svg?v=64" as="image" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -42,7 +42,7 @@
       property="og:description"
       content="需要互联网连接的创意AI提示生成器."
     />
-    <meta property="og:image" content="icons/logo.svg?v=63" />
+    <meta property="og:image" content="icons/logo.svg?v=64" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -51,7 +51,7 @@
       name="twitter:description"
       content="需要互联网连接的创意AI提示生成器."
     />
-    <meta name="twitter:image" content="icons/logo.svg?v=63" />
+    <meta name="twitter:image" content="icons/logo.svg?v=64" />
     <meta property="og:url" content="https://prompterai.space/zh/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -190,8 +190,8 @@
         }
 
         window.lucideScripts = loadWithFallback(
-          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=63',
-          'lucide.min.js?v=63',
+          'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=64',
+          'lucide.min.js?v=64',
         );
         window.lucideScripts.loadPromise.finally(() => {
           const appContainer = document.getElementById('app-container');
@@ -201,9 +201,9 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -215,7 +215,7 @@
         }
       })();
     </script>
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
     <script
@@ -387,7 +387,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="icons/logo.svg?v=63"
+          src="icons/logo.svg?v=64"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -633,7 +633,7 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=63"
+            src="icons/whatsapp.svg?v=64"
             class="w-6 h-6"
             alt="WhatsApp logo"
           />
@@ -647,10 +647,10 @@
         </a>
       </div>
     </div>
-    <script type="module" src="src/init-app.js?v=63"></script>
-    <script nomodule src="dist/init-app.js?v=63"></script>
-    <script type="module" src="src/main.js?v=63"></script>
-    <script nomodule src="dist/main.js?v=63"></script>
+    <script type="module" src="src/init-app.js?v=64"></script>
+    <script nomodule src="dist/init-app.js?v=64"></script>
+    <script type="module" src="src/main.js?v=64"></script>
+    <script nomodule src="dist/main.js?v=64"></script>
     <script type="module">
       import { app } from './src/firebase.js';
       import { onAuth } from './src/auth.js';

--- a/zh/intro.html
+++ b/zh/intro.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Introduction - Prompter</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=63" />
-    <link rel="manifest" href="manifest.json?v=63" />
+    <link rel="icon" type="image/svg+xml" href="icons/logo.svg?v=64" />
+    <link rel="manifest" href="manifest.json?v=64" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <link rel="stylesheet" href="css/tailwind.css?v=63" />
-    <link rel="stylesheet" href="css/app.css?v=63" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=63" />
+    <link rel="stylesheet" href="css/tailwind.css?v=64" />
+    <link rel="stylesheet" href="css/app.css?v=64" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=64" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
-    <script type="module" src="src/version.js?v=63"></script>
+    <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">欢迎使用 Prompter</h1>


### PR DESCRIPTION
## Summary
- fetch creator profile when saving prompts and blog posts
- include `userName` and `userEmail` in saved documents
- update calls to `savePrompt` and `createPost`
- rebuild site assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dbc5431b8832fa7a6453e05b7263e