### PR TITLE
Integrate ad-handler and clean extra ad code

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,26 +230,6 @@ Firestore may take several minutes to build the indexes after deployment. During
 this period queries on the Social page can throw `failed-precondition` errors and
 show "Failed to load prompts."
 
-## Advertising (Google AdSense)
-
-The repository initially documented that every page loaded the standard AdSense
-loader. After reviewing the HTML files no such script tag was present. Pages
-function correctly without the loader.
-
-For testing the script was temporarily added to `index.html`:
-
-```html
-<script
-  async
-  src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5886415182402616'
-  crossorigin="anonymous"
-></script>
-```
-
-Loading the page with this tag did not trigger reload loops in a headless
-browser test, indicating the script itself is not responsible for page reloads.
-Other pages remain unchanged and do not include the AdSense loader.
-
 ## Pop-up ad handler
 
 All pages also load `/js/ad-handler.js` at the bottom of the document:

--- a/fr/index.html
+++ b/fr/index.html
@@ -616,7 +616,6 @@
         }
       });
     </script>
-  <script src="/js/ad-handler.js"></script>
-  <script src="js/ad-loader.js"></script>
+  <script src="js/ad-handler.js" defer></script> <!-- Reklam scripti: Scroll sonrası 2-4 dk içinde bir kez gösterim -->
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -224,11 +224,6 @@
       })();
     </script>
     <script type="module" src="src/version.js?v=64"></script>
-    <script
-      async
-      src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5886415182402616'
-      crossorigin="anonymous"
-    ></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -679,7 +674,6 @@
         }
       });
     </script>
-  <script src="/js/ad-handler.js"></script>
-  <script src="js/ad-loader.js"></script>
+  <script src="js/ad-handler.js" defer></script> <!-- Reklam scripti: Scroll sonrası 2-4 dk içinde bir kez gösterim -->
   </body>
 </html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -616,7 +616,6 @@
         }
       });
     </script>
-  <script src="/js/ad-handler.js"></script>
-  <script src="js/ad-loader.js"></script>
+  <script src="js/ad-handler.js" defer></script> <!-- Reklam scripti: Scroll sonrası 2-4 dk içinde bir kez gösterim -->
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove old AdSense snippet from docs
- drop unused ad-loader.js tags
- add `defer` loading for ad-handler in index pages with comment

## Testing
- `npm test` *(fails: Dependencies missing. Run "npm install" before "npm test".)*

------
https://chatgpt.com/codex/tasks/task_e_685e84ccb034832f962b31dfb74b6851