### PR TITLE
Add Firestore retry wrapper

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -25,6 +25,21 @@ export async function loadFirebaseConfig(retries = 3) {
   }
 }
 
+export async function withRetry(fn, retries = 3, delay = 500) {
+  let lastError;
+  for (let i = 0; i < retries; i += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (i < retries - 1) {
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+  }
+  throw lastError;
+}
+
 export let app;
 export let auth;
 export let db;

--- a/src/my-prompts.js
+++ b/src/my-prompts.js
@@ -20,7 +20,7 @@ import {
   orderBy,
   onSnapshot,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+import { db, withRetry } from './firebase.js';
 
 const uiText = {
   en: {
@@ -326,9 +326,11 @@ const setupEvents = () => {
           JSON.stringify(appState.savedPrompts)
         );
         if (appState.currentUser && savedPromptIds[idx]) {
-          updateDoc(
-            doc(db, `users/${appState.currentUser.uid}/savedPrompts`, savedPromptIds[idx]),
-            { text: textarea.value }
+          withRetry(() =>
+            updateDoc(
+              doc(db, `users/${appState.currentUser.uid}/savedPrompts`, savedPromptIds[idx]),
+              { text: textarea.value }
+            )
           ).catch((err) => console.error('Failed to update prompt:', err));
         }
         showFeedback(saveBtn.nextElementSibling);
@@ -345,8 +347,10 @@ const setupEvents = () => {
           JSON.stringify(appState.savedPrompts)
         );
         if (appState.currentUser && savedPromptIds[idx]) {
-          deleteDoc(
-            doc(db, `users/${appState.currentUser.uid}/savedPrompts`, savedPromptIds[idx])
+          withRetry(() =>
+            deleteDoc(
+              doc(db, `users/${appState.currentUser.uid}/savedPrompts`, savedPromptIds[idx])
+            )
           ).catch((err) => console.error('Failed to delete prompt:', err));
         }
         renderList();

--- a/src/top-collectors.js
+++ b/src/top-collectors.js
@@ -1,5 +1,5 @@
 import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+import { db, withRetry } from './firebase.js';
 import { getUserProfile } from './user.js';
 
 const fetchName = async (uid) => {
@@ -39,7 +39,7 @@ const showMessage = (msg) => {
 
 const load = async () => {
   try {
-    const snap = await getDoc(doc(db, 'stats', 'topCollectors'));
+    const snap = await withRetry(() => getDoc(doc(db, 'stats', 'topCollectors')));
     if (!snap.exists()) {
       console.error('topCollectors document does not exist');
       showMessage('Rankings are not available.');

--- a/src/top-creators.js
+++ b/src/top-creators.js
@@ -1,5 +1,5 @@
 import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+import { db, withRetry } from './firebase.js';
 import { getUserProfile } from './user.js';
 
 const fetchName = async (uid) => {
@@ -39,7 +39,7 @@ const showMessage = (msg) => {
 
 const load = async () => {
   try {
-    const snap = await getDoc(doc(db, 'stats', 'topCreators'));
+    const snap = await withRetry(() => getDoc(doc(db, 'stats', 'topCreators')));
     if (!snap.exists()) {
       console.error('topCreators document does not exist');
       showMessage('Rankings are not available.');

--- a/src/top-pro.js
+++ b/src/top-pro.js
@@ -1,5 +1,5 @@
 import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+import { db, withRetry } from './firebase.js';
 import { getUserProfile } from './user.js';
 
 const fetchName = async (uid) => {
@@ -40,7 +40,7 @@ const showMessage = (msg) => {
 
 const load = async () => {
   try {
-    const snap = await getDoc(doc(db, 'stats', 'longestPro'));
+    const snap = await withRetry(() => getDoc(doc(db, 'stats', 'longestPro')));
     if (!snap.exists()) {
       console.error('longestPro document does not exist');
       showMessage('Rankings are not available.');

--- a/src/top-prompts.js
+++ b/src/top-prompts.js
@@ -1,9 +1,9 @@
 import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+import { db, withRetry } from './firebase.js';
 
 const fetchPromptText = async (id) => {
   try {
-    const snap = await getDoc(doc(db, 'prompts', id));
+    const snap = await withRetry(() => getDoc(doc(db, 'prompts', id)));
     return snap.exists() ? snap.data().text : id;
   } catch {
     return id;
@@ -38,7 +38,7 @@ const showMessage = (msg) => {
 
 const load = async () => {
   try {
-    const snap = await getDoc(doc(db, 'stats', 'topPrompts'));
+    const snap = await withRetry(() => getDoc(doc(db, 'stats', 'topPrompts')));
     if (!snap.exists()) {
       console.error('topPrompts document does not exist');
       showMessage('Rankings are not available.');

--- a/src/top-supporters.js
+++ b/src/top-supporters.js
@@ -1,5 +1,5 @@
 import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+import { db, withRetry } from './firebase.js';
 import { getUserProfile } from './user.js';
 
 const fetchName = async (uid) => {
@@ -39,7 +39,7 @@ const showMessage = (msg) => {
 
 const load = async () => {
   try {
-    const snap = await getDoc(doc(db, 'stats', 'topSupporters'));
+    const snap = await withRetry(() => getDoc(doc(db, 'stats', 'topSupporters')));
     if (!snap.exists()) {
       console.error('topSupporters document does not exist');
       showMessage('Rankings are not available.');

--- a/src/user.js
+++ b/src/user.js
@@ -9,10 +9,12 @@ import {
   deleteDoc,
   serverTimestamp,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
-import { db } from './firebase.js';
+import { db, withRetry } from './firebase.js';
 
 export const setUserProfile = async (uid, profile) => {
-  await setDoc(doc(db, 'users', uid, 'profile', 'info'), profile, { merge: true });
+  await withRetry(() =>
+    setDoc(doc(db, 'users', uid, 'profile', 'info'), profile, { merge: true })
+  );
   const update = {};
   if (profile && profile.name) update.name = profile.name;
   if (profile && profile.email) update.email = profile.email;
@@ -20,18 +22,18 @@ export const setUserProfile = async (uid, profile) => {
     update.bio = profile.bio;
   }
   if (Object.keys(update).length) {
-    await setDoc(doc(db, 'users', uid), update, { merge: true });
+    await withRetry(() => setDoc(doc(db, 'users', uid), update, { merge: true }));
   }
 };
 
 export const getUserProfile = async (uid) => {
-  const snap = await getDoc(doc(db, 'users', uid, 'profile', 'info'));
+  const snap = await withRetry(() => getDoc(doc(db, 'users', uid, 'profile', 'info')));
   return snap.exists() ? snap.data() : null;
 };
 
 export const getUserByName = async (name) => {
   const q = query(collection(db, 'users'), where('name', '==', name));
-  const snap = await getDocs(q);
+  const snap = await withRetry(() => getDocs(q));
   if (snap.empty) return null;
   const d = snap.docs[0];
   return { id: d.id, ...d.data() };
@@ -39,43 +41,49 @@ export const getUserByName = async (name) => {
 
 export const followUser = async (currentUid, targetUid) => {
   if (!currentUid || !targetUid || currentUid === targetUid) return;
-  await setDoc(
-    doc(db, `users/${currentUid}/following`, targetUid),
-    { createdAt: serverTimestamp() },
+  await withRetry(() =>
+    setDoc(doc(db, `users/${currentUid}/following`, targetUid), {
+      createdAt: serverTimestamp(),
+    })
   );
-  await setDoc(
-    doc(db, `users/${targetUid}/followers`, currentUid),
-    { createdAt: serverTimestamp() },
+  await withRetry(() =>
+    setDoc(doc(db, `users/${targetUid}/followers`, currentUid), {
+      createdAt: serverTimestamp(),
+    })
   );
 };
 
 export const unfollowUser = async (currentUid, targetUid) => {
   if (!currentUid || !targetUid || currentUid === targetUid) return;
-  await deleteDoc(doc(db, `users/${currentUid}/following/${targetUid}`));
-  await deleteDoc(doc(db, `users/${targetUid}/followers/${currentUid}`));
+  await withRetry(() => deleteDoc(doc(db, `users/${currentUid}/following/${targetUid}`)));
+  await withRetry(() => deleteDoc(doc(db, `users/${targetUid}/followers/${currentUid}`)));
 };
 
 export const isFollowing = async (currentUid, targetUid) => {
   if (!currentUid || !targetUid) return false;
-  const snap = await getDoc(doc(db, `users/${currentUid}/following/${targetUid}`));
+  const snap = await withRetry(() =>
+    getDoc(doc(db, `users/${currentUid}/following/${targetUid}`))
+  );
   return snap.exists();
 };
 
 export const getFollowingIds = async (uid) => {
-  const snap = await getDocs(collection(db, `users/${uid}/following`));
+  const snap = await withRetry(() => getDocs(collection(db, `users/${uid}/following`)));
   return snap.docs.map((d) => d.id);
 };
 
 export const getFollowerIds = async (uid) => {
-  const snap = await getDocs(collection(db, `users/${uid}/followers`));
+  const snap = await withRetry(() => getDocs(collection(db, `users/${uid}/followers`)));
   return snap.docs.map((d) => d.id);
 };
 
 export const updateLastSocialVisit = (uid, ts) =>
-  setDoc(doc(db, 'users', uid), { lastSocialVisit: ts }, { merge: true });
+  withRetry(() =>
+    setDoc(doc(db, 'users', uid), { lastSocialVisit: ts }, { merge: true })
+  );
 
 export const getLastSocialVisit = async (uid) => {
-  const snap = await getDoc(doc(db, 'users', uid));
+  const snap = await withRetry(() => getDoc(doc(db, 'users', uid)));
   return snap.exists() && snap.data().lastSocialVisit
     ? snap.data().lastSocialVisit
     : null;


### PR DESCRIPTION
## Summary
- add `withRetry` helper for retrying async Firestore operations
- wrap reads/writes in Firestore with the new helper across the codebase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68600bf0564c832fa8991827b950cc08