### PR TITLE
Remove ad links from category buttons

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -949,11 +949,6 @@ const setupEventListeners = () => {
     const button = document.getElementById(`category-${category.id}`);
     if (button) {
       button.addEventListener('click', () => {
-        if (
-          ['random', 'hellprompts', 'ai', 'educational'].includes(category.id)
-        ) {
-          window.open('https://otieu.com/4/9472472', '_blank');
-        }
         appState.selectedCategory = category.id;
         document
           .querySelectorAll('.category-button')


### PR DESCRIPTION
## Summary
- remove otieu ad links from category buttons

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ddcece3b0832f97341667fcbd6b32