### PR TITLE
Set English as default language

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -1170,7 +1170,7 @@ const init = () => {
     if (wasHidden) markAllNotificationsRead();
   });
 
-  const savedLang = localStorage.getItem('language') || 'tr';
+  const savedLang = localStorage.getItem('language') || 'en';
   setLanguage(savedLang);
 
   const currentTheme = localStorage.getItem('theme') || THEMES.DARK;

--- a/src/ui.js
+++ b/src/ui.js
@@ -1417,7 +1417,7 @@ export const initializeApp = () => {
     return false;
   };
 
-  const savedLanguage = localStorage.getItem('language') || 'tr';
+  const savedLanguage = localStorage.getItem('language') || 'en';
   setLanguage(savedLanguage);
 
   const savedTheme = localStorage.getItem('theme') || THEMES.DARK;


### PR DESCRIPTION
## Summary
- switch default interface language from Turkish to English

## Testing
- `npm test` *(fails: Dependencies missing)*
- `npm run lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb4c78ba0832f93b4380f8c93bb5e