### PR TITLE
Add SEO meta tags and CSP

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -17,6 +18,28 @@
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="404 - Page Not Found" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="404 - Page Not Found" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
     <script>

--- a/blog.html
+++ b/blog.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Space - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Space - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/dm.html
+++ b/dm.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Direct Messages - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Direct Messages - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Direct Messages - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/es/blog.html
+++ b/es/blog.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Space - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Space - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/es/intro.html
+++ b/es/intro.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Introduction - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Introduction - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/es/login.html
+++ b/es/login.html
@@ -23,6 +23,7 @@
     -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -30,6 +31,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Login" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Login" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <script type="module" src="src/init-app.js?v=65"></script>

--- a/es/privacy.html
+++ b/es/privacy.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Legal - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Legal - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -26,9 +49,12 @@
     <meta property="og:url" content="https://prompterai.space/es/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
-    <meta property="og:locale:alternate" content="en" />
+<meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
     <meta name="twitter:url" content="https://prompterai.space/es/privacy.html" />
     <script type="module" src="src/version.js?v=65"></script>
   </head>

--- a/es/profile.html
+++ b/es/profile.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Perfil - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Perfil - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Perfil - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/es/social.html
+++ b/es/social.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Social" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Social" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/es/user.html
+++ b/es/user.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="User - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="User - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/fr/blog.html
+++ b/fr/blog.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Space - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Space - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       localStorage.setItem('language', 'fr');
     </script>

--- a/fr/intro.html
+++ b/fr/intro.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Introduction - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Introduction - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/fr/login.html
+++ b/fr/login.html
@@ -23,6 +23,7 @@
     -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -30,6 +31,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Login" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Login" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <script type="module" src="src/init-app.js?v=65"></script>

--- a/fr/privacy.html
+++ b/fr/privacy.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Mentions légales - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Mentions légales - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Mentions légales - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -26,9 +49,12 @@
     <meta property="og:url" content="https://prompterai.space/fr/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
-    <meta property="og:locale:alternate" content="en" />
+<meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="tr" />
     <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
     <meta name="twitter:url" content="https://prompterai.space/fr/privacy.html" />
     <script type="module" src="src/version.js?v=65"></script>
   </head>

--- a/fr/profile.html
+++ b/fr/profile.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Profil - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Profil - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/fr/social.html
+++ b/fr/social.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Social" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Social" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/fr/user.html
+++ b/fr/user.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="User - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="User - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/hi/blog.html
+++ b/hi/blog.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Space - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Space - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/hi/intro.html
+++ b/hi/intro.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Introduction - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Introduction - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/hi/login.html
+++ b/hi/login.html
@@ -23,6 +23,7 @@
     -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -30,6 +31,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Login" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Login" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <script type="module" src="src/init-app.js?v=65"></script>

--- a/hi/privacy.html
+++ b/hi/privacy.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>कानूनी जानकारी - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="कानूनी जानकारी - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="कानूनी जानकारी - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -26,9 +49,12 @@
     <meta property="og:url" content="https://prompterai.space/hi/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
-    <meta property="og:locale:alternate" content="en" />
+<meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="tr" />
     <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
     <meta name="twitter:url" content="https://prompterai.space/hi/privacy.html" />
     <script type="module" src="src/version.js?v=65"></script>
   </head>

--- a/hi/profile.html
+++ b/hi/profile.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>प्रोफ़ाइल - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="प्रोफ़ाइल - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="प्रोफ़ाइल - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/hi/social.html
+++ b/hi/social.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Social" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Social" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/hi/user.html
+++ b/hi/user.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="User - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="User - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/intro.html
+++ b/intro.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Introduction - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Introduction - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/login.html
+++ b/login.html
@@ -23,6 +23,7 @@
     -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -30,6 +31,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Login" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Login" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <script type="module" src="src/init-app.js?v=65"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Legal - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Legal - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -25,9 +48,12 @@
     <meta property="og:url" content="https://prompterai.space/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
-    <meta property="og:locale:alternate" content="tr" />
+<meta property="og:locale:alternate" content="tr" />
     <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
     <meta name="twitter:url" content="https://prompterai.space/privacy.html" />
     <script type="module" src="src/version.js?v=65"></script>
   </head>

--- a/pro.html
+++ b/pro.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Pro</title>
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Pro" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Pro" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
     <!--

--- a/profile.html
+++ b/profile.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Profil - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Profil - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/social.html
+++ b/social.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Social" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Social" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/top-collectors.html
+++ b/top-collectors.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Collectors - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Collectors - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Collectors - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/top-creators.html
+++ b/top-creators.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Creators - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Creators - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Creators - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/top-prompts.html
+++ b/top-prompts.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Prompts - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Prompts - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Prompts - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/top.html
+++ b/top.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Lists - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Lists - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Lists - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/tr/blog.html
+++ b/tr/blog.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Space - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Space - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/tr/dm.html
+++ b/tr/dm.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Direkt Mesajlar - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Direkt Mesajlar - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Direkt Mesajlar - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/tr/intro.html
+++ b/tr/intro.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Tanıtım - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Tanıtım - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Tanıtım - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/tr/login.html
+++ b/tr/login.html
@@ -23,6 +23,7 @@
     -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -30,6 +31,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Login" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Login" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <script type="module" src="src/init-app.js?v=65"></script>

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Yasal - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Yasal - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Yasal - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -26,9 +49,12 @@
     <meta property="og:url" content="https://prompterai.space/tr/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
-    <meta property="og:locale:alternate" content="en" />
+<meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
     <meta name="twitter:url" content="https://prompterai.space/tr/privacy.html" />
     <script type="module" src="src/version.js?v=65"></script>
   </head>

--- a/tr/profile.html
+++ b/tr/profile.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Profil - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Profil - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/tr/social.html
+++ b/tr/social.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Sosyal</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Sosyal" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Sosyal" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/tr/top-collectors.html
+++ b/tr/top-collectors.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>En İyi Koleksiyoncular - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="En İyi Koleksiyoncular - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="En İyi Koleksiyoncular - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/tr/top-creators.html
+++ b/tr/top-creators.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>En İyi Üreticiler - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="En İyi Üreticiler - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="En İyi Üreticiler - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/tr/top-prompts.html
+++ b/tr/top-prompts.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>En İyi Promptlar - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="En İyi Promptlar - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="En İyi Promptlar - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/tr/top.html
+++ b/tr/top.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>En İyi Listeler - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="En İyi Listeler - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="En İyi Listeler - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/tr/user.html
+++ b/tr/user.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Kullanıcı - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Kullanıcı - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Kullanıcı - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/user.html
+++ b/user.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="User - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="User - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+<meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />

--- a/zh/blog.html
+++ b/zh/blog.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Space - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Space - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/zh/intro.html
+++ b/zh/intro.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Introduction - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Introduction - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />

--- a/zh/login.html
+++ b/zh/login.html
@@ -23,6 +23,7 @@
     -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="./" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -30,6 +31,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Login" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Login" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <link rel="stylesheet" href="css/app.css?v=65" />
     <script type="module" src="src/init-app.js?v=65"></script>

--- a/zh/privacy.html
+++ b/zh/privacy.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>法律信息 - Prompter</title>
     <base href="../" />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
@@ -11,6 +12,28 @@
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
       <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="法律信息 - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="法律信息 - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -26,9 +49,12 @@
     <meta property="og:url" content="https://prompterai.space/zh/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
-    <meta property="og:locale:alternate" content="en" />
+<meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="tr" />
     <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
     <meta name="twitter:url" content="https://prompterai.space/zh/privacy.html" />
     <script type="module" src="src/version.js?v=65"></script>
   </head>

--- a/zh/profile.html
+++ b/zh/profile.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>个人资料 - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="个人资料 - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="个人资料 - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/zh/social.html
+++ b/zh/social.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -13,6 +14,28 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Social" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Social" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <script>
       (function () {
         function addScript(src, onLoad) {

--- a/zh/user.html
+++ b/zh/user.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
     <link rel="manifest" href="manifest.json?v=65" />
@@ -10,6 +11,28 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="User - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="User - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="https://prompterai.space/" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=65" />
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65"></script>
     <link rel="stylesheet" href="css/app.css?v=65" />


### PR DESCRIPTION
## Summary
- add SEO metadata and content security policy to several pages
- replicate metadata tags across translation pages

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685efd3470b0832f8d7ea86473858375