### PR TITLE
Add localized 404 pages

### DIFF
--- a/es/404.html
+++ b/es/404.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <title>404 - Página no encontrada</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+      <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="404 - Página no encontrada" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="404 - Página no encontrada" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/es/404.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/es/404.html" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body
+    class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"
+  >
+    <h1 class="text-2xl font-bold mb-4">404 - Página no encontrada</h1>
+    <p class="mb-4">La página que buscas no se pudo encontrar.</p>
+    <a href="/" class="text-blue-400 underline">Volver a Inicio</a>
+  </body>
+</html>

--- a/fr/404.html
+++ b/fr/404.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <title>404 - Page non trouvée</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+      <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="404 - Page non trouvée" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="404 - Page non trouvée" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/fr/404.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/fr/404.html" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body
+    class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"
+  >
+    <h1 class="text-2xl font-bold mb-4">404 - Page non trouvée</h1>
+    <p class="mb-4">La page que vous recherchez est introuvable.</p>
+    <a href="/" class="text-blue-400 underline">Retour à l'accueil</a>
+  </body>
+</html>

--- a/hi/404.html
+++ b/hi/404.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <title>404 - पृष्ठ नहीं मिला</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+      <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="404 - पृष्ठ नहीं मिला" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="404 - पृष्ठ नहीं मिला" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/hi/404.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+
+    <meta name="twitter:url" content="__SITE_URL__/hi/404.html" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body
+    class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"
+  >
+    <h1 class="text-2xl font-bold mb-4">404 - पृष्ठ नहीं मिला</h1>
+    <p class="mb-4">जिस पृष्ठ को आप ढूंढ रहे हैं वह नहीं मिला.</p>
+    <a href="/" class="text-blue-400 underline">होम पेज पर लौटें</a>
+  </body>
+</html>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -27,7 +27,14 @@ function pathToUrl(file) {
 }
 
 let htmlFiles = getHtmlFiles(rootDir);
-const customFiles = [path.join(rootDir, '404.html')];
+const customFiles = [
+  path.join(rootDir, '404.html'),
+  path.join(rootDir, 'tr', '404.html'),
+  path.join(rootDir, 'es', '404.html'),
+  path.join(rootDir, 'fr', '404.html'),
+  path.join(rootDir, 'hi', '404.html'),
+  path.join(rootDir, 'zh', '404.html'),
+];
 htmlFiles = Array.from(new Set([...htmlFiles, ...customFiles]));
 
 const urls = htmlFiles.map((file) => ({

--- a/tr/404.html
+++ b/tr/404.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <title>404 - Sayfa Bulunamadı</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+      <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="404 - Sayfa Bulunamadı" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="404 - Sayfa Bulunamadı" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/tr/404.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="zh" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/tr/404.html" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body
+    class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"
+  >
+    <h1 class="text-2xl font-bold mb-4">404 - Sayfa Bulunamadı</h1>
+    <p class="mb-4">Aradığınız sayfa bulunamadı.</p>
+    <a href="/" class="text-blue-400 underline">Ana Sayfaya Dön</a>
+  </body>
+</html>

--- a/zh/404.html
+++ b/zh/404.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <title>404 - 页面未找到</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=65" />
+    <link rel="manifest" href="manifest.json?v=65" />
+    <meta name="theme-color" content="#000000" />
+      <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="404 - 页面未找到" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="404 - 页面未找到" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=65" />
+    <meta property="og:url" content="__SITE_URL__/zh/404.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+
+    <meta name="twitter:url" content="__SITE_URL__/zh/404.html" />
+    <link rel="stylesheet" href="css/app.css?v=65" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=65" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="src/version.js?v=65"></script>
+  </head>
+  <body
+    class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"
+  >
+    <h1 class="text-2xl font-bold mb-4">404 - 页面未找到</h1>
+    <p class="mb-4">您要找的页面无法找到。</p>
+    <a href="/" class="text-blue-400 underline">返回首页</a>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add per-language 404 pages for Spanish, French, Hindi, Turkish and Chinese
- include the new 404 pages when generating the sitemap

## Testing
- `npm test` *(fails: Dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f11224fcc832fb23cb96387174626