### PR TITLE
Adjust language ordering

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -314,13 +314,6 @@
               EN
             </button>
             <button
-              id="lang-tr"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Turkish"
-            >
-              TR
-            </button>
-            <button
               id="lang-es"
               class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
               aria-label="Switch to Spanish"
@@ -347,6 +340,13 @@
               aria-label="Switch to Hindi"
             >
               HI
+            </button>
+            <button
+              id="lang-tr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Turkish"
+            >
+              TR
             </button>
           </div>
         </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -334,13 +334,6 @@
               EN
             </button>
             <button
-              id="lang-tr"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Turkish"
-            >
-              TR
-            </button>
-            <button
               id="lang-es"
               class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
               aria-label="Switch to Spanish"
@@ -367,6 +360,13 @@
               aria-label="Switch to Hindi"
             >
               HI
+            </button>
+            <button
+              id="lang-tr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Turkish"
+            >
+              TR
             </button>
           </div>
         </div>

--- a/hi/index.html
+++ b/hi/index.html
@@ -314,13 +314,6 @@
               EN
             </button>
             <button
-              id="lang-tr"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Turkish"
-            >
-              TR
-            </button>
-            <button
               id="lang-es"
               class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
               aria-label="Switch to Spanish"
@@ -340,6 +333,13 @@
               aria-label="Switch to Chinese"
             >
               ZH
+            </button>
+            <button
+              id="lang-tr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Turkish"
+            >
+              TR
             </button>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -390,20 +390,6 @@
               EN
             </button>
             <button
-              id="lang-hi"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Hindi"
-            >
-              HI
-            </button>
-            <button
-              id="lang-tr"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Turkish"
-            >
-              TR
-            </button>
-            <button
               id="lang-es"
               class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
               aria-label="Switch to Spanish"
@@ -423,6 +409,20 @@
               aria-label="Switch to Chinese"
             >
               ZH
+            </button>
+            <button
+              id="lang-hi"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Hindi"
+            >
+              HI
+            </button>
+            <button
+              id="lang-tr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Turkish"
+            >
+              TR
             </button>
           </div>
         </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -314,13 +314,6 @@
               EN
             </button>
             <button
-              id="lang-tr"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Turkish"
-            >
-              TR
-            </button>
-            <button
               id="lang-es"
               class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
               aria-label="Switch to Spanish"
@@ -347,6 +340,13 @@
               aria-label="Switch to Hindi"
             >
               HI
+            </button>
+            <button
+              id="lang-tr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Turkish"
+            >
+              TR
             </button>
           </div>
         </div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -334,13 +334,6 @@
               EN
             </button>
             <button
-              id="lang-tr"
-              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
-              aria-label="Switch to Turkish"
-            >
-              TR
-            </button>
-            <button
               id="lang-es"
               class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
               aria-label="Switch to Spanish"
@@ -367,6 +360,13 @@
               aria-label="Switch to Hindi"
             >
               HI
+            </button>
+            <button
+              id="lang-tr"
+              class="block w-full text-left px-3 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+              aria-label="Switch to Turkish"
+            >
+              TR
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reorder language menu items so TR is last
- leave lang menu z-index at 50 in both theme CSS files

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dd5f8a9b4832f9be7c78c428de33b