### PR TITLE
Initialize analytics after Firebase config

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { listenNotifications, markNotificationRead } from './notifications.js';
 import { appState } from './state.js';
 import { getNewestPromptTimestamp } from './prompt.js';
 import { getLastSocialVisit } from './user.js';
+import { db } from './firebase.js';
 
 let notificationBtn;
 let notificationCountEl;


### PR DESCRIPTION
## Summary
- export `firebaseInitPromise` from `init-app.js`
- resolve the promise after Firebase init and user prompts sync
- initialize and export `analytics` via `getAnalytics`
- fix ESLint error in `main.js` by importing `db`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc5fc4304832f8e1efbeb52ec8847