### PR TITLE
Toggle follower/following list visibility

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -1074,12 +1074,24 @@ const init = () => {
 
   followersLink?.addEventListener('click', (e) => {
     e.preventDefault();
+    if (!followersList) return;
+    if (!followersList.classList.contains('hidden')) {
+      followersList.classList.add('hidden');
+      followingList?.classList.add('hidden');
+      return;
+    }
     showList(followerIds, followersList);
     followingList?.classList.add('hidden');
   });
 
   followingLink?.addEventListener('click', (e) => {
     e.preventDefault();
+    if (!followingList) return;
+    if (!followingList.classList.contains('hidden')) {
+      followingList.classList.add('hidden');
+      followersList?.classList.add('hidden');
+      return;
+    }
     showList(followingIds, followingList);
     followersList?.classList.add('hidden');
   });

--- a/src/user-page.js
+++ b/src/user-page.js
@@ -156,12 +156,24 @@ const init = async () => {
 
   followersLink?.addEventListener('click', (e) => {
     e.preventDefault();
+    if (!followersList) return;
+    if (!followersList.classList.contains('hidden')) {
+      followersList.classList.add('hidden');
+      followingList?.classList.add('hidden');
+      return;
+    }
     showList(followerIds, followersList);
     followingList?.classList.add('hidden');
   });
 
   followingLink?.addEventListener('click', (e) => {
     e.preventDefault();
+    if (!followingList) return;
+    if (!followingList.classList.contains('hidden')) {
+      followingList.classList.add('hidden');
+      followersList?.classList.add('hidden');
+      return;
+    }
     showList(followingIds, followingList);
     followersList?.classList.add('hidden');
   });


### PR DESCRIPTION
## Summary
- toggle follower and following lists on profile and user pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc31f6c2c832fbd75084bbb823f61