### PR TITLE
Add terms pages with translations

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -440,6 +440,7 @@
         <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
           Prompter
         </p>
+        <a href="terms.html" class="text-blue-400 underline block mt-2">Términos</a>
         <a
           href="https://chat.whatsapp.com/LAu2OosQEmd73CBl56sIRi"
           target="_blank"

--- a/es/terms.html
+++ b/es/terms.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Términos - Prompter</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Términos - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Términos - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/es/terms.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+    <meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/es/terms.html" />
+    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
+    <link rel="stylesheet" href="css/tailwind.css?v=65" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <link rel="canonical" href="__SITE_URL__/es/terms.html" />
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body class="bg-black text-white min-h-screen p-4">
+      <h1 class="text-2xl font-bold mb-4">Términos de Uso</h1>
+      <p class="mb-2">Prompter proporciona texto generado por IA. Úselo de forma responsable solo para fines legales.</p>
+      <p class="mb-2">El servicio se ofrece "tal cual" sin garantías. No somos responsables de los daños que se deriven de su uso.</p>
+      <p class="mb-2">Al seguir utilizando Prompter, acepta estos términos.</p>
+    <a href="es/" class="text-blue-400 underline">Volver a Prompter</a>
+  </body>
+</html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -547,9 +547,8 @@
         <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
           Prompter
         </p>
-        <a href="privacy.html" class="text-blue-400 underline block mt-2"
-          >Privacy Policy</a
-        >
+        <a href="privacy.html" class="text-blue-400 underline block mt-2">Privacy Policy</a>
+        <a href="terms.html" class="text-blue-400 underline block mt-2">Conditions d'utilisation</a>
         <a
           href="https://chat.whatsapp.com/LAu2OosQEmd73CBl56sIRi"
           target="_blank"

--- a/fr/terms.html
+++ b/fr/terms.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Conditions d'utilisation - Prompter</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Conditions d'utilisation - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Conditions d'utilisation - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/fr/terms.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+    <meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/fr/terms.html" />
+    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
+    <link rel="stylesheet" href="css/tailwind.css?v=65" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <link rel="canonical" href="__SITE_URL__/fr/terms.html" />
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body class="bg-black text-white min-h-screen p-4">
+      <h1 class="text-2xl font-bold mb-4">Conditions d'utilisation</h1>
+      <p class="mb-2">Prompter fournit du texte généré par l'IA. Utilisez-le de manière responsable uniquement à des fins légales.</p>
+      <p class="mb-2">Le service est fourni "en l'état" sans aucune garantie. Nous ne sommes pas responsables des dommages résultant de son utilisation.</p>
+      <p class="mb-2">En continuant à utiliser Prompter, vous acceptez ces conditions.</p>
+    <a href="fr/" class="text-blue-400 underline">Retour à Prompter</a>
+  </body>
+</html>

--- a/hi/index.html
+++ b/hi/index.html
@@ -440,6 +440,7 @@
         <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
           Prompter
         </p>
+        <a href="terms.html" class="text-blue-400 underline block mt-2">उपयोग की शर्तें</a>
         <a
           href="https://chat.whatsapp.com/LAu2OosQEmd73CBl56sIRi"
           target="_blank"

--- a/hi/terms.html
+++ b/hi/terms.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>उपयोग की शर्तें - Prompter</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="उपयोग की शर्तें - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="उपयोग की शर्तें - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/hi/terms.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+    <meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="__SITE_URL__/hi/terms.html" />
+    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
+    <link rel="stylesheet" href="css/tailwind.css?v=65" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <link rel="canonical" href="__SITE_URL__/hi/terms.html" />
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body class="bg-black text-white min-h-screen p-4">
+      <h1 class="text-2xl font-bold mb-4">उपयोग की शर्तें</h1>
+      <p class="mb-2">Prompter एआई द्वारा जनित पाठ प्रदान करता है। इसे केवल कानूनी उद्देश्यों के लिए जिम्मेदारी से उपयोग करें।</p>
+      <p class="mb-2">सेवा बिना किसी वारंटी के 'जैसा है' आधार पर उपलब्ध है। इसके उपयोग से होने वाली किसी भी हानि के लिए हम उत्तरदायी नहीं हैं।</p>
+      <p class="mb-2">Prompter का उपयोग जारी रखकर आप इन शर्तों से सहमत होते हैं।</p>
+    <a href="hi/" class="text-blue-400 underline">Prompter पर वापस जाएं</a>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -538,9 +538,8 @@
         <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
           Prompter
         </p>
-        <a href="privacy.html" class="text-blue-400 underline block mt-2"
-          >Legal</a
-        >
+        <a href="privacy.html" class="text-blue-400 underline block mt-2">Legal</a>
+        <a href="terms.html" class="text-blue-400 underline block mt-2">Terms</a>
         <a
           href="https://chat.whatsapp.com/LAu2OosQEmd73CBl56sIRi"
           target="_blank"

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,4 +12,10 @@
   <url><loc>https://prompterai.space/profile.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
   <url><loc>https://prompterai.space/tr/</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
   <url><loc>https://prompterai.space/zh/</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/terms.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/tr/terms.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/es/terms.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/fr/terms.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/hi/terms.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
+  <url><loc>https://prompterai.space/zh/terms.html</loc><lastmod>2025-06-21</lastmod><changefreq>monthly</changefreq></url>
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Terms - Prompter</title>
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Terms - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Terms - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/terms.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/terms.html" />
+    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
+    <link rel="stylesheet" href="css/tailwind.css?v=65" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <link rel="canonical" href="__SITE_URL__/terms.html" />
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body class="bg-black text-white min-h-screen p-4">
+      <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>
+      <p class="mb-2">Prompter provides AI-generated text. Use it responsibly for lawful purposes only.</p>
+      <p class="mb-2">The service is provided &quot;as is&quot; without warranties. We are not liable for any damages resulting from its use.</p>
+      <p class="mb-2">By continuing to use Prompter, you agree to these terms.</p>
+    <a href="index.html" class="text-blue-400 underline">Return to Prompter</a>
+  </body>
+</html>

--- a/tr/index.html
+++ b/tr/index.html
@@ -541,9 +541,8 @@
         <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
           Prompter
         </p>
-        <a href="tr/privacy.html" class="text-blue-400 underline block mt-2"
-          >Legal</a
-        >
+        <a href="tr/privacy.html" class="text-blue-400 underline block mt-2">Legal</a>
+        <a href="tr/terms.html" class="text-blue-400 underline block mt-2">Kullanım Şartları</a>
         <a
           href="https://chat.whatsapp.com/LAu2OosQEmd73CBl56sIRi"
           target="_blank"

--- a/tr/terms.html
+++ b/tr/terms.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Kullanım Şartları - Prompter</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Kullanım Şartları - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Kullanım Şartları - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/tr/terms.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+    <meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/tr/terms.html" />
+    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
+    <link rel="stylesheet" href="css/tailwind.css?v=65" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <link rel="canonical" href="__SITE_URL__/tr/terms.html" />
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body class="bg-black text-white min-h-screen p-4">
+      <h1 class="text-2xl font-bold mb-4">Kullanım Şartları</h1>
+      <p class="mb-2">Prompter AI tarafından oluşturulan metinler sunar. Lütfen yalnızca yasal amaçlar için sorumlu şekilde kullanın.</p>
+      <p class="mb-2">Hizmet, herhangi bir garanti olmaksızın 'olduğu gibi' sağlanmaktadır. Kullanımından doğabilecek zararlardan sorumlu değiliz.</p>
+      <p class="mb-2">Prompter'ı kullanmaya devam ederek bu koşulları kabul etmiş olursunuz.</p>
+    <a href="tr/" class="text-blue-400 underline">Prompter'a dön</a>
+  </body>
+</html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -544,9 +544,8 @@
         <p id="footer-prompter" class="text-blue-300 text-xs font-semibold">
           Prompter
         </p>
-        <a href="privacy.html" class="text-blue-400 underline block mt-2"
-          >Privacy Policy</a
-        >
+        <a href="privacy.html" class="text-blue-400 underline block mt-2">Privacy Policy</a>
+        <a href="terms.html" class="text-blue-400 underline block mt-2">使用条款</a>
         <a
           href="https://chat.whatsapp.com/LAu2OosQEmd73CBl56sIRi"
           target="_blank"

--- a/zh/terms.html
+++ b/zh/terms.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>使用条款 - Prompter</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="使用条款 - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="使用条款 - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/zh/terms.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+    <meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/zh/terms.html" />
+    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
+    <link rel="stylesheet" href="css/tailwind.css?v=65" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <link rel="canonical" href="__SITE_URL__/zh/terms.html" />
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body class="bg-black text-white min-h-screen p-4">
+      <h1 class="text-2xl font-bold mb-4">使用条款</h1>
+      <p class="mb-2">Prompter 提供 AI 生成的文本。请仅将其用于合法目的，并负责任地使用。</p>
+      <p class="mb-2">本服务按“原样”提供，不附带任何保证。对于使用本服务所造成的任何损害，我们概不负责。</p>
+      <p class="mb-2">继续使用 Prompter 即表示您同意这些条款。</p>
+    <a href="zh/" class="text-blue-400 underline">返回 Prompter</a>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create `terms.html` with usage policies
- add translated copies in Turkish, Spanish, French, Hindi and Chinese
- link new pages from each footer
- include pages in sitemap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f0bcf5180832f95a5f8d1edff351c