### PR TITLE
Remove unused ad script comments

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -531,23 +531,7 @@
           id="container-a1f7e9c6d98927233c3bdba5a0b35b69"
           class="ad-slot"
         ></div>
-        <!--
-        <script type="text/javascript">
-          atOptions = {
-            key: 'cc61698e949aeab017670a8799193d84',
-            format: 'iframe',
-            height: 300,
-            width: 160,
-            params: {},
-          };
-        </script>
-        -->
-        <!--
-        <script
-          type="text/javascript"
-          src="//www.highperformanceformat.com/cc61698e949aeab017670a8799193d84/invoke.js"
-        ></script>
-        -->
+        
       </div>
       <!-- Prompt History -->
       <div

--- a/zh/index.html
+++ b/zh/index.html
@@ -531,23 +531,7 @@
           id="container-a1f7e9c6d98927233c3bdba5a0b35b69"
           class="ad-slot"
         ></div>
-        <!--
-        <script type="text/javascript">
-          atOptions = {
-            key: 'cc61698e949aeab017670a8799193d84',
-            format: 'iframe',
-            height: 300,
-            width: 160,
-            params: {},
-          };
-        </script>
-        -->
-        <!--
-        <script
-          type="text/javascript"
-          src="//www.highperformanceformat.com/cc61698e949aeab017670a8799193d84/invoke.js"
-        ></script>
-        -->
+
       </div>
       <!-- Prompt History -->
       <div


### PR DESCRIPTION
## Summary
- remove old highperformanceformat.com ad scripts from FR and ZH homepages
- keep the existing ad-handler at the bottom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e811b3108832f88785ed27c318673