### PR TITLE
Fix auth handler for missing Firebase init

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -9,4 +9,10 @@ export const login = (email, password) =>
 
 export const logout = () => signOut(auth);
 
-export const onAuth = (cb) => onAuthStateChanged(auth, cb);
+export const onAuth = (cb) => {
+  if (!auth) {
+    cb(null);
+    return;
+  }
+  onAuthStateChanged(auth, cb);
+};


### PR DESCRIPTION
## Summary
- add missing auth check to `onAuth`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fb9148fb0832f9dc5a02cd82b1548