### PR TITLE
Add FIREBASE_SERVICE_ACCOUNT env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,18 @@ node scripts/migrate-user-names.js
 
 Keep service‑account keys private and do not store them in the repository.
 
+### `FIREBASE_SERVICE_ACCOUNT`
+
+The Cloud Functions in `functions/` and Node scripts in `scripts/` also check
+this variable for service‑account credentials. Set it to the JSON contents of
+your key when a file path is inconvenient:
+
+```bash
+export FIREBASE_SERVICE_ACCOUNT="$(cat service-account.json)"
+```
+
+The JSON will be parsed and passed to `initializeApp()` as a credential.
+
 ## Advertising
 
 Prompter no longer loads Google AdSense scripts and currently does not display

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,7 +1,17 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 
-admin.initializeApp();
+const appOptions = {};
+if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+  try {
+    const svc = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+    appOptions.credential = admin.credential.cert(svc);
+  } catch (err) {
+    console.error('Failed to parse FIREBASE_SERVICE_ACCOUNT:', err);
+  }
+}
+
+admin.initializeApp(appOptions);
 const db = admin.firestore();
 const promptScore = (d = {}) => (d.likes || 0) + (d.saveCount || 0) + (d.shareCount || 0);
 const collectorScore = ({ likes = 0, saves = 0, shares = 0 } = {}) =>

--- a/scripts/migrate-categories.js
+++ b/scripts/migrate-categories.js
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 const admin = require('firebase-admin');
 
-admin.initializeApp();
+const appOptions = {};
+if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+  try {
+    const svc = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+    appOptions.credential = admin.credential.cert(svc);
+  } catch (err) {
+    console.error('Failed to parse FIREBASE_SERVICE_ACCOUNT:', err);
+  }
+}
+
+admin.initializeApp(appOptions);
 
 const db = admin.firestore();
 

--- a/scripts/migrate-user-emails.js
+++ b/scripts/migrate-user-emails.js
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
 const admin = require('firebase-admin');
 
-// Initialize using default credentials
-admin.initializeApp();
+const appOptions = {};
+if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+  try {
+    const svc = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+    appOptions.credential = admin.credential.cert(svc);
+  } catch (err) {
+    console.error('Failed to parse FIREBASE_SERVICE_ACCOUNT:', err);
+  }
+}
+
+// Initialize using default credentials or the provided service account
+admin.initializeApp(appOptions);
 
 const db = admin.firestore();
 const auth = admin.auth();

--- a/scripts/migrate-user-names.js
+++ b/scripts/migrate-user-names.js
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
 const admin = require('firebase-admin');
 
-// Initialize using default credentials
-admin.initializeApp();
+const appOptions = {};
+if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+  try {
+    const svc = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+    appOptions.credential = admin.credential.cert(svc);
+  } catch (err) {
+    console.error('Failed to parse FIREBASE_SERVICE_ACCOUNT:', err);
+  }
+}
+
+// Initialize using default credentials or the provided service account
+admin.initializeApp(appOptions);
 
 const db = admin.firestore();
 


### PR DESCRIPTION
## Summary
- parse `FIREBASE_SERVICE_ACCOUNT` JSON in Cloud Functions and scripts
- accept service account JSON via env variable or default credentials
- document `FIREBASE_SERVICE_ACCOUNT` in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860100e96f8832fa1e0bfebdb401748