### PR TITLE
Improve ranking computation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,8 @@
     {
       "files": [
         "scripts/*.js",
-        "functions/*.js"
+        "functions/*.js",
+        "functions/test/*.js"
       ],
       "env": {
         "node": true

--- a/functions/test/aggregateInteractions.test.js
+++ b/functions/test/aggregateInteractions.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { aggregateInteractions } = require('../index');
+
+const prompts = [
+  { data: () => ({ likedBy: ['u1', 'u2'], sharedBy: ['u2'] }) },
+  { data: () => ({ likedBy: ['u1'], sharedBy: [] }) },
+];
+
+const savedDocs = [
+  { ref: { parent: { parent: { id: 'u1' } } } },
+  { ref: { parent: { parent: { id: 'u2' } } } },
+  { ref: { parent: { parent: { id: 'u1' } } } },
+];
+
+const { likes, shares, saves } = aggregateInteractions(prompts, savedDocs);
+assert.deepStrictEqual(likes, { u1: 2, u2: 1 });
+assert.deepStrictEqual(shares, { u2: 1 });
+assert.deepStrictEqual(saves, { u1: 2, u2: 1 });
+
+console.log('aggregateInteractions tests passed');


### PR DESCRIPTION
## Summary
- aggregate like/share/save counts across prompts
- compute collector scores from aggregated data
- export helpers for testing and test them
- lint tests with Node settings

## Testing
- `npm test`
- `node functions/test/aggregateInteractions.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685f28fe5074832f8db1a6ded7caf850