### PR TITLE
Fix firebase initialization race

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -554,10 +554,12 @@
     <script type="module" src="src/main.js?v=67"></script>
     <script nomodule src="dist/main.js?v=67"></script>
     <script type="module">
-      import { app } from './src/firebase.js';
+      import { app, firebaseReady } from './src/firebase.js';
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+
+      await firebaseReady;
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');

--- a/fr/index.html
+++ b/fr/index.html
@@ -554,10 +554,12 @@
     <script type="module" src="src/main.js?v=67"></script>
     <script nomodule src="dist/main.js?v=67"></script>
     <script type="module">
-      import { app } from './src/firebase.js';
+      import { app, firebaseReady } from './src/firebase.js';
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+
+      await firebaseReady;
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');

--- a/hi/index.html
+++ b/hi/index.html
@@ -554,10 +554,12 @@
     <script type="module" src="src/main.js?v=67"></script>
     <script nomodule src="dist/main.js?v=67"></script>
     <script type="module">
-      import { app } from './src/firebase.js';
+      import { app, firebaseReady } from './src/firebase.js';
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+
+      await firebaseReady;
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');

--- a/index.html
+++ b/index.html
@@ -554,10 +554,12 @@
     <script type="module" src="src/main.js?v=67"></script>
     <script nomodule src="dist/main.js?v=67"></script>
     <script type="module">
-      import { app } from './src/firebase.js';
+      import { app, firebaseReady } from './src/firebase.js';
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+
+      await firebaseReady;
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -17,8 +17,14 @@ export let app;
 export let auth;
 export let db;
 
+let readyResolve;
+export const firebaseReady = new Promise((resolve) => {
+  readyResolve = resolve;
+});
+
 export function initFirebase(config) {
   app = initializeApp(config);
   auth = getAuth(app);
   db = getFirestore(app);
+  readyResolve();
 }

--- a/templates/index.template.html
+++ b/templates/index.template.html
@@ -544,10 +544,12 @@
     <script type="module" src="src/main.js?v=66"></script>
     <script nomodule src="dist/main.js?v=66"></script>
     <script type="module">
-      import { app } from './src/firebase.js';
+      import { app, firebaseReady } from './src/firebase.js';
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+
+      await firebaseReady;
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');

--- a/tr/index.html
+++ b/tr/index.html
@@ -554,10 +554,12 @@
     <script type="module" src="src/main.js?v=67"></script>
     <script nomodule src="dist/main.js?v=67"></script>
     <script type="module">
-      import { app } from './src/firebase.js';
+      import { app, firebaseReady } from './src/firebase.js';
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+
+      await firebaseReady;
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');

--- a/zh/index.html
+++ b/zh/index.html
@@ -554,10 +554,12 @@
     <script type="module" src="src/main.js?v=67"></script>
     <script nomodule src="dist/main.js?v=67"></script>
     <script type="module">
-      import { app } from './src/firebase.js';
+      import { app, firebaseReady } from './src/firebase.js';
       import { onAuth } from './src/auth.js';
       import { appState } from './src/state.js';
       import { getAnalytics } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js';
+
+      await firebaseReady;
       const analytics = getAnalytics(app);
 
       const loginLink = document.getElementById('login-link');


### PR DESCRIPTION
## Summary
- expose a `firebaseReady` promise after init
- wait for Firebase init before setting up analytics

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc2d6643c832fae98a95b95615e11