### PR TITLE
Fix service worker cleanup race with storage errors

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -47,8 +47,21 @@ export const startVersionCheck = async () => {
 };
 
 export const clearServiceWorkersAndCaches = () => {
-  if (sessionStorage.getItem('swCleaned')) {
+  let cleaned = false;
+  try {
+    cleaned = sessionStorage.getItem('swCleaned');
+  } catch {
+    // ignore storage access errors
+  }
+
+  if (cleaned) {
     return;
+  }
+
+  try {
+    sessionStorage.setItem('swCleaned', 'true');
+  } catch {
+    // ignore storage access errors
   }
 
   const tasks = [];
@@ -75,9 +88,7 @@ export const clearServiceWorkersAndCaches = () => {
     );
   }
 
-  Promise.all(tasks).finally(() => {
-    sessionStorage.setItem('swCleaned', 'true');
-  });
+  Promise.all(tasks).catch(() => {});
 };
 
 // automatically run when imported


### PR DESCRIPTION
## Summary
- set `swCleaned` flag before kicking off cleanup tasks
- ignore sessionStorage failures
- ensure cleanup tasks swallow errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e6fbe32b0832fad55c658ea6b1861