### PR TITLE
Add fallback for missing firebase config

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -19,7 +19,10 @@ export async function loadFirebaseConfig(retries = 3) {
       return cfg;
     } catch (err) {
       retries -= 1;
-      if (!retries) throw err;
+      if (!retries) {
+        console.error('Failed to load Firebase config:', err);
+        return null;
+      }
       await new Promise((r) => setTimeout(r, 1000));
     }
   }


### PR DESCRIPTION
## Summary
- log friendly error and return `null` if `firebase.config.json` fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68600e8a91e8832f9af691308011313b