### PR TITLE
Refactor lucide loader

### DIFF
--- a/es/user.html
+++ b/es/user.html
@@ -35,7 +35,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/es/user.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/fr/user.html
+++ b/fr/user.html
@@ -35,7 +35,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/fr/user.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/hi/user.html
+++ b/hi/user.html
@@ -35,7 +35,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/hi/user.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/src/lucide-loader.js
+++ b/src/lucide-loader.js
@@ -70,8 +70,8 @@ export function loadWithFallback(primary, local) {
 }
 
 window.lucideScripts = loadWithFallback(
-  'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=65',
-  'lucide.min.js?v=65',
+  'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66',
+  'lucide.min.js?v=66',
 );
 
 window.lucideScripts.loadPromise.finally(() => {

--- a/top-collectors.html
+++ b/top-collectors.html
@@ -34,7 +34,7 @@
 
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/top-creators.html
+++ b/top-creators.html
@@ -34,7 +34,7 @@
 
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/top-prompts.html
+++ b/top-prompts.html
@@ -34,7 +34,7 @@
 
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/top.html
+++ b/top.html
@@ -38,7 +38,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/top.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/tr/top-collectors.html
+++ b/tr/top-collectors.html
@@ -34,7 +34,7 @@
 
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/tr/top-creators.html
+++ b/tr/top-creators.html
@@ -34,7 +34,7 @@
 
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/tr/top-prompts.html
+++ b/tr/top-prompts.html
@@ -34,7 +34,7 @@
 
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/tr/top.html
+++ b/tr/top.html
@@ -38,7 +38,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/tr/top.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/tr/user.html
+++ b/tr/user.html
@@ -35,7 +35,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/tr/user.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/user.html
+++ b/user.html
@@ -35,7 +35,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/user.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>

--- a/zh/user.html
+++ b/zh/user.html
@@ -35,7 +35,7 @@
     <meta name="twitter:url" content="https://prompterai.space/" />
     <link rel="canonical" href="https://prompterai.space/zh/user.html" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js?v=66"></script>
+    <script type="module" src="src/lucide-loader.js?v=66"></script>
     <link rel="stylesheet" href="css/app.css?v=66" />
     <script type="module" src="src/init-app.js?v=66"></script>
     <script nomodule src="dist/init-app.js?v=66"></script>


### PR DESCRIPTION
## Summary
- centralize lucide fallback logic in `src/lucide-loader.js`
- reference the new loader on all pages that previously loaded Lucide from CDN only
- update loader module version to `v=66`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f1f6c5394832f8c6bdcbec4b8d90c