### PR TITLE
Remove obsolete ad scripts and defer handler

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -218,20 +218,6 @@
     <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
-    <script
-      async
-      type="application/javascript"
-      src="https://a.magsrv.com/ad-provider.js"
-    ></script>
-    <ins
-      class="eas6a97888e17"
-      data-zoneid="5646368"
-      data-keywords="keywords"
-      data-sub="123450000"
-    ></ins>
-    <script>
-      (AdProvider = window.AdProvider || []).push({ serve: {} });
-    </script>
 
     <div id="loading-screen">
       <div class="spinner" aria-label="Loading"></div>
@@ -617,6 +603,5 @@
       });
     </script>
   <script src="/js/ad-handler.js"></script>
-  <script src="js/ad-loader.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -224,11 +224,6 @@
       })();
     </script>
     <script type="module" src="src/version.js?v=64"></script>
-    <script
-      async
-      src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5886415182402616'
-      crossorigin="anonymous"
-    ></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -679,7 +674,6 @@
         }
       });
     </script>
-  <script src="/js/ad-handler.js"></script>
-  <script src="js/ad-loader.js"></script>
+  <script src="js/ad-handler.js" defer></script> <!-- Reklam scripti: Scroll sonrası 2-4 dk içinde bir kez gösterim -->
   </body>
 </html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -218,20 +218,6 @@
     <script type="module" src="src/version.js?v=64"></script>
   </head>
   <body class="min-h-screen p-4">
-    <script
-      async
-      type="application/javascript"
-      src="https://a.magsrv.com/ad-provider.js"
-    ></script>
-    <ins
-      class="eas6a97888e17"
-      data-zoneid="5646368"
-      data-keywords="keywords"
-      data-sub="123450000"
-    ></ins>
-    <script>
-      (AdProvider = window.AdProvider || []).push({ serve: {} });
-    </script>
 
     <div id="loading-screen">
       <div class="spinner" aria-label="Loading"></div>
@@ -617,6 +603,5 @@
       });
     </script>
   <script src="/js/ad-handler.js"></script>
-  <script src="js/ad-loader.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove unused ad scripts from French and Chinese pages
- drop Google AdSense loader and ad-loader from index
- load `ad-handler.js` with `defer` and add usage comment

## Testing
- `npm run test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e84ccb034832f962b31dfb74b6851