### PR TITLE
Fix French language persistence

### DIFF
--- a/fr/blog.html
+++ b/fr/blog.html
@@ -14,6 +14,9 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <script>
+      localStorage.setItem('language', 'fr');
+    </script>
+    <script>
       (function () {
         function addScript(src, onLoad) {
           const s = document.createElement('script');

--- a/fr/index.html
+++ b/fr/index.html
@@ -105,9 +105,12 @@
           }
         ]
       }
-    </script>
-    <script>
-      (function () {
+  </script>
+  <script>
+    localStorage.setItem('language', 'fr');
+  </script>
+  <script>
+    (function () {
         function addScript(src, onLoad) {
           const s = document.createElement('script');
           s.src = src;

--- a/fr/intro.html
+++ b/fr/intro.html
@@ -15,6 +15,9 @@
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
+    <script>
+      localStorage.setItem('language', 'fr');
+    </script>
     <script type="module" src="src/version.js?v=65"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">


### PR DESCRIPTION
## Summary
- set `language` to `fr` in `fr/index.html`
- add language persistence for French blog and intro pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb36e87f8832f8af1c60e64faa9fc