### PR TITLE
Enable Firestore persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The JSON file should follow this structure:
 Enable that sign‑in method in your Firebase console and add your domain (for example `localhost`) to the list of authorized domains.
 Serve the app using a simple HTTP server such as `python3 -m http.server` so Firebase initializes correctly.
 Synchronization of saved prompts with Firebase requires a logged-in session. When not authenticated, prompts are only stored locally.
+Firestore caching is enabled via `enableIndexedDbPersistence`. Persistence errors are ignored so the app works even when offline caching cannot be activated.
 
 ### Versioning
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -56,11 +56,7 @@ export function initFirebase(config) {
   app = initializeApp(config);
   auth = getAuth(app);
   db = getFirestore(app);
-  if (typeof window !== 'undefined' && 'indexedDB' in window) {
-    enableIndexedDbPersistence(db).catch(() =>
-      console.warn('Firestore persistence could not be enabled')
-    );
-  }
+  enableIndexedDbPersistence(db).catch(() => {});
   pendingAuthCallbacks.forEach((cb) => onAuthStateChanged(auth, cb));
   pendingAuthCallbacks.length = 0;
   readyResolve();


### PR DESCRIPTION
## Summary
- turn on Firestore's IndexedDB persistence and ignore failures
- document caching behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860127eacf8832f8d3b0d0f84ec53b8