### PR TITLE
Externalize Firebase configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 /prompts.js
+firebase.config.json

--- a/README.md
+++ b/README.md
@@ -44,7 +44,23 @@ disabled.
 
 ## Authentication
 
-Prompter uses Firebase Email/Password authentication configured in `src/firebase.js`.
+Prompter uses Firebase Email/Password authentication. Provide your Firebase
+credentials in a `firebase.config.json` file at the project root or expose them
+via `window.firebaseConfig` before the scripts load.
+The JSON file should follow this structure:
+
+```json
+{
+  "apiKey": "YOUR_API_KEY",
+  "authDomain": "YOUR_PROJECT.firebaseapp.com",
+  "projectId": "YOUR_PROJECT",
+  "storageBucket": "YOUR_PROJECT.appspot.com",
+  "messagingSenderId": "YOUR_SENDER_ID",
+  "appId": "YOUR_APP_ID",
+  "measurementId": "YOUR_MEASUREMENT_ID"
+}
+```
+
 Enable that sign‑in method in your Firebase console and add your domain (for example `localhost`) to the list of authorized domains.
 Serve the app using a simple HTTP server such as `python3 -m http.server` so Firebase initializes correctly.
 Synchronization of saved prompts with Firebase requires a logged-in session. When not authenticated, prompts are only stored locally.
@@ -89,7 +105,6 @@ Prompter offers a variety of prompt themes. Select a category by clicking its ic
 Prompter includes **12 categories** in total—the **Random** plus 11 themed options listed above. Each prompt is composed of four parts. Most categories now have **52** openings and endings and around **51** middle lines. The **AI** set now has **62** entries for its first and last sections, while **Ideas** and **Perspective** gained extra variations. As a result, most categories generate **7,033,104** prompts each. **Perspective** yields **7,030,503**, **Ideas** produces **8,642,816** and **AI** reaches **14,303,524**. In total the 11 themed categories provide **86,241,675** unique prompts per language—**517,450,050** across English, Turkish, Spanish, Hindi, French and Chinese.
 
 If icon fonts fail to load, the app falls back to emoji symbols so the buttons remain visible.
-
 
 Example: click the **Video** icon, then press **Generate New Prompt** to create a video-related idea.
 
@@ -239,7 +254,6 @@ All pages include the standard AdSense loader in the `<head>` tag:
   crossorigin="anonymous"
 ></script>
 ```
-
 
 The script fetches Google's ad library asynchronously using your publisher ID (`client`). After it loads you can place `<ins class="adsbygoogle">` elements in the body to display ads. See [the AdSense documentation](https://support.google.com/adsense/answer/9271723) for details on creating and customizing ad units.
 

--- a/firebase.config.example.json
+++ b/firebase.config.example.json
@@ -1,0 +1,9 @@
+{
+  "apiKey": "YOUR_API_KEY",
+  "authDomain": "YOUR_PROJECT.firebaseapp.com",
+  "projectId": "YOUR_PROJECT",
+  "storageBucket": "YOUR_PROJECT.appspot.com",
+  "messagingSenderId": "YOUR_SENDER_ID",
+  "appId": "YOUR_APP_ID",
+  "measurementId": "YOUR_MEASUREMENT_ID"
+}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,15 +2,16 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.1/firebas
 import { getAuth } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js';
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 
-export const firebaseConfig = {
-  apiKey: 'AIzaSyCiSVRdzDJPsYCWsTvGxueCs-Fcf5LCaYM',
-  authDomain: 'prompter-cc95c.firebaseapp.com',
-  projectId: 'prompter-cc95c',
-  storageBucket: 'prompter-cc95c.appspot.com',
-  messagingSenderId: '349560111475',
-  appId: '1:349560111475:web:b8152fd082702df9e18506',
-  measurementId: 'G-HTSK6FGDQD',
-};
+export async function loadFirebaseConfig() {
+  if (window.firebaseConfig) {
+    return window.firebaseConfig;
+  }
+  const res = await fetch('/firebase.config.json');
+  if (!res.ok) {
+    throw new Error('Firebase configuration not found');
+  }
+  return res.json();
+}
 
 export let app;
 export let auth;

--- a/src/init-app.js
+++ b/src/init-app.js
@@ -1,20 +1,27 @@
-import { initFirebase, firebaseConfig } from './firebase.js';
+import { initFirebase, loadFirebaseConfig } from './firebase.js';
 import { onAuth } from './auth.js';
 import { appState } from './state.js';
 import { getUserSavedPrompts } from './prompt.js';
 
-initFirebase(firebaseConfig);
-
-onAuth(async (user) => {
-  appState.currentUser = user;
-  if (!user) return;
-  try {
-    const docs = await getUserSavedPrompts(user.uid);
-    const texts = docs.map((d) => d.text);
-    const merged = Array.from(new Set([...appState.savedPrompts, ...texts]));
-    localStorage.setItem('savedPrompts', JSON.stringify(merged));
-    appState.savedPrompts = merged;
-  } catch (err) {
-    console.error('Failed to sync saved prompts:', err);
-  }
-});
+loadFirebaseConfig()
+  .then((config) => {
+    initFirebase(config);
+    onAuth(async (user) => {
+      appState.currentUser = user;
+      if (!user) return;
+      try {
+        const docs = await getUserSavedPrompts(user.uid);
+        const texts = docs.map((d) => d.text);
+        const merged = Array.from(
+          new Set([...appState.savedPrompts, ...texts]),
+        );
+        localStorage.setItem('savedPrompts', JSON.stringify(merged));
+        appState.savedPrompts = merged;
+      } catch (err) {
+        console.error('Failed to sync saved prompts:', err);
+      }
+    });
+  })
+  .catch((err) => {
+    console.error('Failed to initialize Firebase:', err);
+  });


### PR DESCRIPTION
## Summary
- read Firebase config from `firebase.config.json` or `window.firebaseConfig`
- load the config dynamically in `init-app.js`
- document the config file format
- provide `firebase.config.example.json`
- ignore the real config file in git

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f265717c4832f9a417a6d56293135