### PR TITLE
Drop unused logo preload lines

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -17,7 +17,6 @@
     <title>PROMPTER</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
-    <link rel="preload" href="/icons/logo.svg?v=65" as="image" />
     <link rel="manifest" href="manifest.json?v=65" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/fr/index.html
+++ b/fr/index.html
@@ -22,7 +22,6 @@
     <title>PROMPTER</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
-    <link rel="preload" href="/icons/logo.svg?v=65" as="image" />
     <link rel="manifest" href="manifest.json?v=65" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/hi/index.html
+++ b/hi/index.html
@@ -17,7 +17,6 @@
     <title>PROMPTER</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
-    <link rel="preload" href="/icons/logo.svg?v=65" as="image" />
     <link rel="manifest" href="manifest.json?v=65" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
     <title>PROMPTER</title>
     <base href="./" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
-    <link rel="preload" href="/icons/logo.svg?v=65" as="image" />
     <link rel="manifest" href="manifest.json?v=65" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/tr/index.html
+++ b/tr/index.html
@@ -30,7 +30,6 @@
     <title>PROMPTER</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
-    <link rel="preload" href="/icons/logo.svg?v=65" as="image" />
     <link rel="manifest" href="manifest.json?v=65" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/zh/index.html
+++ b/zh/index.html
@@ -22,7 +22,6 @@
     <title>PROMPTER</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
-    <link rel="preload" href="/icons/logo.svg?v=65" as="image" />
     <link rel="manifest" href="manifest.json?v=65" />
     <meta name="theme-color" content="#000000" />
     <meta


### PR DESCRIPTION
## Summary
- remove unused SVG preloads in all language index pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eed98bf0c832fb68ea9b7534b08b1