### PR TITLE
Fix NotFoundError on prompts update

### DIFF
--- a/social.html
+++ b/social.html
@@ -873,7 +873,7 @@
           const existingCard = existing.get(p.id);
           const newCard = await createCard(p, name, comments);
           newCard._data = p;
-          if (existingCard) {
+          if (existingCard && list.contains(existingCard)) {
             list.replaceChild(newCard, existingCard);
             existing.delete(p.id);
           } else {

--- a/tr/social.html
+++ b/tr/social.html
@@ -893,7 +893,7 @@
           const existingCard = existing.get(p.id);
           const newCard = await createCard(p, name, comments);
           newCard._data = p;
-          if (existingCard) {
+          if (existingCard && list.contains(existingCard)) {
             list.replaceChild(newCard, existingCard);
             existing.delete(p.id);
           } else {


### PR DESCRIPTION
## Summary
- avoid DOM NotFoundError when prompt cards update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc5cc5c58832fa83b698c3875db44