### PR TITLE
Handle sessionStorage errors for ad

### DIFF
--- a/js/ad-handler.js
+++ b/js/ad-handler.js
@@ -8,14 +8,49 @@
 
   const delayMinutes = [2, 3, 4];
 
+  // Attempt to interact with sessionStorage and fall back to a global
+  // flag when storage is unavailable (e.g. in private mode or restricted
+  // environments). The flag ensures the ad only opens once per session.
+  let storageAvailable = true;
+
+  function canUseSessionStorage() {
+    try {
+      const testKey = '__storage_test__';
+      sessionStorage.setItem(testKey, '1');
+      sessionStorage.removeItem(testKey);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  storageAvailable = canUseSessionStorage();
+
   function scheduleAd() {
-    if (sessionStorage.getItem('adShown')) return;
+    if (storageAvailable) {
+      try {
+        if (sessionStorage.getItem('adShown')) return;
+      } catch (e) {
+        storageAvailable = false;
+      }
+    } else if (window.__adShownFallback) {
+      return;
+    }
 
     const adUrl = adLinks[Math.floor(Math.random() * adLinks.length)];
     const wait =
       delayMinutes[Math.floor(Math.random() * delayMinutes.length)] * 60000;
 
-    sessionStorage.setItem('adShown', 'yes');
+    if (storageAvailable) {
+      try {
+        sessionStorage.setItem('adShown', 'yes');
+      } catch (e) {
+        storageAvailable = false;
+        window.__adShownFallback = true;
+      }
+    } else {
+      window.__adShownFallback = true;
+    }
 
     setTimeout(() => {
       window.open(adUrl, '_blank', 'noopener');


### PR DESCRIPTION
## Summary
- detect sessionStorage failures in ad handler
- fall back to a global flag to prevent multiple popups
- document the fallback behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5c3e7c64832fb363eca67d48e596