### PR TITLE
Disable automatic service worker cleanup

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -93,4 +93,4 @@ export const clearServiceWorkersAndCaches = () => {
 
 // automatically run when imported
 // startVersionCheck();
-clearServiceWorkersAndCaches();
+// clearServiceWorkersAndCaches();


### PR DESCRIPTION
## Summary
- disable automatic `clearServiceWorkersAndCaches()` on module load

## Testing
- `npm test`
- `npm run build`
- `npm run build:es5`
- `npm run build:css`
- `npm start` then `curl -I http://127.0.0.1:8080/`


------
https://chatgpt.com/codex/tasks/task_e_685e7388fca4832f8ea70906cce173f4