### PR TITLE
Ensure service worker cleanup runs once per session

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -47,23 +47,37 @@ export const startVersionCheck = async () => {
 };
 
 export const clearServiceWorkersAndCaches = () => {
+  if (sessionStorage.getItem('swCleaned')) {
+    return;
+  }
+
+  const tasks = [];
+
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker
-      .getRegistrations()
-      .then((regs) => {
-        for (const reg of regs) {
-          reg.unregister().catch(() => {});
-        }
-      })
-      .catch(() => {});
+    tasks.push(
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((regs) => {
+          for (const reg of regs) {
+            reg.unregister().catch(() => {});
+          }
+        })
+        .catch(() => {})
+    );
   }
 
   if ('caches' in window) {
-    caches
-      .keys()
-      .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
-      .catch(() => {});
+    tasks.push(
+      caches
+        .keys()
+        .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+        .catch(() => {})
+    );
   }
+
+  Promise.all(tasks).finally(() => {
+    sessionStorage.setItem('swCleaned', 'true');
+  });
 };
 
 // automatically run when imported


### PR DESCRIPTION
## Summary
- prevent repeated attempts to unregister service workers by using a sessionStorage flag
- set the flag after caches and workers are cleared

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e6b6b57e0832fa27e09f1d495d38d