### PR TITLE
Add Firestore index definitions

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -77,6 +77,24 @@
         { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "shared", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "shared", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- update `firestore.indexes.json` with extra indexes

## Testing
- `npm test`
- `firebase deploy --only firestore:indexes` *(fails: No currently active project)*

------
https://chatgpt.com/codex/tasks/task_e_685dc8d2660c832f8e6080743fa02b28