### PR TITLE
Add terms link in legal page and soften liability text

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -62,6 +62,7 @@
       <p class="mb-2">Prompter relies on Firebase to manage authentication and limited service data. Communication with Firebase is encrypted both in transit and at rest.</p>
       <p class="mb-2">Your prompt history and saved prompts remain in your browser, giving you full control over when to remove them. We do not store personal data on our servers and adhere to recognized security practices.</p>
       <p class="mb-2">Prompter is distributed under the Apache 2.0 License. All rights reserved.</p>
+      <a href="terms.html" class="text-blue-400 underline block mt-2">Terms of Use</a>
     <a href="index.html" class="text-blue-400 underline">Return to Prompter</a>
   </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -43,7 +43,7 @@
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>
       <p class="mb-2">Prompter provides AI-generated text. Use it responsibly for lawful purposes only.</p>
-      <p class="mb-2">The service is provided &quot;as is&quot; without warranties. We are not liable for any damages resulting from its use.</p>
+        <p class="mb-2">The service is provided &quot;as is&quot; without warranties. While we strive for reliability, we cannot accept responsibility for issues arising from its use.</p>
       <p class="mb-2">By continuing to use Prompter, you agree to these terms.</p>
     <a href="index.html" class="text-blue-400 underline">Return to Prompter</a>
   </body>

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -63,6 +63,7 @@
       <p class="mb-2">Prompter, kimlik doğrulama ve sınırlı hizmet verilerini yönetmek için Firebase'e güvenir. Firebase ile iletişim aktarım sırasında ve depolamada şifrelenir.</p>
       <p class="mb-2">Komut geçmişiniz ve kaydedilmiş komutlarınız tarayıcınızda kalır; bunları ne zaman sileceğinize tamamen siz karar verirsiniz. Kişisel verileri sunucularımızda saklamıyor ve kabul görmüş güvenlik uygulamalarına uyuyoruz.</p>
       <p class="mb-2">Prompter, Apache 2.0 Lisansı kapsamında dağıtılır. Tüm hakları saklıdır.</p>
+      <a href="tr/terms.html" class="text-blue-400 underline block mt-2">Kullanım Şartları</a>
     <a href="tr/" class="text-blue-400 underline">Prompter'a dön</a>
   </body>
 </html>

--- a/tr/terms.html
+++ b/tr/terms.html
@@ -44,7 +44,7 @@
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Kullanım Şartları</h1>
       <p class="mb-2">Prompter AI tarafından oluşturulan metinler sunar. Lütfen yalnızca yasal amaçlar için sorumlu şekilde kullanın.</p>
-      <p class="mb-2">Hizmet, herhangi bir garanti olmaksızın 'olduğu gibi' sağlanmaktadır. Kullanımından doğabilecek zararlardan sorumlu değiliz.</p>
+        <p class="mb-2">Hizmet, garanti vermeksizin 'olduğu gibi' sunulmaktadır. Hizmeti en iyi şekilde sunmaya çabalasak da, kullanım sırasında oluşabilecek olumsuzluklardan sorumluluk kabul edilmez.</p>
       <p class="mb-2">Prompter'ı kullanmaya devam ederek bu koşulları kabul etmiş olursunuz.</p>
     <a href="tr/" class="text-blue-400 underline">Prompter'a dön</a>
   </body>


### PR DESCRIPTION
## Summary
- link terms page from the legal page
- add Turkish equivalent in `tr/privacy.html`
- lighten the liability text on terms pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f0e359528832f8d35fa840470a3ad