### PR TITLE
Update README with Firebase config troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Firestore may take several minutes to build the indexes after deployment. During
 this period queries on the Social page can throw `failed-precondition` errors and
 show "Failed to load prompts."
 
+If you encounter `Cannot read properties of undefined (reading 'onAuthStateChanged')` on the Social page, your Firebase configuration is missing. Create a `firebase.config.json` file (using `firebase.config.example.json` as a template) or set `window.firebaseConfig` before loading the scripts.
+
 ## Advertising
 
 Prompter no longer loads Google AdSense scripts and currently does not display


### PR DESCRIPTION
## Summary
- mention that missing Firebase config causes `onAuthStateChanged` errors
- direct users to `firebase.config.example.json` when creating `firebase.config.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fba5e58ec832fa9e762713c98a5b9