### PR TITLE
Fix redirect loops when visiting '/'

### DIFF
--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -120,7 +120,12 @@ const setTheme = (theme) => {
 const setLanguage = (lang) => {
   const targetPage = LANGUAGE_PAGES[lang];
   if (targetPage) {
-    const current = window.location.pathname.replace(/^\//, '');
+    // Some servers redirect /index.html to / so pathname becomes "".
+    // Normalize to avoid endless redirects when the target is index.html.
+    let current = window.location.pathname.replace(/^\//, '');
+    if (current === '') {
+      current = 'index.html';
+    }
     if (current !== targetPage) {
       window.location.href = targetPage;
       localStorage.setItem('language', lang);

--- a/src/ui.js
+++ b/src/ui.js
@@ -355,7 +355,12 @@ const setTheme = (theme) => {
 const setLanguage = (lang) => {
   const targetPage = LANGUAGE_PAGES[lang];
   if (targetPage) {
-    const current = window.location.pathname.replace(/^\//, '');
+    // Some servers redirect /index.html to / which results in
+    // window.location.pathname being "". Normalize to avoid loops.
+    let current = window.location.pathname.replace(/^\//, '');
+    if (current === '') {
+      current = 'index.html';
+    }
     if (current !== targetPage) {
       window.location.href = targetPage;
       localStorage.setItem('language', lang);


### PR DESCRIPTION
## Summary
- normalize `window.location.pathname` in `setLanguage`
- avoid redirects when path already matches the target page
- add comments on why normalization is needed

## Testing
- `npm test`
- `npm start` (fails to show redirect loops)

------
https://chatgpt.com/codex/tasks/task_e_685eb82ce2ac832f82fe033d82b92150