### PR TITLE
Align localized pages with main template

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -223,47 +223,83 @@
       style="visibility: hidden"
     >
       <!-- Theme Toggle -->
-      <div
-        class="theme-toggle-container absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
-      >
-        <button
-          id="theme-light"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Light Theme"
-          aria-label="Light Theme"
+      <div class="absolute top-4 right-0 flex flex-col items-end gap-2 z-10">
+        <div class="theme-toggle-container flex items-center gap-2">
+          <a
+            href="es/intro.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Prompter overview"
+            aria-label="Prompter overview"
+          >
+            <i data-lucide="help-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+          <button
+            id="theme-light"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Light Theme"
+            aria-label="Light Theme"
+          >
+            <i
+              data-lucide="sun"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Sun icon"
+            ></i>
+          </button>
+          <button
+            id="theme-dark"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Dark Theme"
+            aria-label="Dark Theme"
+          >
+            <i
+              data-lucide="moon"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Moon icon"
+            ></i>
+          </button>
+          <button
+            id="notifications-btn"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 relative w-16 h-10 flex items-center justify-center"
+            title="Notifications"
+            aria-label="Notifications"
+          >
+            <i data-lucide="bell" class="w-5 h-5" aria-hidden="true"></i>
+            <span
+              id="notification-count"
+              class="hidden absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center"
+            ></span>
+          </button>
+          <a
+            href="dm.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Messages"
+            aria-label="Messages"
+          >
+            <i data-lucide="message-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+        </div>
+        <a
+          href="elonmusksimulator-main/index.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Game</a
         >
-          <i
-            data-lucide="sun"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Sun icon"
-          ></i>
-        </button>
-        <button
-          id="theme-dark"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Dark Theme"
-          aria-label="Dark Theme"
+        <a
+          href="top.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Top</a
         >
-          <i
-            data-lucide="moon"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Moon icon"
-          ></i>
-        </button>
+        <a
+          href="es/blog.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Space</a
+        >
+        <div
+          id="notifications-panel"
+          class="hidden absolute right-0 mt-10 bg-black/80 backdrop-blur-md p-2 rounded-md border border-white/20 text-sm w-64 max-h-60 overflow-y-auto"
+        ></div>
       </div>
-
-      <a
-        href="top.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Top</a
-      >
-      <a
-        href="es/blog.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Space</a
-      >
 
       <!-- Language Switcher -->
       <div class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10">
@@ -287,7 +323,7 @@
             id="current-lang"
             class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
           >
-            TR
+            ES
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="w-3 h-3 mt-0.5"
@@ -353,8 +389,8 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
-          >Iniciar sesión</a
+          class="hidden px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
+          >Login</a
         >
         <a
           id="profile-link"
@@ -382,7 +418,7 @@
           PROMPTER
         </h1>
         <p id="app-subtitle" class="text-blue-200 text-sm md:text-base px-2">
-          YZ için prompt üretici - prompt mühendisliğinin online adresi
+          Prompt generator for AI - the ultimate prompt engineering online space
         </p>
       </div>
 

--- a/fr/index.html
+++ b/fr/index.html
@@ -221,20 +221,6 @@
     <script type="module" src="src/version.js?v=65"></script>
   </head>
   <body class="min-h-screen p-4">
-    <script
-      async
-      type="application/javascript"
-      src="https://a.magsrv.com/ad-provider.js"
-    ></script>
-    <ins
-      class="eas6a97888e17"
-      data-zoneid="5646368"
-      data-keywords="keywords"
-      data-sub="123450000"
-    ></ins>
-    <script>
-      (AdProvider = window.AdProvider || []).push({ serve: {} });
-    </script>
 
     <div id="loading-screen">
       <div class="spinner" aria-label="Loading"></div>
@@ -246,47 +232,83 @@
       style="visibility: hidden"
     >
       <!-- Theme Toggle -->
-      <div
-        class="theme-toggle-container absolute top-4 right-0 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
-      >
-        <button
-          id="theme-light"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Light Theme"
-          aria-label="Light Theme"
+      <div class="absolute top-4 right-0 flex flex-col items-end gap-2 z-10">
+        <div class="theme-toggle-container flex items-center gap-2">
+          <a
+            href="fr/intro.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Prompter overview"
+            aria-label="Prompter overview"
+          >
+            <i data-lucide="help-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+          <button
+            id="theme-light"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Light Theme"
+            aria-label="Light Theme"
+          >
+            <i
+              data-lucide="sun"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Sun icon"
+            ></i>
+          </button>
+          <button
+            id="theme-dark"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Dark Theme"
+            aria-label="Dark Theme"
+          >
+            <i
+              data-lucide="moon"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Moon icon"
+            ></i>
+          </button>
+          <button
+            id="notifications-btn"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 relative w-16 h-10 flex items-center justify-center"
+            title="Notifications"
+            aria-label="Notifications"
+          >
+            <i data-lucide="bell" class="w-5 h-5" aria-hidden="true"></i>
+            <span
+              id="notification-count"
+              class="hidden absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center"
+            ></span>
+          </button>
+          <a
+            href="dm.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Messages"
+            aria-label="Messages"
+          >
+            <i data-lucide="message-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+        </div>
+        <a
+          href="elonmusksimulator-main/index.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Game</a
         >
-          <i
-            data-lucide="sun"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Sun icon"
-          ></i>
-        </button>
-        <button
-          id="theme-dark"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Dark Theme"
-          aria-label="Dark Theme"
+        <a
+          href="top.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Top</a
         >
-          <i
-            data-lucide="moon"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Moon icon"
-          ></i>
-        </button>
+        <a
+          href="fr/blog.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Space</a
+        >
+        <div
+          id="notifications-panel"
+          class="hidden absolute right-0 mt-10 bg-black/80 backdrop-blur-md p-2 rounded-md border border-white/20 text-sm w-64 max-h-60 overflow-y-auto"
+        ></div>
       </div>
-
-      <a
-        href="top.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Top</a
-      >
-      <a
-        href="fr/blog.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Space</a
-      >
 
       <!-- Language Switcher -->
       <div class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10">
@@ -310,7 +332,7 @@
             id="current-lang"
             class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
           >
-            EN
+            FR
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="w-3 h-3 mt-0.5"
@@ -376,8 +398,8 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
-          >Se connecter</a
+          class="hidden px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
+          >Login</a
         >
         <a
           id="profile-link"
@@ -568,28 +590,7 @@
             l.parentNode.insertBefore(s, l);
           })({});
         </script>
-        <script
-          async="async"
-          data-cfasync="false"
-          src="//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js"
-        ></script>
-        <div
-          id="container-a1f7e9c6d98927233c3bdba5a0b35b69"
-          class="ad-slot"
-        ></div>
-        <script type="text/javascript">
-          atOptions = {
-            key: 'cc61698e949aeab017670a8799193d84',
-            format: 'iframe',
-            height: 300,
-            width: 160,
-            params: {},
-          };
-        </script>
-        <script
-          type="text/javascript"
-          src="//www.highperformanceformat.com/cc61698e949aeab017670a8799193d84/invoke.js"
-        ></script>
+
       </div>
       <!-- Prompt History -->
       <div

--- a/hi/index.html
+++ b/hi/index.html
@@ -223,47 +223,83 @@
       style="visibility: hidden"
     >
       <!-- Theme Toggle -->
-      <div
-        class="theme-toggle-container absolute top-4 right-4 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
-      >
-        <button
-          id="theme-light"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Light Theme"
-          aria-label="Light Theme"
+      <div class="absolute top-4 right-0 flex flex-col items-end gap-2 z-10">
+        <div class="theme-toggle-container flex items-center gap-2">
+          <a
+            href="hi/intro.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Prompter overview"
+            aria-label="Prompter overview"
+          >
+            <i data-lucide="help-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+          <button
+            id="theme-light"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Light Theme"
+            aria-label="Light Theme"
+          >
+            <i
+              data-lucide="sun"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Sun icon"
+            ></i>
+          </button>
+          <button
+            id="theme-dark"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Dark Theme"
+            aria-label="Dark Theme"
+          >
+            <i
+              data-lucide="moon"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Moon icon"
+            ></i>
+          </button>
+          <button
+            id="notifications-btn"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 relative w-16 h-10 flex items-center justify-center"
+            title="Notifications"
+            aria-label="Notifications"
+          >
+            <i data-lucide="bell" class="w-5 h-5" aria-hidden="true"></i>
+            <span
+              id="notification-count"
+              class="hidden absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center"
+            ></span>
+          </button>
+          <a
+            href="dm.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Messages"
+            aria-label="Messages"
+          >
+            <i data-lucide="message-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+        </div>
+        <a
+          href="elonmusksimulator-main/index.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Game</a
         >
-          <i
-            data-lucide="sun"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Sun icon"
-          ></i>
-        </button>
-        <button
-          id="theme-dark"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Dark Theme"
-          aria-label="Dark Theme"
+        <a
+          href="top.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Top</a
         >
-          <i
-            data-lucide="moon"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Moon icon"
-          ></i>
-        </button>
+        <a
+          href="hi/blog.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Space</a
+        >
+        <div
+          id="notifications-panel"
+          class="hidden absolute right-0 mt-10 bg-black/80 backdrop-blur-md p-2 rounded-md border border-white/20 text-sm w-64 max-h-60 overflow-y-auto"
+        ></div>
       </div>
-
-      <a
-        href="top.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Top</a
-      >
-      <a
-        href="hi/blog.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Space</a
-      >
 
       <!-- Language Switcher -->
       <div class="absolute top-4 left-4 flex flex-col items-stretch gap-2 z-10">
@@ -287,7 +323,7 @@
             id="current-lang"
             class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
           >
-            TR
+            HI
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="w-3 h-3 mt-0.5"
@@ -353,8 +389,8 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
-          >लॉग इन</a
+          class="hidden px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
+          >Login</a
         >
         <a
           id="profile-link"
@@ -382,7 +418,7 @@
           PROMPTER
         </h1>
         <p id="app-subtitle" class="text-blue-200 text-sm md:text-base px-2">
-          YZ için prompt üretici - prompt mühendisliğinin online adresi
+          Prompt generator for AI - the ultimate prompt engineering online space
         </p>
       </div>
 

--- a/zh/index.html
+++ b/zh/index.html
@@ -218,20 +218,6 @@
     <script type="module" src="src/version.js?v=65"></script>
   </head>
   <body class="min-h-screen p-4">
-    <script
-      async
-      type="application/javascript"
-      src="https://a.magsrv.com/ad-provider.js"
-    ></script>
-    <ins
-      class="eas6a97888e17"
-      data-zoneid="5646368"
-      data-keywords="keywords"
-      data-sub="123450000"
-    ></ins>
-    <script>
-      (AdProvider = window.AdProvider || []).push({ serve: {} });
-    </script>
 
     <div id="loading-screen">
       <div class="spinner" aria-label="Loading"></div>
@@ -243,47 +229,83 @@
       style="visibility: hidden"
     >
       <!-- Theme Toggle -->
-      <div
-        class="theme-toggle-container absolute top-4 right-0 flex items-center gap-2 bg-black/20 backdrop-blur-sm p-1 rounded-lg border border-white/20 z-10"
-      >
-        <button
-          id="theme-light"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Light Theme"
-          aria-label="Light Theme"
+      <div class="absolute top-4 right-0 flex flex-col items-end gap-2 z-10">
+        <div class="theme-toggle-container flex items-center gap-2">
+          <a
+            href="zh/intro.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Prompter overview"
+            aria-label="Prompter overview"
+          >
+            <i data-lucide="help-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+          <button
+            id="theme-light"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Light Theme"
+            aria-label="Light Theme"
+          >
+            <i
+              data-lucide="sun"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Sun icon"
+            ></i>
+          </button>
+          <button
+            id="theme-dark"
+            class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Dark Theme"
+            aria-label="Dark Theme"
+          >
+            <i
+              data-lucide="moon"
+              class="w-5 h-5"
+              role="img"
+              aria-label="Moon icon"
+            ></i>
+          </button>
+          <button
+            id="notifications-btn"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 relative w-16 h-10 flex items-center justify-center"
+            title="Notifications"
+            aria-label="Notifications"
+          >
+            <i data-lucide="bell" class="w-5 h-5" aria-hidden="true"></i>
+            <span
+              id="notification-count"
+              class="hidden absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center"
+            ></span>
+          </button>
+          <a
+            href="dm.html"
+            class="p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-16 h-10 flex items-center justify-center"
+            title="Messages"
+            aria-label="Messages"
+          >
+            <i data-lucide="message-circle" class="w-5 h-5" aria-hidden="true"></i>
+          </a>
+        </div>
+        <a
+          href="elonmusksimulator-main/index.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Game</a
         >
-          <i
-            data-lucide="sun"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Sun icon"
-          ></i>
-        </button>
-        <button
-          id="theme-dark"
-          class="p-1.5 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-white/50"
-          title="Dark Theme"
-          aria-label="Dark Theme"
+        <a
+          href="top.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Top</a
         >
-          <i
-            data-lucide="moon"
-            class="w-5 h-5"
-            role="img"
-            aria-label="Moon icon"
-          ></i>
-        </button>
+        <a
+          href="zh/blog.html"
+          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
+          >Space</a
+        >
+        <div
+          id="notifications-panel"
+          class="hidden absolute right-0 mt-10 bg-black/80 backdrop-blur-md p-2 rounded-md border border-white/20 text-sm w-64 max-h-60 overflow-y-auto"
+        ></div>
       </div>
-
-      <a
-        href="top.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Top</a
-      >
-      <a
-        href="zh/blog.html"
-        class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 text-center w-16"
-        >Space</a
-      >
 
       <!-- Language Switcher -->
       <div class="absolute top-4 left-0 flex flex-col items-stretch gap-2 z-10">
@@ -307,7 +329,7 @@
             id="current-lang"
             class="text-blue-200 text-sm font-semibold cursor-pointer flex flex-col items-center leading-none"
           >
-            EN
+            ZH
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="w-3 h-3 mt-0.5"
@@ -373,8 +395,8 @@
         <a
           id="login-link"
           href="login.html"
-          class="px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
-          >登录</a
+          class="hidden px-1 py-0.5 rounded-lg border border-white/20 text-xs font-medium bg-black/20 hover:bg-black/30 transition-all duration-200 w-16 text-center"
+          >Login</a
         >
         <a
           id="profile-link"
@@ -565,28 +587,7 @@
             l.parentNode.insertBefore(s, l);
           })({});
         </script>
-        <script
-          async="async"
-          data-cfasync="false"
-          src="//pl26937665.profitableratecpm.com/a1f7e9c6d98927233c3bdba5a0b35b69/invoke.js"
-        ></script>
-        <div
-          id="container-a1f7e9c6d98927233c3bdba5a0b35b69"
-          class="ad-slot"
-        ></div>
-        <script type="text/javascript">
-          atOptions = {
-            key: 'cc61698e949aeab017670a8799193d84',
-            format: 'iframe',
-            height: 300,
-            width: 160,
-            params: {},
-          };
-        </script>
-        <script
-          type="text/javascript"
-          src="//www.highperformanceformat.com/cc61698e949aeab017670a8799193d84/invoke.js"
-        ></script>
+
       </div>
       <!-- Prompt History -->
       <div


### PR DESCRIPTION
## Summary
- sync navigation across localized pages using English template
- remove ad scripts from `fr/index.html` and `zh/index.html`
- revert login buttons to default and fix current language labels
- standardize subtitle text

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ebb814ac8832f888cc96cb3ad802b