### PR TITLE
Fix TR language redirect issue

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -365,17 +365,19 @@ const setLanguage = (lang, fromSaved = false) => {
   const refLangEntry = Object.entries(LANGUAGE_PAGES).find(([, page]) =>
     document.referrer.includes(page)
   );
-  const overrideLang =
+  let overrideLang =
     (paramLang && LANGUAGE_PAGES[paramLang] ? paramLang : null) ||
     (refLangEntry ? refLangEntry[0] : null);
-  if (overrideLang) {
+  let current = window.location.pathname.replace(/^\//, '');
+  if (current === '') current = 'index.html';
+  if (overrideLang && (!fromSaved || current !== LANGUAGE_PAGES[lang])) {
     lang = overrideLang;
   }
   const targetPage = LANGUAGE_PAGES[lang];
   if (targetPage) {
     // Some servers redirect /index.html to / which results in
     // window.location.pathname being "". Normalize to avoid loops.
-    let current = window.location.pathname.replace(/^\//, '');
+    current = window.location.pathname.replace(/^\//, '');
     if (current === '') {
       current = 'index.html';
     }


### PR DESCRIPTION
## Summary
- avoid incorrect redirect when switching languages by preserving the user's saved language if the current page matches

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ec88e7044832fa1a41dbd035e1be7