### PR TITLE
Fix social listener update on auth change

### DIFF
--- a/es/social.html
+++ b/es/social.html
@@ -862,8 +862,9 @@
 
       let unsubscribe = null;
 
-      const startListener = async () => {
+      const startListener = async (user) => {
         if (unsubscribe) unsubscribe();
+        filterAndRender();
         const constraints = [where('shared', '==', true)];
 
         constraints.push(orderBy('createdAt', 'desc'));
@@ -897,8 +898,7 @@
           if (u) updateLastSocialVisit(u.uid, Date.now());
         });
         promptSearch?.addEventListener('input', debouncedFilter);
-        onAuth(startListener);
-        startListener();
+        onAuth((u) => startListener(u));
       }
 
       document.addEventListener('DOMContentLoaded', init);

--- a/fr/social.html
+++ b/fr/social.html
@@ -862,8 +862,9 @@
 
       let unsubscribe = null;
 
-      const startListener = async () => {
+      const startListener = async (user) => {
         if (unsubscribe) unsubscribe();
+        filterAndRender();
         const constraints = [where('shared', '==', true)];
 
         constraints.push(orderBy('createdAt', 'desc'));
@@ -897,8 +898,7 @@
           if (u) updateLastSocialVisit(u.uid, Date.now());
         });
         promptSearch?.addEventListener('input', debouncedFilter);
-        onAuth(startListener);
-        startListener();
+        onAuth((u) => startListener(u));
       }
 
       document.addEventListener('DOMContentLoaded', init);

--- a/hi/social.html
+++ b/hi/social.html
@@ -862,8 +862,9 @@
 
       let unsubscribe = null;
 
-      const startListener = async () => {
+      const startListener = async (user) => {
         if (unsubscribe) unsubscribe();
+        filterAndRender();
         const constraints = [where('shared', '==', true)];
 
         constraints.push(orderBy('createdAt', 'desc'));
@@ -897,8 +898,7 @@
           if (u) updateLastSocialVisit(u.uid, Date.now());
         });
         promptSearch?.addEventListener('input', debouncedFilter);
-        onAuth(startListener);
-        startListener();
+        onAuth((u) => startListener(u));
       }
 
       document.addEventListener('DOMContentLoaded', init);

--- a/social.html
+++ b/social.html
@@ -862,8 +862,9 @@
 
       let unsubscribe = null;
 
-      const startListener = async () => {
+      const startListener = async (user) => {
         if (unsubscribe) unsubscribe();
+        filterAndRender();
         const constraints = [where('shared', '==', true)];
 
         constraints.push(orderBy('createdAt', 'desc'));
@@ -897,8 +898,7 @@
           if (u) updateLastSocialVisit(u.uid, Date.now());
         });
         promptSearch?.addEventListener('input', debouncedFilter);
-        onAuth(startListener);
-        startListener();
+        onAuth((u) => startListener(u));
       }
 
       document.addEventListener('DOMContentLoaded', init);

--- a/tr/social.html
+++ b/tr/social.html
@@ -899,8 +899,9 @@
 
       let unsubscribe = null;
 
-      const startListener = async () => {
+      const startListener = async (user) => {
         if (unsubscribe) unsubscribe();
+        filterAndRender();
         const constraints = [where('shared', '==', true)];
 
         constraints.push(orderBy('createdAt', 'desc'));
@@ -934,8 +935,7 @@
           if (u) updateLastSocialVisit(u.uid, Date.now());
         });
         promptSearch?.addEventListener('input', debouncedFilter);
-        onAuth(startListener);
-        startListener();
+        onAuth((u) => startListener(u));
       }
 
       document.addEventListener('DOMContentLoaded', init);

--- a/zh/social.html
+++ b/zh/social.html
@@ -862,8 +862,9 @@
 
       let unsubscribe = null;
 
-      const startListener = async () => {
+      const startListener = async (user) => {
         if (unsubscribe) unsubscribe();
+        filterAndRender();
         const constraints = [where('shared', '==', true)];
 
         constraints.push(orderBy('createdAt', 'desc'));
@@ -897,8 +898,7 @@
           if (u) updateLastSocialVisit(u.uid, Date.now());
         });
         promptSearch?.addEventListener('input', debouncedFilter);
-        onAuth(startListener);
-        startListener();
+        onAuth((u) => startListener(u));
       }
 
       document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- update listener registration in all social pages to rerender cards when auth changes
- pass user to `startListener` and trigger an immediate render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee8223520832f80fe56b75c0474ce