### PR TITLE
Sanitize HTML before using innerHTML

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -153,6 +153,7 @@
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { linkify } from './src/linkify.js';
+      import { sanitizeHTML, setSanitizedHTML } from './src/sanitize.js';
       import { timeAgo } from './src/timeago.js';
       const msgs = {
         en: { loginRequired: 'Login required' },
@@ -175,7 +176,7 @@
       const fetchName = async (uid) => {
         if (profileCache[uid]) return profileCache[uid];
         const prof = await getUserProfile(uid);
-        const name = prof?.name || 'Unknown User';
+        const name = sanitizeHTML(prof?.name || 'Unknown User');
         profileCache[uid] = name;
         return name;
       };
@@ -220,7 +221,10 @@
 
         const nameEl = document.createElement('p');
         nameEl.className = 'text-blue-200 text-xs mt-1 underline';
-        nameEl.innerHTML = `<a href="user.html?uid=${p.userId}">${name}</a>`;
+        setSanitizedHTML(
+          nameEl,
+          `<a href="user.html?uid=${p.userId}">${name}</a>`
+        );
         card.appendChild(nameEl);
 
         const timeEl = document.createElement('p');
@@ -426,9 +430,9 @@
           const n = await fetchName(c.userId);
           const d = document.createElement('div');
           d.className = 'bg-white/5 rounded-md px-2 py-1 text-sm';
-          d.innerHTML = `<span class="underline">${n}</span>: ${linkify(
-            c.text
-          )}`;
+          d.innerHTML = sanitizeHTML(
+            `<span class="underline">${n}</span>: ${linkify(c.text)}`
+          );
           commentList.appendChild(d);
         };
         for (const c of comments) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "prompter",
       "version": "1.0.0",
+      "dependencies": {
+        "dompurify": "^2.4.4"
+      },
       "devDependencies": {
         "@babel/cli": "^7.27.2",
         "@babel/core": "^7.27.4",
@@ -3242,6 +3245,12 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.4.tgz",
+      "integrity": "sha512-1e2SpqHiRx4DPvmRuXU5J0di3iQACwJM+mFGE2HAkkK7Tbnfk9WcghcAmyWc9CRrjyRRUpmuhPUH6LphQQR3EQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/domutils": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "prettier": "^2.8.8",
     "svgo": "^3.3.2",
     "tailwindcss": "^3.4.17"
+  },
+  "dependencies": {
+    "dompurify": "^2.4.4"
   }
 }

--- a/social.html
+++ b/social.html
@@ -126,6 +126,7 @@
       import { promptScore } from './src/scoring.js';
       import { appState } from './src/state.js';
       import { linkify } from './src/linkify.js';
+      import { sanitizeHTML, setSanitizedHTML } from './src/sanitize.js';
       import { timeAgo } from './src/timeago.js';
       import { categories } from './src/prompts.js?v=66';
       import { BASE_URL } from './src/config.js';
@@ -222,8 +223,9 @@
       const fetchName = async (uid) => {
         if (profileCache[uid]) return profileCache[uid];
         const prof = await getUserProfile(uid);
-        profileCache[uid] = prof?.name || 'Unknown User';
-        return profileCache[uid];
+        const n = sanitizeHTML(prof?.name || 'Unknown User');
+        profileCache[uid] = n;
+        return n;
       };
 
       const urlParams = new URLSearchParams(window.location.search);
@@ -318,7 +320,10 @@
 
         const nameEl = document.createElement('p');
         nameEl.className = 'text-blue-200 text-xs mt-1 underline';
-        nameEl.innerHTML = `<a href="user.html?uid=${p.userId}">${name}</a>`;
+        setSanitizedHTML(
+          nameEl,
+          `<a href="user.html?uid=${p.userId}">${name}</a>`
+        );
 
         const catEl = document.createElement('p');
         catEl.className = 'text-blue-200 text-xs';
@@ -670,11 +675,13 @@
 
           const span = document.createElement('span');
           span.className = 'flex-1';
-          span.innerHTML = n
-            ? `<a href="user.html?uid=${c.userId}" class="underline">${n}</a>: ${linkify(
-                c.text
-              )}`
-            : linkify(c.text);
+          span.innerHTML = sanitizeHTML(
+            n
+              ? `<a href="user.html?uid=${c.userId}" class="underline">${n}</a>: ${linkify(
+                  c.text
+                )}`
+              : linkify(c.text)
+          );
           d.appendChild(span);
 
           if (appState.currentUser && c.userId === appState.currentUser.uid) {

--- a/src/linkify.js
+++ b/src/linkify.js
@@ -1,7 +1,9 @@
+import { sanitizeHTML } from './sanitize.js';
 export function linkify(text) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
-  return text.replace(urlRegex, (url) => {
+  const html = text.replace(urlRegex, (url) => {
     const safeUrl = url.replace(/"/g, '&quot;');
     return `<a href="${safeUrl}" target="_blank" class="underline">${url}</a>`;
   });
+  return sanitizeHTML(html);
 }

--- a/src/profile.js
+++ b/src/profile.js
@@ -24,6 +24,7 @@ import { appState, THEMES } from './state.js';
 import { categories } from './prompts.js';
 import { BASE_URL } from './config.js';
 import { linkify } from './linkify.js';
+import { sanitizeHTML, setSanitizedHTML } from './sanitize.js';
 
 const uiText = {
   en: {
@@ -220,6 +221,7 @@ const fetchName = async (uid) => {
   if (prof?.email) {
     display += ` (${prof.email})`;
   }
+  display = sanitizeHTML(display);
   profileCache[uid] = display;
   return display;
 };
@@ -442,7 +444,7 @@ const renderSavedPrompts = (prompts) => {
     textContainer.className = 'prompt-text-box overflow-hidden max-h-40';
 
     const pEl = document.createElement('p');
-    pEl.innerHTML = linkify(text);
+    setSanitizedHTML(pEl, linkify(text));
     textContainer.appendChild(pEl);
     textWrap.appendChild(textContainer);
 
@@ -666,7 +668,7 @@ const renderSharedPrompts = async (prompts) => {
     textContainer.className = 'prompt-text-box overflow-hidden max-h-40';
 
     const text = document.createElement('p');
-    text.innerHTML = linkify(p.text);
+    setSanitizedHTML(text, linkify(p.text));
     textContainer.appendChild(text);
     textWrap.appendChild(textContainer);
 
@@ -993,11 +995,13 @@ const renderSharedPrompts = async (prompts) => {
 
       const span = document.createElement('span');
       span.className = 'flex-1';
-      span.innerHTML = n
-        ? `<a href="user.html?uid=${c.userId}" class="underline">${n}</a>: ${linkify(
-            c.text
-          )}`
-        : linkify(c.text);
+      span.innerHTML = sanitizeHTML(
+        n
+          ? `<a href="user.html?uid=${c.userId}" class="underline">${n}</a>: ${linkify(
+              c.text
+            )}`
+          : linkify(c.text)
+      );
       d.appendChild(span);
 
       if (appState.currentUser && c.userId === appState.currentUser.uid) {

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -1,0 +1,5 @@
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@2.4.4/dist/purify.es.js';
+export const sanitizeHTML = (html) => DOMPurify.sanitize(html);
+export const setSanitizedHTML = (el, html) => {
+  el.innerHTML = DOMPurify.sanitize(html);
+};


### PR DESCRIPTION
## Summary
- add DOMPurify dependency
- expose `sanitizeHTML` and `setSanitizedHTML` helpers
- sanitize URLs returned from `linkify`
- escape names and comments before assigning `innerHTML`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2444e838832fb96c447d80a83774