### PR TITLE
Refactor BASE_URL constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Before deploying your own instance, update all references to the default domain
 
 - Edit the canonical `<link>` tags in all HTML files so they point to your final
   site.
+- Update `src/config.js` with your domain so scripts use the correct `BASE_URL`.
 - Ensure the `<base>` tag in every HTML file matches the path where the site is
   hosted. A mismatched value will break relative URLs. Example: `<base
 href="/subdir/">` when serving from `/subdir/`.

--- a/blog.html
+++ b/blog.html
@@ -144,6 +144,7 @@
         updatePostText,
         postScore,
       } from './src/blog.js';
+      import { BASE_URL } from './src/config.js';
       import {
         getUserProfile,
         getFollowingIds,
@@ -296,7 +297,7 @@
         twitterBtn.addEventListener('click', () => {
           const url =
             'https://twitter.com/intent/tweet?text=' +
-            encodeURIComponent(p.text + ' https://prompterai.space');
+            encodeURIComponent(p.text + ` ${BASE_URL}`);
           window.open(url, '_blank');
         });
 

--- a/es/social.html
+++ b/es/social.html
@@ -126,6 +126,7 @@
       import { linkify } from './src/linkify.js';
       import { timeAgo } from './src/timeago.js';
       import { categories } from './src/prompts.js?v=66';
+      import { BASE_URL } from '../src/config.js';
       import {
         getUserProfile,
         getFollowingIds,
@@ -229,7 +230,7 @@
 
       const sharePrompt = (prompt, baseUrl) => {
         if (!prompt) return;
-        const link = ' https://prompterai.space';
+        const link = ` ${BASE_URL}`;
         const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
         window.open(url, '_blank');
       };

--- a/fr/social.html
+++ b/fr/social.html
@@ -126,6 +126,7 @@
       import { linkify } from './src/linkify.js';
       import { timeAgo } from './src/timeago.js';
       import { categories } from './src/prompts.js?v=66';
+      import { BASE_URL } from '../src/config.js';
       import {
         getUserProfile,
         getFollowingIds,
@@ -229,7 +230,7 @@
 
       const sharePrompt = (prompt, baseUrl) => {
         if (!prompt) return;
-        const link = ' https://prompterai.space';
+        const link = ` ${BASE_URL}`;
         const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
         window.open(url, '_blank');
       };

--- a/hi/social.html
+++ b/hi/social.html
@@ -126,6 +126,7 @@
       import { linkify } from './src/linkify.js';
       import { timeAgo } from './src/timeago.js';
       import { categories } from './src/prompts.js?v=66';
+      import { BASE_URL } from '../src/config.js';
       import {
         getUserProfile,
         getFollowingIds,
@@ -229,7 +230,7 @@
 
       const sharePrompt = (prompt, baseUrl) => {
         if (!prompt) return;
-        const link = ' https://prompterai.space';
+        const link = ` ${BASE_URL}`;
         const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
         window.open(url, '_blank');
       };

--- a/social.html
+++ b/social.html
@@ -128,6 +128,7 @@
       import { linkify } from './src/linkify.js';
       import { timeAgo } from './src/timeago.js';
       import { categories } from './src/prompts.js?v=66';
+      import { BASE_URL } from './src/config.js';
       import {
         getUserProfile,
         getFollowingIds,
@@ -231,7 +232,7 @@
 
       const sharePrompt = (prompt, baseUrl) => {
         if (!prompt) return;
-        const link = ' https://prompterai.space';
+        const link = ` ${BASE_URL}`;
         const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
         window.open(url, '_blank');
       };

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,1 @@
-export const SITE_URL = 'https://prompterai.space';
+export const BASE_URL = 'https://prompterai.space';

--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -1,6 +1,7 @@
 import { appState, THEMES } from './state.js';
 import { onAuth } from './auth.js';
 import { getUserSavedPrompts } from './prompt.js';
+import { BASE_URL } from './config.js';
 
 const LANGUAGE_PAGES = {
   en: 'index.html',
@@ -246,7 +247,7 @@ const renderList = () => {
 
 const sharePrompt = (prompt, baseUrl) => {
   if (!prompt) return;
-  const link = ' https://prompterai.space';
+  const link = ` ${BASE_URL}`;
   const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
   window.open(url, '_blank');
 };

--- a/src/profile.js
+++ b/src/profile.js
@@ -22,6 +22,7 @@ import {
 import { listenNotifications, markNotificationRead } from './notifications.js';
 import { appState, THEMES } from './state.js';
 import { categories } from './prompts.js';
+import { BASE_URL } from './config.js';
 import { linkify } from './linkify.js';
 
 const uiText = {
@@ -414,7 +415,7 @@ const markAllNotificationsRead = async () => {
 
 const sharePrompt = (prompt, baseUrl) => {
   if (!prompt) return;
-  const link = ' https://prompterai.space';
+  const link = ` ${BASE_URL}`;
   const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
   window.open(url, '_blank');
 };

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,6 +1,6 @@
 import { appState, THEMES } from './state.js';
 import { categories, ICON_FALLBACKS, generatePrompt } from './prompts.js';
-import { SITE_URL } from './config.js';
+import { BASE_URL } from './config.js';
 
 const LANGUAGE_PAGES = {
   en: 'index.html',
@@ -981,7 +981,7 @@ const handleGenerate = async () => {
 
 const sharePrompt = (prompt, baseUrl) => {
   if (!prompt) return;
-  const link = ` ${SITE_URL}`;
+  const link = ` ${BASE_URL}`;
   const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
   window.open(url, '_blank');
 };

--- a/tr/social.html
+++ b/tr/social.html
@@ -124,6 +124,7 @@
       import { promptScore } from './src/scoring.js';
       import { appState } from './src/state.js';
       import { categories } from './src/prompts.js?v=66';
+      import { BASE_URL } from '../src/config.js';
       import {
         getUserProfile,
         getFollowingIds,
@@ -226,7 +227,7 @@
 
       const sharePrompt = (prompt, baseUrl) => {
         if (!prompt) return;
-        const link = ' https://prompterai.space';
+        const link = ` ${BASE_URL}`;
         const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
         window.open(url, '_blank');
       };

--- a/zh/social.html
+++ b/zh/social.html
@@ -126,6 +126,7 @@
       import { linkify } from './src/linkify.js';
       import { timeAgo } from './src/timeago.js';
       import { categories } from './src/prompts.js?v=66';
+      import { BASE_URL } from '../src/config.js';
       import {
         getUserProfile,
         getFollowingIds,
@@ -229,7 +230,7 @@
 
       const sharePrompt = (prompt, baseUrl) => {
         if (!prompt) return;
-        const link = ' https://prompterai.space';
+        const link = ` ${BASE_URL}`;
         const url = `${baseUrl}${encodeURIComponent(`${prompt}${link}`)}`;
         window.open(url, '_blank');
       };


### PR DESCRIPTION
## Summary
- centralize project URL as BASE_URL in `src/config.js`
- use BASE_URL when sharing prompts in scripts and HTML
- document editing `BASE_URL` for custom deployments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f1bc9e558832fab25abff89f9779d