### PR TITLE
Update 404 pages and sitemap handling

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,7 +20,7 @@
       <meta http-equiv="Expires" content="0" />
     <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
     <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page Not Found" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
     <meta property="og:image" content="/icons/logo.svg?v=66" />

--- a/es/404.html
+++ b/es/404.html
@@ -21,7 +21,7 @@
       <meta http-equiv="Expires" content="0" />
     <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
     <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Página no encontrada" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
     <meta property="og:image" content="/icons/logo.svg?v=66" />

--- a/fr/404.html
+++ b/fr/404.html
@@ -21,7 +21,7 @@
       <meta http-equiv="Expires" content="0" />
     <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
     <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page non trouvée" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
     <meta property="og:image" content="/icons/logo.svg?v=66" />

--- a/hi/404.html
+++ b/hi/404.html
@@ -21,7 +21,7 @@
       <meta http-equiv="Expires" content="0" />
     <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
     <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - पृष्ठ नहीं मिला" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
     <meta property="og:image" content="/icons/logo.svg?v=66" />

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -26,16 +26,9 @@ function pathToUrl(file) {
   return `${BASE_URL}/${rel}`;
 }
 
-let htmlFiles = getHtmlFiles(rootDir);
-const customFiles = [
-  path.join(rootDir, '404.html'),
-  path.join(rootDir, 'tr', '404.html'),
-  path.join(rootDir, 'es', '404.html'),
-  path.join(rootDir, 'fr', '404.html'),
-  path.join(rootDir, 'hi', '404.html'),
-  path.join(rootDir, 'zh', '404.html'),
-];
-htmlFiles = Array.from(new Set([...htmlFiles, ...customFiles]));
+let htmlFiles = getHtmlFiles(rootDir).filter(
+  (file) => !file.endsWith('404.html')
+);
 
 const urls = htmlFiles.map((file) => ({
   loc: pathToUrl(file),

--- a/tr/404.html
+++ b/tr/404.html
@@ -21,7 +21,7 @@
       <meta http-equiv="Expires" content="0" />
     <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
     <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Sayfa Bulunamadı" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
     <meta property="og:image" content="/icons/logo.svg?v=66" />

--- a/zh/404.html
+++ b/zh/404.html
@@ -21,7 +21,7 @@
       <meta http-equiv="Expires" content="0" />
     <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
     <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
-    <meta name="robots" content="index,follow" />
+    <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - 页面未找到" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
     <meta property="og:image" content="/icons/logo.svg?v=66" />


### PR DESCRIPTION
## Summary
- mark all 404 pages as `noindex`
- skip 404 pages in sitemap generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2f301594832f97eae9d2508aa383