### PR TITLE
Handle sessionStorage failures gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ All pages also load `/js/ad-handler.js` at the bottom of the document:
 <script src="/js/ad-handler.js"></script>
 ```
 
-This small script waits for the user to scroll or click. On the first interaction it schedules a new tab with one of the URLs defined in the `adLinks` array inside `ad-handler.js`. The link opens after a random 2–4 minute delay. A flag stored in `sessionStorage`—or a fallback variable when storage is unavailable—ensures the ad only appears once per browser session.
+This small script waits for the user to scroll or click. On the first interaction it schedules a new tab with one of the URLs defined in the `adLinks` array inside `ad-handler.js`. The link opens after a random 2–4 minute delay. Access to `sessionStorage` is wrapped in a `try/catch`; if it fails, a `window.__adShownFallback` flag prevents additional pop-up attempts so the ad appears only once per browser session.
 
 To disable the pop-up entirely, remove the snippet above from each HTML file or clear the `adLinks` list in `js/ad-handler.js`.
 

--- a/js/ad-handler.js
+++ b/js/ad-handler.js
@@ -13,10 +13,15 @@
     // repeated attempts and duplicate ads.
     if (window.__adShownFallback) return;
 
+    let storageFailed = false;
     try {
       if (sessionStorage.getItem('adShown')) return;
       sessionStorage.setItem('adShown', 'yes');
-    } catch {
+    } catch (err) {
+      storageFailed = true;
+    }
+
+    if (storageFailed) {
       // sessionStorage may be unavailable (incognito mode, old browsers, etc.).
       // Mark with a fallback flag so future calls skip trying again.
       window.__adShownFallback = true;


### PR DESCRIPTION
## Summary
- ensure the pop-up ad handler stores a fallback flag when sessionStorage fails
- document the try/catch logic and fallback behavior in README

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e67f5b118832fa215cdee9d5bbaf7