### PR TITLE
Add prompter link to shared tweets

### DIFF
--- a/src/profile.js
+++ b/src/profile.js
@@ -412,7 +412,8 @@ const markAllNotificationsRead = async () => {
 
 const sharePrompt = (prompt, baseUrl) => {
   if (!prompt) return;
-  const url = `${baseUrl}${encodeURIComponent(prompt)}`;
+  const link = ' https://prompterai.space';
+  const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
   window.open(url, '_blank');
 };
 


### PR DESCRIPTION
## Summary
- add website link in `sharePrompt()`
- ensure saved/shared prompts share this link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ed8b57a88832fb5fb920d861e476f