### PR TITLE
Fix quotes for AdSense script

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ All pages include the standard AdSense loader in the `<head>` tag:
 ```html
 <script
   async
-  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5886415182402616"
+  src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5886415182402616'
   crossorigin="anonymous"
 ></script>
 ```


### PR DESCRIPTION
## Summary
- fix docs to use single quotes for the ad script URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e672ad0f0832f8ddddd70dd59b94f