### PR TITLE
Fix default locale to English

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -1170,8 +1170,10 @@ const init = () => {
     if (wasHidden) markAllNotificationsRead();
   });
 
-  const savedLang = localStorage.getItem('language') || 'tr';
-  setLanguage(savedLang);
+  const savedLang = localStorage.getItem('language');
+  if (savedLang) {
+    setLanguage(savedLang);
+  }
 
   const currentTheme = localStorage.getItem('theme') || THEMES.DARK;
   setTheme(currentTheme);

--- a/src/ui.js
+++ b/src/ui.js
@@ -1417,8 +1417,10 @@ export const initializeApp = () => {
     return false;
   };
 
-  const savedLanguage = localStorage.getItem('language') || 'tr';
-  setLanguage(savedLanguage);
+  const savedLanguage = localStorage.getItem('language');
+  if (savedLanguage) {
+    setLanguage(savedLanguage);
+  }
 
   const savedTheme = localStorage.getItem('theme') || THEMES.DARK;
   setTheme(savedTheme);


### PR DESCRIPTION
## Summary
- avoid auto-redirect to Turkish by default
- check `localStorage` for preferred language before calling `setLanguage`

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eb4c78ba0832f93b4380f8c93bb5e