### PR TITLE
Update README advertising section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,19 +243,10 @@ Firestore may take several minutes to build the indexes after deployment. During
 this period queries on the Social page can throw `failed-precondition` errors and
 show "Failed to load prompts."
 
-## Advertising (Google AdSense)
+## Advertising
 
-All pages include the standard AdSense loader in the `<head>` tag:
-
-```html
-<script
-  async
-  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5886415182402616"
-  crossorigin="anonymous"
-></script>
-```
-
-The script fetches Google's ad library asynchronously using your publisher ID (`client`). After it loads you can place `<ins class="adsbygoogle">` elements in the body to display ads. See [the AdSense documentation](https://support.google.com/adsense/answer/9271723) for details on creating and customizing ad units.
+Prompter no longer loads Google AdSense scripts and currently does not display
+any third‑party advertising.
 
 ## FAQ
 


### PR DESCRIPTION
## Summary
- update the README advertising text to state that AdSense is no longer used

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685f2d9e8cb0832fa0c212d0570da08a