### PR TITLE
Add Turkish privacy page and language redirect

### DIFF
--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -1,6 +1,15 @@
 import { appState, THEMES } from './state.js';
 import { onAuth } from './auth.js';
 import { getUserSavedPrompts } from './prompt.js';
+
+const LANGUAGE_PAGES = {
+  en: 'index.html',
+  tr: 'tr/index.html',
+  es: 'es/index.html',
+  fr: 'fr/index.html',
+  zh: 'zh/index.html',
+  hi: 'hi/index.html',
+};
 import {
   collection,
   doc,
@@ -109,6 +118,15 @@ const setTheme = (theme) => {
 };
 
 const setLanguage = (lang) => {
+  const targetPage = LANGUAGE_PAGES[lang];
+  if (targetPage) {
+    const current = window.location.pathname.replace(/^\//, '');
+    if (current !== targetPage) {
+      window.location.href = targetPage;
+      localStorage.setItem('language', lang);
+      return;
+    }
+  }
   appState.language = lang;
   document.documentElement.lang = lang;
   document.getElementById('page-title').textContent = uiText[lang].pageTitle;

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,6 +1,15 @@
 import { appState, THEMES } from './state.js';
 import { categories, ICON_FALLBACKS, generatePrompt } from './prompts.js';
 
+const LANGUAGE_PAGES = {
+  en: 'index.html',
+  tr: 'tr/index.html',
+  es: 'es/index.html',
+  fr: 'fr/index.html',
+  zh: 'zh/index.html',
+  hi: 'hi/index.html',
+};
+
 const uiText = {
   en: {
     appTitle: 'PROMPTER',
@@ -336,6 +345,15 @@ const setTheme = (theme) => {
 };
 
 const setLanguage = (lang) => {
+  const targetPage = LANGUAGE_PAGES[lang];
+  if (targetPage) {
+    const current = window.location.pathname.replace(/^\//, '');
+    if (current !== targetPage) {
+      window.location.href = targetPage;
+      localStorage.setItem('language', lang);
+      return;
+    }
+  }
   appState.language = lang;
   document.documentElement.lang = lang;
   document.getElementById('app-title').textContent = uiText[lang].appTitle;


### PR DESCRIPTION
## Summary
- add mappings of languages to page paths
- redirect when switching languages so the correct page loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd733bb48832fb19bd75b9af3dd94