### PR TITLE
Update ad handler docs and HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,10 @@ show "Failed to load prompts."
 
 ## Pop-up ad handler
 
-All pages also load `/js/ad-handler.js` at the bottom of the document:
+Every HTML page, including the localized directories and the `elonmusksimulator-main` game,
+loads `/js/ad-handler.js` right before the closing `</body>` tag. The script is referenced
+using an **absolute path** so it resolves correctly no matter which subfolder the page
+resides in:
 
 ```html
 <script src="/js/ad-handler.js"></script>

--- a/elonmusksimulator-main/index.html
+++ b/elonmusksimulator-main/index.html
@@ -58,5 +58,6 @@
     <!-- Question data will be loaded lazily from JSON files -->
     <script type="module" src="translations.js?v=65"></script>
     <script type="module" src="main.js?v=65"></script>
+    <script src="/js/ad-handler.js?v=65"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `ad-handler.js` on the Elon Musk Simulator page
- clarify in README that every HTML file includes `ad-handler.js` via absolute path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e8ecc1e0c832f99acada5040d181c