### PR TITLE
Add loader for ad scripts

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -526,52 +526,7 @@
         </p>
       </div>
       <div class="mt-4 flex flex-wrap justify-between gap-4 items-start">
-        <!--
-        <script>
-          (function (ebuww) {
-            var d = document,
-              s = d.createElement('script'),
-              l = d.scripts[d.scripts.length - 1];
-            s.settings = ebuww || {};
-            s.src =
-              '\/\/complete-drink.com\/bsXRVnsld.G\/lB0gYzWocl\/_eXm\/9uu_ZSUjlMkYPFT\/Y_0dMezpUI2\/NvzCUot\/NzjUQYzDNMTVYS3INKgF';
-            s.async = true;
-            s.referrerPolicy = 'no-referrer-when-downgrade';
-            l.parentNode.insertBefore(s, l);
-          })({});
-        </script>
-        <script>
-          (function (ccqp) {
-            var d = document,
-              s = d.createElement('script'),
-              l = d.scripts[d.scripts.length - 1];
-            s.settings = ccqp || {};
-            s.src =
-              '\/\/complete-drink.com\/b\/XxV.sydBGBlg0zYGWIcx\/ceAmE9juAZGU\/l-k\/PwTJYB0WMEzIUM4SMETjYIteNfjHQLzENzTRgdxxNewE';
-            s.async = true;
-            s.referrerPolicy = 'no-referrer-when-downgrade';
-            l.parentNode.insertBefore(s, l);
-          })({});
-        </script>
-        <script>
-          (function (wsnt) {
-            var d = document,
-              s = d.createElement('script'),
-              l = d.scripts[d.scripts.length - 1];
-            s.settings = wsnt || {};
-            s.src =
-              '\/\/complete-drink.com\/bgX.VEsydqGplf0UYIWCc-\/me\/mn9cubZxUEl\/kMP\/TiYT0oMNz\/Ud4NMpjIY-tQNFjbQozHNrT_gfy\/NawS';
-            s.async = true;
-            s.referrerPolicy = 'no-referrer-when-downgrade';
-            l.parentNode.insertBefore(s, l);
-          })({});
-        </script>
-        <script
-          async="async"
-          data-cfasync="false"
-          src="//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js"
-        ></script>
-        -->
+        
         <div
           id="container-a1f7e9c6d98927233c3bdba5a0b35b69"
           class="ad-slot"
@@ -678,5 +633,6 @@
       });
     </script>
   <script src="/js/ad-handler.js"></script>
+  <script src="js/ad-loader.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -680,5 +680,6 @@
       });
     </script>
   <script src="/js/ad-handler.js"></script>
+  <script src="js/ad-loader.js"></script>
   </body>
 </html>

--- a/js/ad-loader.js
+++ b/js/ad-loader.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cdnScripts = [
+    '//complete-drink.com/bsXRVnsld.G/lB0gYzWocl/_eXm/9uu_ZSUjlMkYPFT/Y_0dMezpUI2/NvzCUot/NzjUQYzDNMTVYS3INKgF',
+    '//complete-drink.com/b/XxV.sydBGBlg0zYGWIcx/ceAmE9juAZGU/l-k/PwTJYB0WMEzIUM4SMETjYIteNfjHQLzENzTRgdxxNewE',
+    '//complete-drink.com/bgX.VEsydqGplf0UYIWCc-/me/mn9cubZxUEl/kMP/TiYT0oMNz/Ud4NMpjIY-tQNFjbQozHNrT_gfy/NawS'
+  ];
+
+  cdnScripts.forEach((src) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.async = true;
+    s.referrerPolicy = 'no-referrer-when-downgrade';
+    document.body.appendChild(s);
+  });
+
+  const profitSrc = '//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js';
+  const ps = document.createElement('script');
+  ps.src = profitSrc;
+  ps.async = true;
+  ps.dataset.cfasync = 'false';
+  document.body.appendChild(ps);
+});

--- a/zh/index.html
+++ b/zh/index.html
@@ -526,52 +526,7 @@
         </p>
       </div>
       <div class="mt-4 flex flex-wrap justify-between gap-4 items-start">
-        <!--
-        <script>
-          (function (ebuww) {
-            var d = document,
-              s = d.createElement('script'),
-              l = d.scripts[d.scripts.length - 1];
-            s.settings = ebuww || {};
-            s.src =
-              '\/\/complete-drink.com\/bsXRVnsld.G\/lB0gYzWocl\/_eXm\/9uu_ZSUjlMkYPFT\/Y_0dMezpUI2\/NvzCUot\/NzjUQYzDNMTVYS3INKgF';
-            s.async = true;
-            s.referrerPolicy = 'no-referrer-when-downgrade';
-            l.parentNode.insertBefore(s, l);
-          })({});
-        </script>
-        <script>
-          (function (ccqp) {
-            var d = document,
-              s = d.createElement('script'),
-              l = d.scripts[d.scripts.length - 1];
-            s.settings = ccqp || {};
-            s.src =
-              '\/\/complete-drink.com\/b\/XxV.sydBGBlg0zYGWIcx\/ceAmE9juAZGU\/l-k\/PwTJYB0WMEzIUM4SMETjYIteNfjHQLzENzTRgdxxNewE';
-            s.async = true;
-            s.referrerPolicy = 'no-referrer-when-downgrade';
-            l.parentNode.insertBefore(s, l);
-          })({});
-        </script>
-        <script>
-          (function (wsnt) {
-            var d = document,
-              s = d.createElement('script'),
-              l = d.scripts[d.scripts.length - 1];
-            s.settings = wsnt || {};
-            s.src =
-              '\/\/complete-drink.com\/bgX.VEsydqGplf0UYIWCc-\/me\/mn9cubZxUEl\/kMP\/TiYT0oMNz\/Ud4NMpjIY-tQNFjbQozHNrT_gfy\/NawS';
-            s.async = true;
-            s.referrerPolicy = 'no-referrer-when-downgrade';
-            l.parentNode.insertBefore(s, l);
-          })({});
-        </script>
-        <script
-          async="async"
-          data-cfasync="false"
-          src="//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js"
-        ></script>
-        -->
+        
         <div
           id="container-a1f7e9c6d98927233c3bdba5a0b35b69"
           class="ad-slot"
@@ -678,5 +633,6 @@
       });
     </script>
   <script src="/js/ad-handler.js"></script>
+  <script src="js/ad-loader.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- create `js/ad-loader.js` to inject third-party ads on DOM ready
- remove inline ad network snippets from French and Chinese index pages
- load the new module on `index.html`, `fr/index.html`, and `zh/index.html`

## Testing
- `node scripts/check-reload.js`

------
https://chatgpt.com/codex/tasks/task_e_685e78d293e4832f97edbcb593599715