### PR TITLE
Remove monetag meta tag

### DIFF
--- a/es/privacy.html
+++ b/es/privacy.html
@@ -41,7 +41,6 @@
       }
     </script>
     -->
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/es/terms.html
+++ b/es/terms.html
@@ -34,7 +34,6 @@
     <meta property="og:locale:alternate" content="hi" />
 
     <meta name="twitter:url" content="https://prompterai.space/es/terms.html" />
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/fr/privacy.html
+++ b/fr/privacy.html
@@ -41,7 +41,6 @@
       }
     </script>
     -->
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/fr/terms.html
+++ b/fr/terms.html
@@ -34,7 +34,6 @@
     <meta property="og:locale:alternate" content="hi" />
 
     <meta name="twitter:url" content="https://prompterai.space/fr/terms.html" />
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/hi/privacy.html
+++ b/hi/privacy.html
@@ -41,7 +41,6 @@
       }
     </script>
     -->
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/hi/terms.html
+++ b/hi/terms.html
@@ -34,7 +34,6 @@
     <meta property="og:locale:alternate" content="fr" />
 
     <meta name="twitter:url" content="https://prompterai.space/hi/terms.html" />
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/privacy.html
+++ b/privacy.html
@@ -40,7 +40,6 @@
       }
     </script>
     -->
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/terms.html
+++ b/terms.html
@@ -33,7 +33,6 @@
     <meta property="og:locale:alternate" content="hi" />
 
     <meta name="twitter:url" content="https://prompterai.space/terms.html" />
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -41,7 +41,6 @@
       }
     </script>
     -->
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/tr/terms.html
+++ b/tr/terms.html
@@ -34,7 +34,6 @@
     <meta property="og:locale:alternate" content="hi" />
 
     <meta name="twitter:url" content="https://prompterai.space/tr/terms.html" />
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/zh/privacy.html
+++ b/zh/privacy.html
@@ -41,7 +41,6 @@
       }
     </script>
     -->
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />

--- a/zh/terms.html
+++ b/zh/terms.html
@@ -34,7 +34,6 @@
     <meta property="og:locale:alternate" content="hi" />
 
     <meta name="twitter:url" content="https://prompterai.space/zh/terms.html" />
-    <meta name="monetag" content="44844d38cfa76c8330dc164a2fcb7b18" />
     <link rel="stylesheet" href="css/tailwind.css?v=66" />
     <link rel="stylesheet" href="css/app.css?v=66" />
     <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=66" />


### PR DESCRIPTION
## Summary
- remove `<meta name="monetag">` tag from privacy and terms pages
- apply same removal to translated versions in FR/ES/TR/ZH/HI

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f2cb17060832f819296dbcda4f756