### PR TITLE
Queue auth callbacks until Firebase ready

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,8 @@
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js';
 import { auth } from './firebase.js';
 
+export const pendingAuthCallbacks = [];
+
 export const register = (email, password) =>
   createUserWithEmailAndPassword(auth, email, password);
 
@@ -11,7 +13,7 @@ export const logout = () => signOut(auth);
 
 export const onAuth = (cb) => {
   if (!auth) {
-    cb(null);
+    pendingAuthCallbacks.push(cb);
     return;
   }
   onAuthStateChanged(auth, cb);

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,6 +1,7 @@
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js';
-import { getAuth } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js';
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
+import { pendingAuthCallbacks } from './auth.js';
 
 export async function loadFirebaseConfig() {
   if (window.firebaseConfig) {
@@ -26,5 +27,7 @@ export function initFirebase(config) {
   app = initializeApp(config);
   auth = getAuth(app);
   db = getFirestore(app);
+  pendingAuthCallbacks.forEach((cb) => onAuthStateChanged(auth, cb));
+  pendingAuthCallbacks.length = 0;
   readyResolve();
 }


### PR DESCRIPTION
## Summary
- expose `pendingAuthCallbacks` in `auth.js`
- store auth callbacks before Firebase is initialized
- register pending callbacks in `initFirebase`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc4b60af8832f9cdfd8ccb5666ba9