### PR TITLE
Add canonical and alternate links to new templates

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,8 +12,8 @@
     </script>
     -->
     <title>404 - Page Not Found</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -23,13 +23,13 @@
     <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page Not Found" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="404 - Page Not Found" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/404.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/404.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/404.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/404.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -61,7 +61,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body
     class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"

--- a/blog.html
+++ b/blog.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Space - Prompter" />
     <meta property="og:description" content="Articles and updates about Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Space - Prompter" />
     <meta name="twitter:description" content="Articles and updates about Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/blog.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -36,12 +36,12 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/blog.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/blog.html" />
 <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="en" />
@@ -63,7 +63,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -90,7 +90,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/dm.html
+++ b/dm.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Direct Messages - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,34 +16,39 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Direct Messages - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Direct Messages - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/dm.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
-<meta property="og:locale:alternate" content="tr" />
-    <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
+<meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/dm.js?v=67"></script>
-    <script nomodule src="dist/dm.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
+    <meta name="twitter:url" content="https://prompterai.space/dm.html" />
+    <link rel="canonical" href="https://prompterai.space/dm.html" />
+<link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/dm.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/dm.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/dm.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/dm.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/dm.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/dm.js?v=69"></script>
+    <script nomodule src="dist/dm.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -52,7 +57,7 @@
           <a id="back-link" href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <img src="/icons/logo.svg?v=67" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <div class="ml-1">
             <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
             <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>

--- a/elonmusksimulator-main/index.html
+++ b/elonmusksimulator-main/index.html
@@ -8,13 +8,13 @@
     <title>Elon Musk Simulator</title>
     <meta property="og:title" content="Elon Musk Simulator">
     <meta property="og:description" content="Elon Musk Simulator is a parody browser game where your decisions keep his ventures afloat.">
-    <meta property="og:image" content="elon_musk_cartoon.png?v=67">
+    <meta property="og:image" content="elon_musk_cartoon.png?v=69">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Elon Musk Simulator">
     <meta name="twitter:description" content="Elon Musk Simulator is a parody browser game where your decisions keep his ventures afloat.">
-    <meta name="twitter:image" content="elon_musk_cartoon.png?v=67">
-    <link rel="stylesheet" href="style.css?v=67">
-    <link rel="manifest" href="manifest.json?v=67">
+    <meta name="twitter:image" content="elon_musk_cartoon.png?v=69">
+    <link rel="stylesheet" href="style.css?v=69">
+    <link rel="manifest" href="manifest.json?v=69">
     <link rel="alternate" href="https://prompterai.space/elonmusksimulator-main/index.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/elonmusksimulator-main/index.html" hreflang="en" />
 </head>
@@ -58,7 +58,7 @@
         </div>
     </div>
     <!-- Question data will be loaded lazily from JSON files -->
-    <script type="module" src="translations.js?v=67"></script>
-    <script type="module" src="main.js?v=67"></script>
+    <script type="module" src="translations.js?v=69"></script>
+    <script type="module" src="main.js?v=69"></script>
 </body>
 </html>

--- a/es/404.html
+++ b/es/404.html
@@ -12,8 +12,8 @@
     </script>
     -->
     <title>404 - Page Not Found</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -23,13 +23,13 @@
     <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page Not Found" />
     <meta property="og:description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="404 - Page Not Found" />
     <meta name="twitter:description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/404.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/404.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/404.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/404.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -61,7 +61,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body
     class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"

--- a/es/blog.html
+++ b/es/blog.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Space - Prompter" />
     <meta property="og:description" content="Artículos y novedades sobre Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Space - Prompter" />
     <meta name="twitter:description" content="Artículos y novedades sobre Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/blog.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -36,12 +36,12 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/es/blog.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/es/blog.html" />
 <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="en" />
@@ -63,7 +63,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -90,7 +90,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/es/dm.html
+++ b/es/dm.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Direct Messages - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
+    <meta name="keywords" content="prompts de IA, generador de prompts, prompts creativos, prompter de IA, creador de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Direct Messages - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Direct Messages - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/es/dm.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/es/dm.html" />
+    <link rel="canonical" href="https://prompterai.space/es/dm.html" />
+<link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/dm.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/dm.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/dm.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/dm.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/dm.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/dm.js?v=69"></script>
+    <script nomodule src="dist/dm.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="w-full">
+      <header class="flex items-center justify-between w-full mt-4 mb-6">
+        <div class="flex items-center gap-2">
+          <a id="back-link" href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+            <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+          </a>
+          <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <div class="ml-1">
+            <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
+            <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>
+          </div>
+        </div>
+      </header>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <button id="create-conv" class="mb-2 bg-white/20 hover:bg-white/30 p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-full">New Conversation</button>
+          <ul id="conv-list" class="space-y-2"></ul>
+        </div>
+        <div class="flex-1">
+          <div id="messages" class="space-y-2 mb-2 h-80 overflow-y-auto border border-white/20 p-2 rounded-md bg-white/10"></div>
+          <form id="message-form" class="flex gap-2" data-conv-id="">
+            <input id="message-input" type="text" class="flex-1 p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50" placeholder="Type a message" />
+            <button type="submit" class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/es/index.html
+++ b/es/index.html
@@ -29,8 +29,8 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -51,7 +51,7 @@
     <meta
       property="og:description" content="Generador de prompts creativos para IA que requiere conexión a Internet."
     />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Logo de Prompter" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -59,7 +59,7 @@
     <meta
       name="twitter:description" content="Generador de prompts creativos para IA que requiere conexión a Internet."
     />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -108,10 +108,10 @@
       }
     </script>
     <script>localStorage.setItem('language', 'es');</script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -123,7 +123,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -359,7 +359,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="/icons/logo.svg?v=67"
+          src="/icons/logo.svg?v=69"
           alt="Logo de Prompter"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -542,17 +542,17 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=67"
+            src="icons/whatsapp.svg?v=69"
             class="w-6 h-6"
             alt="Logo de WhatsApp"
           />
         </a>
       </div>
     </div>
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/main.js?v=67"></script>
-    <script nomodule src="/dist/main.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/main.js?v=69"></script>
+    <script nomodule src="/dist/main.js?v=69"></script>
     <script type="module">
       import { app, firebaseReady } from '/src/firebase.js';
       import { onAuth } from '/src/auth.js';
@@ -574,7 +574,8 @@
         });
       };
 
-      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init); else init();
+      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+      else init();
     </script>
   </body>
 </html>

--- a/es/intro.html
+++ b/es/intro.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Introduction - Prompter" />
     <meta property="og:description" content="Introducción a cómo usar Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Introduction - Prompter" />
     <meta name="twitter:description" content="Introducción a cómo usar Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/intro.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/es/intro.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/es/intro.html" />
 <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/intro.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/intro.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/intro.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>

--- a/es/login.html
+++ b/es/login.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -36,13 +36,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Login" />
     <meta property="og:description" content="Inicie sesión en Prompter para guardar sus indicaciones favoritas." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Login" />
     <meta name="twitter:description" content="Inicie sesión en Prompter para guardar sus indicaciones favoritas." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/login.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -61,12 +61,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/login.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/login.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/login.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -78,8 +78,8 @@
         }
       })();
     </script>
-    <script type="module" src="/src/auth.js?v=67"></script>
-    <script nomodule src="dist/auth.js?v=67"></script>
+    <script type="module" src="/src/auth.js?v=69"></script>
+    <script nomodule src="dist/auth.js?v=69"></script>
     <script type="module">
       import { login, register, onAuth } from '/src/auth.js';
       import { setUserProfile, getUserByName } from '/src/user.js';
@@ -177,7 +177,7 @@
         else init();
       });
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-md mx-auto relative mt-16">

--- a/es/privacy.html
+++ b/es/privacy.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Legal - Prompter" />
     <meta property="og:description" content="Información y política de privacidad de Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Legal - Prompter" />
     <meta name="twitter:description" content="Información y política de privacidad de Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -40,9 +40,9 @@
       }
     </script>
     -->
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/es/privacy.html" />
 <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="en" />
@@ -61,7 +61,7 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/es/privacy.html" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Legal</h1>

--- a/es/pro.html
+++ b/es/pro.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Prompter Pro</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
+    <meta name="keywords" content="prompts de IA, generador de prompts, prompts creativos, prompter de IA, creador de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Pro" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Pro" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/es/pro.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/es/pro.html" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/es/pro.html" />
+<link rel="alternate" href="https://prompterai.space/pro.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/pro.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/pro.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/pro.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/pro.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/pro.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/pro.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-md mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+
+    <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
+      <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
+      <p class="mb-2 text-center">
+        Tüm özelliklerin kilidini yalnızca <strong>79 TL / 1.99 USD</strong>
+        karşılığında açın.
+      </p>
+      <ul class="list-disc list-inside space-y-1 mb-4">
+        <li>Yeni özelliklere erken erişim</li>
+        <li>Gelişmiş modeller ile prompt üretimi</li>
+        <li>Sınırsız prompt üretimi, kaydetme ve paylaşma</li>
+        <li>Premium promptlara erişim</li>
+        <li>Prompter WhatsApp kanalına üyelik</li>
+        <li>Günlük yapay zeka bülteni</li>
+        <li>Prompter’ın geleceği hakkında oy kullanma</li>
+        <li>Prompter fikri ve gelişimine destek</li>
+        <li>Prompter ekosistemine sınırsız erişim (şimdiki+gelecek eklentiler dahil)</li>
+      </ul>
+        <div class="flex gap-2 mb-4">
+          <input
+            type="text"
+            placeholder="İndirim kodu"
+            class="flex-grow p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          />
+          <button
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+          >
+            Uygula
+          </button>
+        </div>
+      <div class="flex gap-2 justify-center">
+        <button
+          id="payment-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          abone ol
+        </button>
+        <button
+          id="support-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          destek ol
+        </button>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          geri
+        </a>
+      </div>
+      </div>
+
+      <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg max-w-md mx-auto mt-4">
+        <h2 class="text-lg font-semibold mb-2 text-center">IBAN ile ödeme</h2>
+        <ul class="space-y-2 text-sm break-all">
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">IBAN:</span>
+            <span id="iban-text" class="ml-1">TR060082900009491666598560</span>
+            <button
+              id="iban-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="IBAN kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Alıcı adı:</span>
+            <span id="recipient-text" class="ml-1">Muratcan Gençtürk</span>
+            <button
+              id="recipient-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="Alıcı adı kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Açıklama:</span>
+            <span class="ml-1">Bu bölüme sadece Prompter'a kayıtlı e-mail adresinizi yazınız.</span>
+          </li>
+        </ul>
+      </div>
+
+        <script>
+        document.getElementById('payment-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompter', '_blank');
+        });
+        document.getElementById('support-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompterai', '_blank');
+        });
+        document.getElementById('iban-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('TR060082900009491666598560');
+        });
+        document.getElementById('recipient-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('Muratcan Gençtürk');
+        });
+      </script>
+  </div>
+  </body>
+</html>

--- a/es/profile.html
+++ b/es/profile.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Profil - Prompter" />
     <meta property="og:description" content="Administre los detalles de su cuenta y las indicaciones guardadas" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Profil - Prompter" />
     <meta name="twitter:description" content="Administre los detalles de su cuenta y las indicaciones guardadas" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/profile.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -36,10 +36,10 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/es/profile.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/es/profile.html" />
 <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="en" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/profile.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/profile.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/profile.html" hreflang="zh" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -70,9 +70,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/profile.js?v=67"></script>
-    <script nomodule src="dist/profile.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/profile.js?v=69"></script>
+    <script nomodule src="dist/profile.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -96,7 +96,7 @@
           </a>
           <img
             id="app-logo"
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/es/social.html
+++ b/es/social.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Social" />
     <meta property="og:description" content="Enlaces para conectar con otros usuarios de Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Social" />
     <meta name="twitter:description" content="Enlaces para conectar con otros usuarios de Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/social.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -36,11 +36,11 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/es/social.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -48,7 +48,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/es/social.html" />
 <link rel="alternate" href="https://prompterai.space/social.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/social.html" hreflang="en" />
@@ -70,7 +70,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -93,7 +93,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -136,7 +136,7 @@
       import { linkify } from '/src/linkify.js';
       import { sanitizeHTML, setSanitizedHTML } from '/src/sanitize.js';
       import { timeAgo } from '/src/timeago.js';
-      import { categories } from '/src/prompts.js?v=67';
+      import { categories } from '/src/prompts.js?v=69';
       import { BASE_URL } from '/src/config.js';
       import {
         getUserProfile,

--- a/es/terms.html
+++ b/es/terms.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Terms - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Terms - Prompter" />
     <meta property="og:description" content="Términos de uso de Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terms - Prompter" />
     <meta name="twitter:description" content="Términos de uso de Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/terms.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/es/terms.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/es/terms.html" />
 <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/terms.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/terms.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/terms.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>

--- a/es/top-collectors.html
+++ b/es/top-collectors.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Collectors - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
+    <meta name="keywords" content="prompts de IA, generador de prompts, prompts creativos, prompter de IA, creador de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Collectors - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Collectors - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/es/top-collectors.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/es/top-collectors.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script nomodule src="dist/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/es/top-collectors.html" />
+<link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-collectors.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-collectors.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-collectors.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-collectors.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-collectors.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompt Collectors</h1>
+      <div id="collector-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/es/top-creators.html
+++ b/es/top-creators.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Creators - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
+    <meta name="keywords" content="prompts de IA, generador de prompts, prompts creativos, prompter de IA, creador de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Creators - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Creators - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/es/top-creators.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/es/top-creators.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script nomodule src="dist/top-creators.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/es/top-creators.html" />
+<link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-creators.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-creators.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-creators.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-creators.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-creators.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Creators</h1>
+      <div id="creator-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/es/top-prompts.html
+++ b/es/top-prompts.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Prompts - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
+    <meta name="keywords" content="prompts de IA, generador de prompts, prompts creativos, prompter de IA, creador de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Prompts - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Prompts - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/es/top-prompts.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/es/top-prompts.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script nomodule src="dist/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/es/top-prompts.html" />
+<link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-prompts.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-prompts.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-prompts.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-prompts.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-prompts.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompts</h1>
+      <div id="prompt-list" class="space-y-4"></div>
+    </div>
+  </body>
+</html>

--- a/es/top.html
+++ b/es/top.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Lists - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Generador de prompts creativos para IA que requiere conexión a Internet." />
+    <meta name="keywords" content="prompts de IA, generador de prompts, prompts creativos, prompter de IA, creador de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Lists - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Lists - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/es/top.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="es" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/es/top.html" />
+    <link rel="canonical" href="https://prompterai.space/es/top.html" />
+<link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${
+            version ? `?${version}` : ''
+          }`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-4xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span
+            class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+            aria-hidden="true"
+            >&larr;</span
+          >
+        </a>
+      </div>
+      <div
+        class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg"
+      >
+        <h1 class="text-2xl font-bold mb-4 text-center">Top Rankings</h1>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Creators</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by total likes, saves and shares on their prompts.
+            </p>
+            <div id="creator-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">
+              Top Collectors
+            </h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by how many prompts they've liked, saved and shared.
+            </p>
+            <div id="collector-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Prompts</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by likes, saves and shares each prompt receives.
+            </p>
+            <div id="prompt-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Supporters</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Ranked by total donations.</p>
+            <div id="supporter-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Longest Pro Members</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Earliest subscribers still active.</p>
+            <div id="pro-list" class="space-y-2"></div>
+          </div>
+        </div>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          Back
+        </a>
+      </div>
+    </div>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/top-supporters.js?v=69"></script>
+    <script type="module" src="/src/top-pro.js?v=69"></script>
+  </body>
+</html>

--- a/es/user.html
+++ b/es/user.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="User - Prompter" />
     <meta property="og:description" content="Ver los prompts y el perfil compartidos de un usuario." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="User - Prompter" />
     <meta name="twitter:description" content="Ver los prompts y el perfil compartidos de un usuario." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/es/user.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="es" />
@@ -41,12 +41,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/user.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/user.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/user.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -58,9 +58,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/user-page.js?v=67"></script>
-    <script nomodule src="dist/user-page.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/user-page.js?v=69"></script>
+    <script nomodule src="dist/user-page.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -75,7 +75,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="/icons/logo.svg?v=67" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>

--- a/fr/404.html
+++ b/fr/404.html
@@ -12,8 +12,8 @@
     </script>
     -->
     <title>404 - Page Not Found</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -23,13 +23,13 @@
     <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page Not Found" />
     <meta property="og:description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="404 - Page Not Found" />
     <meta name="twitter:description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/404.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/404.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/404.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/404.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -61,7 +61,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body
     class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"

--- a/fr/blog.html
+++ b/fr/blog.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Space - Prompter" />
     <meta property="og:description" content="Articles et actualités sur Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Space - Prompter" />
     <meta name="twitter:description" content="Articles et actualités sur Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/blog.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -36,12 +36,12 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/fr/blog.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/fr/blog.html" />
 <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="en" />
@@ -63,7 +63,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -90,7 +90,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/fr/dm.html
+++ b/fr/dm.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Direct Messages - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
+    <meta name="keywords" content="prompts IA, générateur de prompts, prompts créatifs, prompteur IA, créateur de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Direct Messages - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Direct Messages - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/fr/dm.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/fr/dm.html" />
+    <link rel="canonical" href="https://prompterai.space/fr/dm.html" />
+<link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/dm.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/dm.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/dm.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/dm.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/dm.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/dm.js?v=69"></script>
+    <script nomodule src="dist/dm.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="w-full">
+      <header class="flex items-center justify-between w-full mt-4 mb-6">
+        <div class="flex items-center gap-2">
+          <a id="back-link" href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+            <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+          </a>
+          <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <div class="ml-1">
+            <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
+            <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>
+          </div>
+        </div>
+      </header>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <button id="create-conv" class="mb-2 bg-white/20 hover:bg-white/30 p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-full">New Conversation</button>
+          <ul id="conv-list" class="space-y-2"></ul>
+        </div>
+        <div class="flex-1">
+          <div id="messages" class="space-y-2 mb-2 h-80 overflow-y-auto border border-white/20 p-2 rounded-md bg-white/10"></div>
+          <form id="message-form" class="flex gap-2" data-conv-id="">
+            <input id="message-input" type="text" class="flex-1 p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50" placeholder="Type a message" />
+            <button type="submit" class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -29,8 +29,8 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -51,7 +51,7 @@
     <meta
       property="og:description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet."
     />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Logo de Prompter" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -59,7 +59,7 @@
     <meta
       name="twitter:description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet."
     />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -108,10 +108,10 @@
       }
     </script>
     <script>localStorage.setItem('language', 'fr');</script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -123,7 +123,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -359,7 +359,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="/icons/logo.svg?v=67"
+          src="/icons/logo.svg?v=69"
           alt="Logo de Prompter"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -542,17 +542,17 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=67"
+            src="icons/whatsapp.svg?v=69"
             class="w-6 h-6"
             alt="Logo WhatsApp"
           />
         </a>
       </div>
     </div>
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/main.js?v=67"></script>
-    <script nomodule src="/dist/main.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/main.js?v=69"></script>
+    <script nomodule src="/dist/main.js?v=69"></script>
     <script type="module">
       import { app, firebaseReady } from '/src/firebase.js';
       import { onAuth } from '/src/auth.js';
@@ -574,7 +574,8 @@
         });
       };
 
-      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init); else init();
+      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+      else init();
     </script>
   </body>
 </html>

--- a/fr/intro.html
+++ b/fr/intro.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Introduction - Prompter" />
     <meta property="og:description" content="Introduction à l'utilisation de Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Introduction - Prompter" />
     <meta name="twitter:description" content="Introduction à l'utilisation de Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/intro.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/fr/intro.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/fr/intro.html" />
 <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/intro.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/intro.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/intro.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>

--- a/fr/login.html
+++ b/fr/login.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -36,13 +36,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Login" />
     <meta property="og:description" content="Connectez-vous à Prompter pour enregistrer vos invites préférées." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Login" />
     <meta name="twitter:description" content="Connectez-vous à Prompter pour enregistrer vos invites préférées." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/login.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -61,12 +61,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/login.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/login.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/login.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -78,8 +78,8 @@
         }
       })();
     </script>
-    <script type="module" src="/src/auth.js?v=67"></script>
-    <script nomodule src="dist/auth.js?v=67"></script>
+    <script type="module" src="/src/auth.js?v=69"></script>
+    <script nomodule src="dist/auth.js?v=69"></script>
     <script type="module">
       import { login, register, onAuth } from '/src/auth.js';
       import { setUserProfile, getUserByName } from '/src/user.js';
@@ -177,7 +177,7 @@
         else init();
       });
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-md mx-auto relative mt-16">

--- a/fr/privacy.html
+++ b/fr/privacy.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Legal - Prompter" />
     <meta property="og:description" content="Informations sur la confidentialité de Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Legal - Prompter" />
     <meta name="twitter:description" content="Informations sur la confidentialité de Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -40,9 +40,9 @@
       }
     </script>
     -->
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/fr/privacy.html" />
 <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="en" />
@@ -61,7 +61,7 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/fr/privacy.html" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Legal</h1>

--- a/fr/pro.html
+++ b/fr/pro.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Prompter Pro</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
+    <meta name="keywords" content="prompts IA, générateur de prompts, prompts créatifs, prompteur IA, créateur de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Pro" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Pro" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/fr/pro.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/fr/pro.html" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/fr/pro.html" />
+<link rel="alternate" href="https://prompterai.space/pro.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/pro.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/pro.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/pro.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/pro.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/pro.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/pro.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-md mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+
+    <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
+      <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
+      <p class="mb-2 text-center">
+        Tüm özelliklerin kilidini yalnızca <strong>79 TL / 1.99 USD</strong>
+        karşılığında açın.
+      </p>
+      <ul class="list-disc list-inside space-y-1 mb-4">
+        <li>Yeni özelliklere erken erişim</li>
+        <li>Gelişmiş modeller ile prompt üretimi</li>
+        <li>Sınırsız prompt üretimi, kaydetme ve paylaşma</li>
+        <li>Premium promptlara erişim</li>
+        <li>Prompter WhatsApp kanalına üyelik</li>
+        <li>Günlük yapay zeka bülteni</li>
+        <li>Prompter’ın geleceği hakkında oy kullanma</li>
+        <li>Prompter fikri ve gelişimine destek</li>
+        <li>Prompter ekosistemine sınırsız erişim (şimdiki+gelecek eklentiler dahil)</li>
+      </ul>
+        <div class="flex gap-2 mb-4">
+          <input
+            type="text"
+            placeholder="İndirim kodu"
+            class="flex-grow p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          />
+          <button
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+          >
+            Uygula
+          </button>
+        </div>
+      <div class="flex gap-2 justify-center">
+        <button
+          id="payment-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          abone ol
+        </button>
+        <button
+          id="support-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          destek ol
+        </button>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          geri
+        </a>
+      </div>
+      </div>
+
+      <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg max-w-md mx-auto mt-4">
+        <h2 class="text-lg font-semibold mb-2 text-center">IBAN ile ödeme</h2>
+        <ul class="space-y-2 text-sm break-all">
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">IBAN:</span>
+            <span id="iban-text" class="ml-1">TR060082900009491666598560</span>
+            <button
+              id="iban-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="IBAN kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Alıcı adı:</span>
+            <span id="recipient-text" class="ml-1">Muratcan Gençtürk</span>
+            <button
+              id="recipient-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="Alıcı adı kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Açıklama:</span>
+            <span class="ml-1">Bu bölüme sadece Prompter'a kayıtlı e-mail adresinizi yazınız.</span>
+          </li>
+        </ul>
+      </div>
+
+        <script>
+        document.getElementById('payment-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompter', '_blank');
+        });
+        document.getElementById('support-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompterai', '_blank');
+        });
+        document.getElementById('iban-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('TR060082900009491666598560');
+        });
+        document.getElementById('recipient-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('Muratcan Gençtürk');
+        });
+      </script>
+  </div>
+  </body>
+</html>

--- a/fr/profile.html
+++ b/fr/profile.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Profil - Prompter" />
     <meta property="og:description" content="Gérez les détails de votre compte et les invites enregistrées" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Profil - Prompter" />
     <meta name="twitter:description" content="Gérez les détails de votre compte et les invites enregistrées" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/profile.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -36,10 +36,10 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/fr/profile.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/fr/profile.html" />
 <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="en" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/profile.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/profile.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/profile.html" hreflang="zh" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -70,9 +70,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/profile.js?v=67"></script>
-    <script nomodule src="dist/profile.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/profile.js?v=69"></script>
+    <script nomodule src="dist/profile.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -96,7 +96,7 @@
           </a>
           <img
             id="app-logo"
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/fr/social.html
+++ b/fr/social.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Social" />
     <meta property="og:description" content="Liens pour se connecter avec d'autres utilisateurs de Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Social" />
     <meta name="twitter:description" content="Liens pour se connecter avec d'autres utilisateurs de Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/social.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -36,11 +36,11 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/fr/social.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -48,7 +48,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/fr/social.html" />
 <link rel="alternate" href="https://prompterai.space/social.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/social.html" hreflang="en" />
@@ -70,7 +70,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -93,7 +93,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -136,7 +136,7 @@
       import { linkify } from '/src/linkify.js';
       import { sanitizeHTML, setSanitizedHTML } from '/src/sanitize.js';
       import { timeAgo } from '/src/timeago.js';
-      import { categories } from '/src/prompts.js?v=67';
+      import { categories } from '/src/prompts.js?v=69';
       import { BASE_URL } from '/src/config.js';
       import {
         getUserProfile,

--- a/fr/terms.html
+++ b/fr/terms.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Terms - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Terms - Prompter" />
     <meta property="og:description" content="Conditions d'utilisation de Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terms - Prompter" />
     <meta name="twitter:description" content="Conditions d'utilisation de Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/terms.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/fr/terms.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/fr/terms.html" />
 <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/terms.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/terms.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/terms.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>

--- a/fr/top-collectors.html
+++ b/fr/top-collectors.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Collectors - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
+    <meta name="keywords" content="prompts IA, générateur de prompts, prompts créatifs, prompteur IA, créateur de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Collectors - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Collectors - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/fr/top-collectors.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/fr/top-collectors.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script nomodule src="dist/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/fr/top-collectors.html" />
+<link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-collectors.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-collectors.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-collectors.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-collectors.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-collectors.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompt Collectors</h1>
+      <div id="collector-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/fr/top-creators.html
+++ b/fr/top-creators.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Creators - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
+    <meta name="keywords" content="prompts IA, générateur de prompts, prompts créatifs, prompteur IA, créateur de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Creators - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Creators - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/fr/top-creators.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/fr/top-creators.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script nomodule src="dist/top-creators.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/fr/top-creators.html" />
+<link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-creators.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-creators.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-creators.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-creators.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-creators.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Creators</h1>
+      <div id="creator-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/fr/top-prompts.html
+++ b/fr/top-prompts.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Prompts - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
+    <meta name="keywords" content="prompts IA, générateur de prompts, prompts créatifs, prompteur IA, créateur de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Prompts - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Prompts - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/fr/top-prompts.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/fr/top-prompts.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script nomodule src="dist/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/fr/top-prompts.html" />
+<link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-prompts.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-prompts.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-prompts.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-prompts.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-prompts.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompts</h1>
+      <div id="prompt-list" class="space-y-4"></div>
+    </div>
+  </body>
+</html>

--- a/fr/top.html
+++ b/fr/top.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Lists - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="Générateur de prompts créatifs pour l'IA nécessitant une connexion Internet." />
+    <meta name="keywords" content="prompts IA, générateur de prompts, prompts créatifs, prompteur IA, créateur de prompts" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Lists - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Lists - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/fr/top.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="fr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/fr/top.html" />
+    <link rel="canonical" href="https://prompterai.space/fr/top.html" />
+<link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${
+            version ? `?${version}` : ''
+          }`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-4xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span
+            class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+            aria-hidden="true"
+            >&larr;</span
+          >
+        </a>
+      </div>
+      <div
+        class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg"
+      >
+        <h1 class="text-2xl font-bold mb-4 text-center">Top Rankings</h1>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Creators</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by total likes, saves and shares on their prompts.
+            </p>
+            <div id="creator-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">
+              Top Collectors
+            </h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by how many prompts they've liked, saved and shared.
+            </p>
+            <div id="collector-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Prompts</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by likes, saves and shares each prompt receives.
+            </p>
+            <div id="prompt-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Supporters</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Ranked by total donations.</p>
+            <div id="supporter-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Longest Pro Members</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Earliest subscribers still active.</p>
+            <div id="pro-list" class="space-y-2"></div>
+          </div>
+        </div>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          Back
+        </a>
+      </div>
+    </div>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/top-supporters.js?v=69"></script>
+    <script type="module" src="/src/top-pro.js?v=69"></script>
+  </body>
+</html>

--- a/fr/user.html
+++ b/fr/user.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="User - Prompter" />
     <meta property="og:description" content="Voir les invites partagées et le profil d'un utilisateur." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="User - Prompter" />
     <meta name="twitter:description" content="Voir les invites partagées et le profil d'un utilisateur." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/fr/user.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="fr" />
@@ -41,12 +41,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/user.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/user.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/user.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -58,9 +58,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/user-page.js?v=67"></script>
-    <script nomodule src="dist/user-page.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/user-page.js?v=69"></script>
+    <script nomodule src="dist/user-page.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -75,7 +75,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="/icons/logo.svg?v=67" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>

--- a/hi/404.html
+++ b/hi/404.html
@@ -12,8 +12,8 @@
     </script>
     -->
     <title>404 - Page Not Found</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -23,13 +23,13 @@
     <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page Not Found" />
     <meta property="og:description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="404 - Page Not Found" />
     <meta name="twitter:description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/404.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/404.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/404.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/404.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -61,7 +61,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body
     class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"

--- a/hi/blog.html
+++ b/hi/blog.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Space - Prompter" />
     <meta property="og:description" content="Prompter से संबंधित लेख और अपडेट।" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Space - Prompter" />
     <meta name="twitter:description" content="Prompter से संबंधित लेख और अपडेट।" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/blog.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -36,12 +36,12 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/hi/blog.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/hi/blog.html" />
 <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="en" />
@@ -63,7 +63,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -90,7 +90,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/hi/dm.html
+++ b/hi/dm.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Direct Messages - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
+    <meta name="keywords" content="एआई प्रॉम्प्ट, प्रॉम्प्ट जनरेटर, रचनात्मक प्रॉम्प्ट, एआई प्रॉम्प्टर, प्रॉम्प्ट निर्माता" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Direct Messages - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Direct Messages - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/hi/dm.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/hi/dm.html" />
+    <link rel="canonical" href="https://prompterai.space/hi/dm.html" />
+<link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/dm.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/dm.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/dm.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/dm.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/dm.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/dm.js?v=69"></script>
+    <script nomodule src="dist/dm.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="w-full">
+      <header class="flex items-center justify-between w-full mt-4 mb-6">
+        <div class="flex items-center gap-2">
+          <a id="back-link" href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+            <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+          </a>
+          <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <div class="ml-1">
+            <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
+            <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>
+          </div>
+        </div>
+      </header>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <button id="create-conv" class="mb-2 bg-white/20 hover:bg-white/30 p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-full">New Conversation</button>
+          <ul id="conv-list" class="space-y-2"></ul>
+        </div>
+        <div class="flex-1">
+          <div id="messages" class="space-y-2 mb-2 h-80 overflow-y-auto border border-white/20 p-2 rounded-md bg-white/10"></div>
+          <form id="message-form" class="flex gap-2" data-conv-id="">
+            <input id="message-input" type="text" class="flex-1 p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50" placeholder="Type a message" />
+            <button type="submit" class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/hi/index.html
+++ b/hi/index.html
@@ -29,8 +29,8 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -51,7 +51,7 @@
     <meta
       property="og:description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर."
     />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter लोगो" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -59,7 +59,7 @@
     <meta
       name="twitter:description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर."
     />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -108,10 +108,10 @@
       }
     </script>
     <script>localStorage.setItem('language', 'hi');</script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -123,7 +123,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -359,7 +359,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="/icons/logo.svg?v=67"
+          src="/icons/logo.svg?v=69"
           alt="Prompter लोगो"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -542,17 +542,17 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=67"
+            src="icons/whatsapp.svg?v=69"
             class="w-6 h-6"
             alt="WhatsApp लोगो"
           />
         </a>
       </div>
     </div>
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/main.js?v=67"></script>
-    <script nomodule src="/dist/main.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/main.js?v=69"></script>
+    <script nomodule src="/dist/main.js?v=69"></script>
     <script type="module">
       import { app, firebaseReady } from '/src/firebase.js';
       import { onAuth } from '/src/auth.js';
@@ -574,7 +574,8 @@
         });
       };
 
-      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init); else init();
+      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+      else init();
     </script>
   </body>
 </html>

--- a/hi/intro.html
+++ b/hi/intro.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Introduction - Prompter" />
     <meta property="og:description" content="Prompter का उपयोग कैसे करें इसका परिचय।" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Introduction - Prompter" />
     <meta name="twitter:description" content="Prompter का उपयोग कैसे करें इसका परिचय।" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/intro.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/hi/intro.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/hi/intro.html" />
 <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/intro.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/intro.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/intro.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>

--- a/hi/login.html
+++ b/hi/login.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -36,13 +36,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Login" />
     <meta property="og:description" content="अपने पसंदीदा संकेतों को बचाने के लिए प्रॉम्प्टर में लॉग इन करें." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Login" />
     <meta name="twitter:description" content="अपने पसंदीदा संकेतों को बचाने के लिए प्रॉम्प्टर में लॉग इन करें." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/login.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -61,12 +61,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/login.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/login.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/login.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -78,8 +78,8 @@
         }
       })();
     </script>
-    <script type="module" src="/src/auth.js?v=67"></script>
-    <script nomodule src="dist/auth.js?v=67"></script>
+    <script type="module" src="/src/auth.js?v=69"></script>
+    <script nomodule src="dist/auth.js?v=69"></script>
     <script type="module">
       import { login, register, onAuth } from '/src/auth.js';
       import { setUserProfile, getUserByName } from '/src/user.js';
@@ -177,7 +177,7 @@
         else init();
       });
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-md mx-auto relative mt-16">

--- a/hi/privacy.html
+++ b/hi/privacy.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Legal - Prompter" />
     <meta property="og:description" content="Prompter की गोपनीयता जानकारी और नीति।" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Legal - Prompter" />
     <meta name="twitter:description" content="Prompter की गोपनीयता जानकारी और नीति।" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -40,9 +40,9 @@
       }
     </script>
     -->
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/hi/privacy.html" />
 <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="en" />
@@ -61,7 +61,7 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/hi/privacy.html" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Legal</h1>

--- a/hi/pro.html
+++ b/hi/pro.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Prompter Pro</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
+    <meta name="keywords" content="एआई प्रॉम्प्ट, प्रॉम्प्ट जनरेटर, रचनात्मक प्रॉम्प्ट, एआई प्रॉम्प्टर, प्रॉम्प्ट निर्माता" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Pro" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Pro" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/hi/pro.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/hi/pro.html" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/hi/pro.html" />
+<link rel="alternate" href="https://prompterai.space/pro.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/pro.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/pro.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/pro.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/pro.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/pro.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/pro.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-md mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+
+    <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
+      <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
+      <p class="mb-2 text-center">
+        Tüm özelliklerin kilidini yalnızca <strong>79 TL / 1.99 USD</strong>
+        karşılığında açın.
+      </p>
+      <ul class="list-disc list-inside space-y-1 mb-4">
+        <li>Yeni özelliklere erken erişim</li>
+        <li>Gelişmiş modeller ile prompt üretimi</li>
+        <li>Sınırsız prompt üretimi, kaydetme ve paylaşma</li>
+        <li>Premium promptlara erişim</li>
+        <li>Prompter WhatsApp kanalına üyelik</li>
+        <li>Günlük yapay zeka bülteni</li>
+        <li>Prompter’ın geleceği hakkında oy kullanma</li>
+        <li>Prompter fikri ve gelişimine destek</li>
+        <li>Prompter ekosistemine sınırsız erişim (şimdiki+gelecek eklentiler dahil)</li>
+      </ul>
+        <div class="flex gap-2 mb-4">
+          <input
+            type="text"
+            placeholder="İndirim kodu"
+            class="flex-grow p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          />
+          <button
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+          >
+            Uygula
+          </button>
+        </div>
+      <div class="flex gap-2 justify-center">
+        <button
+          id="payment-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          abone ol
+        </button>
+        <button
+          id="support-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          destek ol
+        </button>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          geri
+        </a>
+      </div>
+      </div>
+
+      <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg max-w-md mx-auto mt-4">
+        <h2 class="text-lg font-semibold mb-2 text-center">IBAN ile ödeme</h2>
+        <ul class="space-y-2 text-sm break-all">
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">IBAN:</span>
+            <span id="iban-text" class="ml-1">TR060082900009491666598560</span>
+            <button
+              id="iban-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="IBAN kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Alıcı adı:</span>
+            <span id="recipient-text" class="ml-1">Muratcan Gençtürk</span>
+            <button
+              id="recipient-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="Alıcı adı kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Açıklama:</span>
+            <span class="ml-1">Bu bölüme sadece Prompter'a kayıtlı e-mail adresinizi yazınız.</span>
+          </li>
+        </ul>
+      </div>
+
+        <script>
+        document.getElementById('payment-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompter', '_blank');
+        });
+        document.getElementById('support-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompterai', '_blank');
+        });
+        document.getElementById('iban-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('TR060082900009491666598560');
+        });
+        document.getElementById('recipient-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('Muratcan Gençtürk');
+        });
+      </script>
+  </div>
+  </body>
+</html>

--- a/hi/profile.html
+++ b/hi/profile.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Profil - Prompter" />
     <meta property="og:description" content="अपने खाते के विवरण का प्रबंधन करें और संकेतों को सहेजें" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Profil - Prompter" />
     <meta name="twitter:description" content="अपने खाते के विवरण का प्रबंधन करें और संकेतों को सहेजें" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/profile.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -36,10 +36,10 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/hi/profile.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/hi/profile.html" />
 <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="en" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/profile.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/profile.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/profile.html" hreflang="zh" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -70,9 +70,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/profile.js?v=67"></script>
-    <script nomodule src="dist/profile.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/profile.js?v=69"></script>
+    <script nomodule src="dist/profile.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -96,7 +96,7 @@
           </a>
           <img
             id="app-logo"
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/hi/social.html
+++ b/hi/social.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Social" />
     <meta property="og:description" content="अन्य Prompter उपयोगकर्ताओं से जुड़ने के लिए लिंक।" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Social" />
     <meta name="twitter:description" content="अन्य Prompter उपयोगकर्ताओं से जुड़ने के लिए लिंक।" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/social.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -36,11 +36,11 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/hi/social.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -48,7 +48,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/hi/social.html" />
 <link rel="alternate" href="https://prompterai.space/social.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/social.html" hreflang="en" />
@@ -70,7 +70,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -93,7 +93,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -136,7 +136,7 @@
       import { linkify } from '/src/linkify.js';
       import { sanitizeHTML, setSanitizedHTML } from '/src/sanitize.js';
       import { timeAgo } from '/src/timeago.js';
-      import { categories } from '/src/prompts.js?v=67';
+      import { categories } from '/src/prompts.js?v=69';
       import { BASE_URL } from '/src/config.js';
       import {
         getUserProfile,

--- a/hi/terms.html
+++ b/hi/terms.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Terms - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Terms - Prompter" />
     <meta property="og:description" content="Prompter के उपयोग की शर्तें।" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terms - Prompter" />
     <meta name="twitter:description" content="Prompter के उपयोग की शर्तें।" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/terms.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/hi/terms.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/hi/terms.html" />
 <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/terms.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/terms.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/terms.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>

--- a/hi/top-collectors.html
+++ b/hi/top-collectors.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Collectors - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
+    <meta name="keywords" content="एआई प्रॉम्प्ट, प्रॉम्प्ट जनरेटर, रचनात्मक प्रॉम्प्ट, एआई प्रॉम्प्टर, प्रॉम्प्ट निर्माता" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Collectors - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Collectors - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/hi/top-collectors.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/hi/top-collectors.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script nomodule src="dist/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/hi/top-collectors.html" />
+<link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-collectors.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-collectors.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-collectors.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-collectors.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-collectors.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompt Collectors</h1>
+      <div id="collector-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/hi/top-creators.html
+++ b/hi/top-creators.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Creators - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
+    <meta name="keywords" content="एआई प्रॉम्प्ट, प्रॉम्प्ट जनरेटर, रचनात्मक प्रॉम्प्ट, एआई प्रॉम्प्टर, प्रॉम्प्ट निर्माता" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Creators - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Creators - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/hi/top-creators.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/hi/top-creators.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script nomodule src="dist/top-creators.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/hi/top-creators.html" />
+<link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-creators.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-creators.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-creators.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-creators.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-creators.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Creators</h1>
+      <div id="creator-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/hi/top-prompts.html
+++ b/hi/top-prompts.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Prompts - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
+    <meta name="keywords" content="एआई प्रॉम्प्ट, प्रॉम्प्ट जनरेटर, रचनात्मक प्रॉम्प्ट, एआई प्रॉम्प्टर, प्रॉम्प्ट निर्माता" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Prompts - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Prompts - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/hi/top-prompts.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/hi/top-prompts.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script nomodule src="dist/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/hi/top-prompts.html" />
+<link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-prompts.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-prompts.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-prompts.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-prompts.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-prompts.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompts</h1>
+      <div id="prompt-list" class="space-y-4"></div>
+    </div>
+  </body>
+</html>

--- a/hi/top.html
+++ b/hi/top.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="hi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Lists - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="इंटरनेट कनेक्शन की आवश्यकता वाला रचनात्मक एआई प्रॉम्प्ट जनरेटर." />
+    <meta name="keywords" content="एआई प्रॉम्प्ट, प्रॉम्प्ट जनरेटर, रचनात्मक प्रॉम्प्ट, एआई प्रॉम्प्टर, प्रॉम्प्ट निर्माता" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Lists - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Lists - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/hi/top.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="hi" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/hi/top.html" />
+    <link rel="canonical" href="https://prompterai.space/hi/top.html" />
+<link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${
+            version ? `?${version}` : ''
+          }`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-4xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span
+            class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+            aria-hidden="true"
+            >&larr;</span
+          >
+        </a>
+      </div>
+      <div
+        class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg"
+      >
+        <h1 class="text-2xl font-bold mb-4 text-center">Top Rankings</h1>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Creators</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by total likes, saves and shares on their prompts.
+            </p>
+            <div id="creator-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">
+              Top Collectors
+            </h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by how many prompts they've liked, saved and shared.
+            </p>
+            <div id="collector-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Prompts</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by likes, saves and shares each prompt receives.
+            </p>
+            <div id="prompt-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Supporters</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Ranked by total donations.</p>
+            <div id="supporter-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Longest Pro Members</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Earliest subscribers still active.</p>
+            <div id="pro-list" class="space-y-2"></div>
+          </div>
+        </div>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          Back
+        </a>
+      </div>
+    </div>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/top-supporters.js?v=69"></script>
+    <script type="module" src="/src/top-pro.js?v=69"></script>
+  </body>
+</html>

--- a/hi/user.html
+++ b/hi/user.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="User - Prompter" />
     <meta property="og:description" content="किसी उपयोगकर्ता के साझा किए गए प्रॉम्प्ट और प्रोफ़ाइल देखें।" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="User - Prompter" />
     <meta name="twitter:description" content="किसी उपयोगकर्ता के साझा किए गए प्रॉम्प्ट और प्रोफ़ाइल देखें।" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/hi/user.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="hi" />
@@ -41,12 +41,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/user.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/user.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/user.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -58,9 +58,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/user-page.js?v=67"></script>
-    <script nomodule src="dist/user-page.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/user-page.js?v=69"></script>
+    <script nomodule src="dist/user-page.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -75,7 +75,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="/icons/logo.svg?v=67" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>

--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
     />
     <title>PROMPTER</title>
     <base href="./" />
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -51,7 +51,7 @@
     <meta
       property="og:description" content="Creative AI prompt generator that requires an internet connection."
     />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -59,7 +59,7 @@
     <meta
       name="twitter:description" content="Creative AI prompt generator that requires an internet connection."
     />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -108,10 +108,10 @@
       }
     </script>
     
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -123,7 +123,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -359,7 +359,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="/icons/logo.svg?v=67"
+          src="/icons/logo.svg?v=69"
           alt="Prompter logo"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -542,17 +542,17 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=67"
+            src="icons/whatsapp.svg?v=69"
             class="w-6 h-6"
             alt="WhatsApp logo"
           />
         </a>
       </div>
     </div>
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/main.js?v=67"></script>
-    <script nomodule src="/dist/main.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/main.js?v=69"></script>
+    <script nomodule src="/dist/main.js?v=69"></script>
     <script type="module">
       import { app, firebaseReady } from '/src/firebase.js';
       import { onAuth } from '/src/auth.js';

--- a/intro.html
+++ b/intro.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Introduction - Prompter" />
     <meta property="og:description" content="Introduction to using Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Introduction - Prompter" />
     <meta name="twitter:description" content="Introduction to using Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/intro.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/intro.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/intro.html" />
 <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/intro.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/intro.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/intro.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>

--- a/login.html
+++ b/login.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -36,13 +36,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Login" />
     <meta property="og:description" content="Log in to Prompter to save your favorite prompts." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Login" />
     <meta name="twitter:description" content="Log in to Prompter to save your favorite prompts." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/login.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -61,12 +61,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/login.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/login.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/login.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -78,8 +78,8 @@
         }
       })();
     </script>
-    <script type="module" src="/src/auth.js?v=67"></script>
-    <script nomodule src="dist/auth.js?v=67"></script>
+    <script type="module" src="/src/auth.js?v=69"></script>
+    <script nomodule src="dist/auth.js?v=69"></script>
     <script type="module">
       import { login, register, onAuth } from '/src/auth.js';
       import { setUserProfile, getUserByName } from '/src/user.js';
@@ -177,7 +177,7 @@
         else init();
       });
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-md mx-auto relative mt-16">

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "theme_color": "#000000",
   "background_color": "#000000",
   "display": "standalone",
-  "version": "67",
+  "version": "69",
   "start_url": "./",
   "icons": [
     {

--- a/privacy.html
+++ b/privacy.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Legal - Prompter" />
     <meta property="og:description" content="Prompter privacy information and policy." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Legal - Prompter" />
     <meta name="twitter:description" content="Prompter privacy information and policy." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -40,9 +40,9 @@
       }
     </script>
     -->
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/privacy.html" />
 <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="en" />
@@ -61,7 +61,7 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/privacy.html" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Legal</h1>

--- a/pro.html
+++ b/pro.html
@@ -5,8 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Pro</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <base href="./" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,25 +17,25 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Pro" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Pro" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/pro.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
-<meta property="og:locale:alternate" content="tr" />
-    <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
+<meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <meta name="twitter:url" content="https://prompterai.space/pro.html" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -53,9 +54,15 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/pro.html" hreflang="x-default" />
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/pro.html" />
+<link rel="alternate" href="https://prompterai.space/pro.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/pro.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/pro.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/pro.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/pro.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/pro.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/pro.html" hreflang="zh" />
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-md mx-auto relative mt-16">

--- a/profile.html
+++ b/profile.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Profil - Prompter" />
     <meta property="og:description" content="Manage your account details and saved prompts." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Profil - Prompter" />
     <meta name="twitter:description" content="Manage your account details and saved prompts." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/profile.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -36,10 +36,10 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/profile.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/profile.html" />
 <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="en" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/profile.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/profile.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/profile.html" hreflang="zh" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -70,9 +70,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/profile.js?v=67"></script>
-    <script nomodule src="dist/profile.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/profile.js?v=69"></script>
+    <script nomodule src="dist/profile.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -96,7 +96,7 @@
           </a>
           <img
             id="app-logo"
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/social.html
+++ b/social.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Social" />
     <meta property="og:description" content="Links to connect with other Prompter users." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Social" />
     <meta name="twitter:description" content="Links to connect with other Prompter users." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/social.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -36,11 +36,11 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/social.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -48,7 +48,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/social.html" />
 <link rel="alternate" href="https://prompterai.space/social.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/social.html" hreflang="en" />
@@ -70,7 +70,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -93,7 +93,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -136,7 +136,7 @@
       import { linkify } from '/src/linkify.js';
       import { sanitizeHTML, setSanitizedHTML } from '/src/sanitize.js';
       import { timeAgo } from '/src/timeago.js';
-      import { categories } from '/src/prompts.js?v=67';
+      import { categories } from '/src/prompts.js?v=69';
       import { BASE_URL } from '/src/config.js';
       import {
         getUserProfile,

--- a/templates/dm.template.html
+++ b/templates/dm.template.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="{{LANG}}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Direct Messages - Prompter</title>
+    <base href="{{BASE_HREF}}" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <meta name="keywords" content="{{KEYWORDS}}" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Direct Messages - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Direct Messages - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="{{CANONICAL_URL}}" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="{{LANG}}" />
+{{OG_ALTERNATES}}
+
+    <meta name="twitter:url" content="{{CANONICAL_URL}}" />
+    <link rel="canonical" href="{{CANONICAL_URL}}" />
+{{ALTERNATE_LINKS}}
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/dm.js?v=69"></script>
+    <script nomodule src="dist/dm.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="w-full">
+      <header class="flex items-center justify-between w-full mt-4 mb-6">
+        <div class="flex items-center gap-2">
+          <a id="back-link" href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+            <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+          </a>
+          <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <div class="ml-1">
+            <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
+            <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>
+          </div>
+        </div>
+      </header>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <button id="create-conv" class="mb-2 bg-white/20 hover:bg-white/30 p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-full">New Conversation</button>
+          <ul id="conv-list" class="space-y-2"></ul>
+        </div>
+        <div class="flex-1">
+          <div id="messages" class="space-y-2 mb-2 h-80 overflow-y-auto border border-white/20 p-2 rounded-md bg-white/10"></div>
+          <form id="message-form" class="flex gap-2" data-conv-id="">
+            <input id="message-input" type="text" class="flex-1 p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50" placeholder="Type a message" />
+            <button type="submit" class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/templates/pro.template.html
+++ b/templates/pro.template.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="{{LANG}}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Prompter Pro</title>
+    <base href="{{BASE_HREF}}" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <meta name="keywords" content="{{KEYWORDS}}" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Pro" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Pro" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="{{CANONICAL_URL}}" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="{{LANG}}" />
+{{OG_ALTERNATES}}
+
+    <meta name="twitter:url" content="{{CANONICAL_URL}}" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="{{CANONICAL_URL}}" />
+{{ALTERNATE_LINKS}}
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-md mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+
+    <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
+      <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
+      <p class="mb-2 text-center">
+        Tüm özelliklerin kilidini yalnızca <strong>79 TL / 1.99 USD</strong>
+        karşılığında açın.
+      </p>
+      <ul class="list-disc list-inside space-y-1 mb-4">
+        <li>Yeni özelliklere erken erişim</li>
+        <li>Gelişmiş modeller ile prompt üretimi</li>
+        <li>Sınırsız prompt üretimi, kaydetme ve paylaşma</li>
+        <li>Premium promptlara erişim</li>
+        <li>Prompter WhatsApp kanalına üyelik</li>
+        <li>Günlük yapay zeka bülteni</li>
+        <li>Prompter’ın geleceği hakkında oy kullanma</li>
+        <li>Prompter fikri ve gelişimine destek</li>
+        <li>Prompter ekosistemine sınırsız erişim (şimdiki+gelecek eklentiler dahil)</li>
+      </ul>
+        <div class="flex gap-2 mb-4">
+          <input
+            type="text"
+            placeholder="İndirim kodu"
+            class="flex-grow p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          />
+          <button
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+          >
+            Uygula
+          </button>
+        </div>
+      <div class="flex gap-2 justify-center">
+        <button
+          id="payment-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          abone ol
+        </button>
+        <button
+          id="support-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          destek ol
+        </button>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          geri
+        </a>
+      </div>
+      </div>
+
+      <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg max-w-md mx-auto mt-4">
+        <h2 class="text-lg font-semibold mb-2 text-center">IBAN ile ödeme</h2>
+        <ul class="space-y-2 text-sm break-all">
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">IBAN:</span>
+            <span id="iban-text" class="ml-1">TR060082900009491666598560</span>
+            <button
+              id="iban-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="IBAN kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Alıcı adı:</span>
+            <span id="recipient-text" class="ml-1">Muratcan Gençtürk</span>
+            <button
+              id="recipient-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="Alıcı adı kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Açıklama:</span>
+            <span class="ml-1">Bu bölüme sadece Prompter'a kayıtlı e-mail adresinizi yazınız.</span>
+          </li>
+        </ul>
+      </div>
+
+        <script>
+        document.getElementById('payment-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompter', '_blank');
+        });
+        document.getElementById('support-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompterai', '_blank');
+        });
+        document.getElementById('iban-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('TR060082900009491666598560');
+        });
+        document.getElementById('recipient-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('Muratcan Gençtürk');
+        });
+      </script>
+  </div>
+  </body>
+</html>

--- a/templates/top-collectors.template.html
+++ b/templates/top-collectors.template.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="{{LANG}}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Collectors - Prompter</title>
+    <base href="{{BASE_HREF}}" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <meta name="keywords" content="{{KEYWORDS}}" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Collectors - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Collectors - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="{{CANONICAL_URL}}" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="{{LANG}}" />
+{{OG_ALTERNATES}}
+
+    <meta name="twitter:url" content="{{CANONICAL_URL}}" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script nomodule src="dist/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="{{CANONICAL_URL}}" />
+{{ALTERNATE_LINKS}}
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompt Collectors</h1>
+      <div id="collector-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/templates/top-creators.template.html
+++ b/templates/top-creators.template.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="{{LANG}}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Creators - Prompter</title>
+    <base href="{{BASE_HREF}}" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <meta name="keywords" content="{{KEYWORDS}}" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Creators - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Creators - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="{{CANONICAL_URL}}" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="{{LANG}}" />
+{{OG_ALTERNATES}}
+
+    <meta name="twitter:url" content="{{CANONICAL_URL}}" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script nomodule src="dist/top-creators.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="{{CANONICAL_URL}}" />
+{{ALTERNATE_LINKS}}
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Creators</h1>
+      <div id="creator-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/templates/top-prompts.template.html
+++ b/templates/top-prompts.template.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="{{LANG}}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Prompts - Prompter</title>
+    <base href="{{BASE_HREF}}" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <meta name="keywords" content="{{KEYWORDS}}" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Prompts - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Prompts - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="{{CANONICAL_URL}}" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="{{LANG}}" />
+{{OG_ALTERNATES}}
+
+    <meta name="twitter:url" content="{{CANONICAL_URL}}" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script nomodule src="dist/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="{{CANONICAL_URL}}" />
+{{ALTERNATE_LINKS}}
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompts</h1>
+      <div id="prompt-list" class="space-y-4"></div>
+    </div>
+  </body>
+</html>

--- a/templates/top.template.html
+++ b/templates/top.template.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="{{LANG}}">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Lists - Prompter</title>
+    <base href="{{BASE_HREF}}" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="{{DESCRIPTION}}" />
+    <meta name="keywords" content="{{KEYWORDS}}" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Lists - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Lists - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="{{CANONICAL_URL}}" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="{{LANG}}" />
+{{OG_ALTERNATES}}
+
+    <meta name="twitter:url" content="{{CANONICAL_URL}}" />
+    <link rel="canonical" href="{{CANONICAL_URL}}" />
+{{ALTERNATE_LINKS}}
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${
+            version ? `?${version}` : ''
+          }`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-4xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span
+            class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+            aria-hidden="true"
+            >&larr;</span
+          >
+        </a>
+      </div>
+      <div
+        class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg"
+      >
+        <h1 class="text-2xl font-bold mb-4 text-center">Top Rankings</h1>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Creators</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by total likes, saves and shares on their prompts.
+            </p>
+            <div id="creator-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">
+              Top Collectors
+            </h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by how many prompts they've liked, saved and shared.
+            </p>
+            <div id="collector-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Prompts</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by likes, saves and shares each prompt receives.
+            </p>
+            <div id="prompt-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Supporters</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Ranked by total donations.</p>
+            <div id="supporter-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Longest Pro Members</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Earliest subscribers still active.</p>
+            <div id="pro-list" class="space-y-2"></div>
+          </div>
+        </div>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          Back
+        </a>
+      </div>
+    </div>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/top-supporters.js?v=69"></script>
+    <script type="module" src="/src/top-pro.js?v=69"></script>
+  </body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Terms - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Terms - Prompter" />
     <meta property="og:description" content="Terms of use for Prompter." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terms - Prompter" />
     <meta name="twitter:description" content="Terms of use for Prompter." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/terms.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/terms.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/terms.html" />
 <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/terms.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/terms.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/terms.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>

--- a/top-collectors.html
+++ b/top-collectors.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Collectors - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,29 +16,29 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Collectors - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Collectors - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/top-collectors.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
-<meta property="og:locale:alternate" content="tr" />
-    <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
+<meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <meta name="twitter:url" content="https://prompterai.space/top-collectors.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -50,12 +50,17 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-collectors.js?v=67"></script>
-    <script nomodule src="dist/top-collectors.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script nomodule src="dist/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/top-collectors.html" />
+<link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-collectors.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-collectors.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-collectors.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top-collectors.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-collectors.html" hreflang="zh" />
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/top-creators.html
+++ b/top-creators.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Creators - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,29 +16,29 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Creators - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Creators - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/top-creators.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
-<meta property="og:locale:alternate" content="tr" />
-    <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
+<meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <meta name="twitter:url" content="https://prompterai.space/top-creators.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -50,12 +50,17 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-creators.js?v=67"></script>
-    <script nomodule src="dist/top-creators.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script nomodule src="dist/top-creators.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/top-creators.html" />
+<link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-creators.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-creators.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-creators.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top-creators.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-creators.html" hreflang="zh" />
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/top-prompts.html
+++ b/top-prompts.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Prompts - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,29 +16,29 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Prompts - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Prompts - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/top-prompts.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
-<meta property="og:locale:alternate" content="tr" />
-    <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
+<meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <meta name="twitter:url" content="https://prompterai.space/top-prompts.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -50,12 +50,17 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-prompts.js?v=67"></script>
-    <script nomodule src="dist/top-prompts.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script nomodule src="dist/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/top-prompts.html" />
+<link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-prompts.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-prompts.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-prompts.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top-prompts.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-prompts.html" hreflang="zh" />
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">

--- a/top.html
+++ b/top.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Lists - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,33 +19,37 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Lists - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Lists - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/top.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
-<meta property="og:locale:alternate" content="tr" />
-    <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
+<meta property="og:locale:alternate" content="es" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
+    <meta name="twitter:url" content="https://prompterai.space/top.html" />
     <link rel="canonical" href="https://prompterai.space/top.html" />
-    <link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
+<link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top.html" hreflang="tr" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="alternate" href="https://prompterai.space/zh/top.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -59,7 +63,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-4xl mx-auto relative mt-16">
@@ -127,10 +131,10 @@
         </a>
       </div>
     </div>
-    <script type="module" src="/src/top-creators.js?v=67"></script>
-    <script type="module" src="/src/top-collectors.js?v=67"></script>
-    <script type="module" src="/src/top-prompts.js?v=67"></script>
-    <script type="module" src="/src/top-supporters.js?v=67"></script>
-    <script type="module" src="/src/top-pro.js?v=67"></script>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/top-supporters.js?v=69"></script>
+    <script type="module" src="/src/top-pro.js?v=69"></script>
   </body>
 </html>

--- a/tr/404.html
+++ b/tr/404.html
@@ -12,8 +12,8 @@
     </script>
     -->
     <title>404 - Page Not Found</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -23,13 +23,13 @@
     <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page Not Found" />
     <meta property="og:description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="404 - Page Not Found" />
     <meta name="twitter:description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/404.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/404.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/404.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/404.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -61,7 +61,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body
     class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"

--- a/tr/blog.html
+++ b/tr/blog.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Space - Prompter" />
     <meta property="og:description" content="Prompter hakkında makaleler ve güncellemeler." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Space - Prompter" />
     <meta name="twitter:description" content="Prompter hakkında makaleler ve güncellemeler." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/blog.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -36,12 +36,12 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/tr/blog.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/tr/blog.html" />
 <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="en" />
@@ -63,7 +63,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -90,7 +90,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/tr/dm.html
+++ b/tr/dm.html
@@ -4,55 +4,60 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
-    <title>Direkt Mesajlar - Prompter</title>
+    <title>Direct Messages - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
+    <meta name="keywords" content="yapay zeka komutları, komut üreticisi, yaratıcı komutlar, yapay zeka komut aracı, komut oluşturucu" />
     <meta name="robots" content="index,follow" />
-    <meta property="og:title" content="Direkt Mesajlar - Prompter" />
+    <meta property="og:title" content="Direct Messages - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:image:alt" content="Prompter logosu" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Direkt Mesajlar - Prompter" />
+    <meta name="twitter:title" content="Direct Messages - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/tr/dm.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
 <meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/dm.js?v=67"></script>
-    <script nomodule src="dist/dm.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
+    <meta name="twitter:url" content="https://prompterai.space/tr/dm.html" />
+    <link rel="canonical" href="https://prompterai.space/tr/dm.html" />
+<link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/dm.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/dm.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/dm.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/dm.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/dm.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/dm.js?v=69"></script>
+    <script nomodule src="dist/dm.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
-          <a id="back-link" href="tr/" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+          <a id="back-link" href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
             <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
           </a>
-          <img src="/icons/logo.svg?v=67" alt="Prompter logosu" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
           <div class="ml-1">
             <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
             <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>

--- a/tr/index.html
+++ b/tr/index.html
@@ -29,8 +29,8 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -51,7 +51,7 @@
     <meta
       property="og:description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi."
     />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logosu" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -59,7 +59,7 @@
     <meta
       name="twitter:description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi."
     />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -108,10 +108,10 @@
       }
     </script>
     <script>localStorage.setItem('language', 'tr');</script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -123,7 +123,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -359,7 +359,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="/icons/logo.svg?v=67"
+          src="/icons/logo.svg?v=69"
           alt="Prompter logosu"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -542,17 +542,17 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=67"
+            src="icons/whatsapp.svg?v=69"
             class="w-6 h-6"
             alt="WhatsApp logosu"
           />
         </a>
       </div>
     </div>
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/main.js?v=67"></script>
-    <script nomodule src="/dist/main.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/main.js?v=69"></script>
+    <script nomodule src="/dist/main.js?v=69"></script>
     <script type="module">
       import { app, firebaseReady } from '/src/firebase.js';
       import { onAuth } from '/src/auth.js';
@@ -574,7 +574,8 @@
         });
       };
 
-      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init); else init();
+      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+      else init();
     </script>
   </body>
 </html>

--- a/tr/intro.html
+++ b/tr/intro.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Introduction - Prompter" />
     <meta property="og:description" content="Prompter'ı kullanmaya giriş." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Introduction - Prompter" />
     <meta name="twitter:description" content="Prompter'ı kullanmaya giriş." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/intro.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/tr/intro.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/tr/intro.html" />
 <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/intro.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/intro.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/intro.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>

--- a/tr/login.html
+++ b/tr/login.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -36,13 +36,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Login" />
     <meta property="og:description" content="En sevdiğiniz istemleri kaydetmek için Prompter'a giriş yapın." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Login" />
     <meta name="twitter:description" content="En sevdiğiniz istemleri kaydetmek için Prompter'a giriş yapın." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/login.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -61,12 +61,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/login.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/login.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/login.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -78,8 +78,8 @@
         }
       })();
     </script>
-    <script type="module" src="/src/auth.js?v=67"></script>
-    <script nomodule src="dist/auth.js?v=67"></script>
+    <script type="module" src="/src/auth.js?v=69"></script>
+    <script nomodule src="dist/auth.js?v=69"></script>
     <script type="module">
       import { login, register, onAuth } from '/src/auth.js';
       import { setUserProfile, getUserByName } from '/src/user.js';
@@ -177,7 +177,7 @@
         else init();
       });
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-md mx-auto relative mt-16">

--- a/tr/privacy.html
+++ b/tr/privacy.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Legal - Prompter" />
     <meta property="og:description" content="Prompter gizlilik bilgileri ve politikası." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Legal - Prompter" />
     <meta name="twitter:description" content="Prompter gizlilik bilgileri ve politikası." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -40,9 +40,9 @@
       }
     </script>
     -->
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/tr/privacy.html" />
 <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="en" />
@@ -61,7 +61,7 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/tr/privacy.html" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Legal</h1>

--- a/tr/pro.html
+++ b/tr/pro.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Prompter Pro</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
+    <meta name="keywords" content="yapay zeka komutları, komut üreticisi, yaratıcı komutlar, yapay zeka komut aracı, komut oluşturucu" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Pro" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Pro" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/tr/pro.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="tr" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="zh" />
+
+    <meta name="twitter:url" content="https://prompterai.space/tr/pro.html" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/tr/pro.html" />
+<link rel="alternate" href="https://prompterai.space/pro.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/pro.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/pro.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/pro.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/pro.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/pro.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/pro.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-md mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+
+    <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
+      <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
+      <p class="mb-2 text-center">
+        Tüm özelliklerin kilidini yalnızca <strong>79 TL / 1.99 USD</strong>
+        karşılığında açın.
+      </p>
+      <ul class="list-disc list-inside space-y-1 mb-4">
+        <li>Yeni özelliklere erken erişim</li>
+        <li>Gelişmiş modeller ile prompt üretimi</li>
+        <li>Sınırsız prompt üretimi, kaydetme ve paylaşma</li>
+        <li>Premium promptlara erişim</li>
+        <li>Prompter WhatsApp kanalına üyelik</li>
+        <li>Günlük yapay zeka bülteni</li>
+        <li>Prompter’ın geleceği hakkında oy kullanma</li>
+        <li>Prompter fikri ve gelişimine destek</li>
+        <li>Prompter ekosistemine sınırsız erişim (şimdiki+gelecek eklentiler dahil)</li>
+      </ul>
+        <div class="flex gap-2 mb-4">
+          <input
+            type="text"
+            placeholder="İndirim kodu"
+            class="flex-grow p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          />
+          <button
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+          >
+            Uygula
+          </button>
+        </div>
+      <div class="flex gap-2 justify-center">
+        <button
+          id="payment-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          abone ol
+        </button>
+        <button
+          id="support-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          destek ol
+        </button>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          geri
+        </a>
+      </div>
+      </div>
+
+      <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg max-w-md mx-auto mt-4">
+        <h2 class="text-lg font-semibold mb-2 text-center">IBAN ile ödeme</h2>
+        <ul class="space-y-2 text-sm break-all">
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">IBAN:</span>
+            <span id="iban-text" class="ml-1">TR060082900009491666598560</span>
+            <button
+              id="iban-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="IBAN kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Alıcı adı:</span>
+            <span id="recipient-text" class="ml-1">Muratcan Gençtürk</span>
+            <button
+              id="recipient-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="Alıcı adı kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Açıklama:</span>
+            <span class="ml-1">Bu bölüme sadece Prompter'a kayıtlı e-mail adresinizi yazınız.</span>
+          </li>
+        </ul>
+      </div>
+
+        <script>
+        document.getElementById('payment-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompter', '_blank');
+        });
+        document.getElementById('support-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompterai', '_blank');
+        });
+        document.getElementById('iban-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('TR060082900009491666598560');
+        });
+        document.getElementById('recipient-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('Muratcan Gençtürk');
+        });
+      </script>
+  </div>
+  </body>
+</html>

--- a/tr/profile.html
+++ b/tr/profile.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Profil - Prompter" />
     <meta property="og:description" content="Hesap bilgilerinizi ve kaydedilmiş istemlerinizi yönetin" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Profil - Prompter" />
     <meta name="twitter:description" content="Hesap bilgilerinizi ve kaydedilmiş istemlerinizi yönetin" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/profile.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -36,10 +36,10 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/tr/profile.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/tr/profile.html" />
 <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="en" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/profile.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/profile.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/profile.html" hreflang="zh" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -70,9 +70,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/profile.js?v=67"></script>
-    <script nomodule src="dist/profile.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/profile.js?v=69"></script>
+    <script nomodule src="dist/profile.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -96,7 +96,7 @@
           </a>
           <img
             id="app-logo"
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/tr/social.html
+++ b/tr/social.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Social" />
     <meta property="og:description" content="Diğer Prompter kullanıcılarıyla bağlantı kurmak için bağlantılar." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Social" />
     <meta name="twitter:description" content="Diğer Prompter kullanıcılarıyla bağlantı kurmak için bağlantılar." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/social.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -36,11 +36,11 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/tr/social.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -48,7 +48,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/tr/social.html" />
 <link rel="alternate" href="https://prompterai.space/social.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/social.html" hreflang="en" />
@@ -70,7 +70,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -93,7 +93,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -136,7 +136,7 @@
       import { linkify } from '/src/linkify.js';
       import { sanitizeHTML, setSanitizedHTML } from '/src/sanitize.js';
       import { timeAgo } from '/src/timeago.js';
-      import { categories } from '/src/prompts.js?v=67';
+      import { categories } from '/src/prompts.js?v=69';
       import { BASE_URL } from '/src/config.js';
       import {
         getUserProfile,

--- a/tr/terms.html
+++ b/tr/terms.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Terms - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Terms - Prompter" />
     <meta property="og:description" content="Prompter kullanım şartları." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terms - Prompter" />
     <meta name="twitter:description" content="Prompter kullanım şartları." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/terms.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="zh" />
 
     <meta name="twitter:url" content="https://prompterai.space/tr/terms.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/tr/terms.html" />
 <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/terms.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/terms.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/terms.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>

--- a/tr/top-collectors.html
+++ b/tr/top-collectors.html
@@ -4,41 +4,41 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
-    <title>En İyi Koleksiyoncular - Prompter</title>
+    <title>Top Collectors - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
+    <meta name="keywords" content="yapay zeka komutları, komut üreticisi, yaratıcı komutlar, yapay zeka komut aracı, komut oluşturucu" />
     <meta name="robots" content="index,follow" />
-    <meta property="og:title" content="En İyi Koleksiyoncular - Prompter" />
+    <meta property="og:title" content="Top Collectors - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:image:alt" content="Prompter logosu" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="En İyi Koleksiyoncular - Prompter" />
+    <meta name="twitter:title" content="Top Collectors - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/tr/top-collectors.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
 <meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <meta name="twitter:url" content="https://prompterai.space/tr/top-collectors.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -50,19 +50,24 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-collectors.js?v=67"></script>
-    <script nomodule src="dist/top-collectors.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script nomodule src="dist/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/tr/top-collectors.html" />
+<link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-collectors.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-collectors.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-collectors.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top-collectors.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-collectors.html" hreflang="zh" />
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">
       <div class="absolute top-4 left-4">
         <a
           id="back-link"
-          href="tr/"
+          href="index.html"
           class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
           title="Back"
           aria-label="Back"

--- a/tr/top-creators.html
+++ b/tr/top-creators.html
@@ -4,41 +4,41 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
-    <title>En İyi Üreticiler - Prompter</title>
+    <title>Top Creators - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
+    <meta name="keywords" content="yapay zeka komutları, komut üreticisi, yaratıcı komutlar, yapay zeka komut aracı, komut oluşturucu" />
     <meta name="robots" content="index,follow" />
-    <meta property="og:title" content="En İyi Üreticiler - Prompter" />
+    <meta property="og:title" content="Top Creators - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:image:alt" content="Prompter logosu" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="En İyi Üreticiler - Prompter" />
+    <meta name="twitter:title" content="Top Creators - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/tr/top-creators.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
 <meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <meta name="twitter:url" content="https://prompterai.space/tr/top-creators.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -50,19 +50,24 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-creators.js?v=67"></script>
-    <script nomodule src="dist/top-creators.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script nomodule src="dist/top-creators.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/tr/top-creators.html" />
+<link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-creators.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-creators.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-creators.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top-creators.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-creators.html" hreflang="zh" />
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">
       <div class="absolute top-4 left-4">
         <a
           id="back-link"
-          href="tr/"
+          href="index.html"
           class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
           title="Back"
           aria-label="Back"

--- a/tr/top-prompts.html
+++ b/tr/top-prompts.html
@@ -4,41 +4,41 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
-    <title>En İyi Promptlar - Prompter</title>
+    <title>Top Prompts - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
+    <meta name="keywords" content="yapay zeka komutları, komut üreticisi, yaratıcı komutlar, yapay zeka komut aracı, komut oluşturucu" />
     <meta name="robots" content="index,follow" />
-    <meta property="og:title" content="En İyi Promptlar - Prompter" />
+    <meta property="og:title" content="Top Prompts - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:image:alt" content="Prompter logosu" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="En İyi Promptlar - Prompter" />
+    <meta name="twitter:title" content="Top Prompts - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/tr/top-prompts.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
 <meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <meta name="twitter:url" content="https://prompterai.space/tr/top-prompts.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -50,19 +50,24 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-prompts.js?v=67"></script>
-    <script nomodule src="dist/top-prompts.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
-    <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script nomodule src="dist/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/tr/top-prompts.html" />
+<link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-prompts.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-prompts.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-prompts.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top-prompts.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-prompts.html" hreflang="zh" />
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-xl mx-auto relative mt-16">
       <div class="absolute top-4 left-4">
         <a
           id="back-link"
-          href="tr/"
+          href="index.html"
           class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
           title="Back"
           aria-label="Back"

--- a/tr/top.html
+++ b/tr/top.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
-    <title>En İyi Listeler - Prompter</title>
+    <title>Top Lists - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -14,38 +14,42 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <meta name="description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="keywords" content="AI prompts, prompt generator, creative prompts, AI prompter, prompt maker" />
+    <meta name="description" content="İnternet bağlantısı gerektiren yaratıcı yapay zeka komut üreticisi." />
+    <meta name="keywords" content="yapay zeka komutları, komut üreticisi, yaratıcı komutlar, yapay zeka komut aracı, komut oluşturucu" />
     <meta name="robots" content="index,follow" />
-    <meta property="og:title" content="En İyi Listeler - Prompter" />
+    <meta property="og:title" content="Top Lists - Prompter" />
     <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:image:alt" content="Prompter logosu" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="En İyi Listeler - Prompter" />
+    <meta name="twitter:title" content="Top Lists - Prompter" />
     <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
-    <meta property="og:url" content="https://prompterai.space/" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/tr/top.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
 <meta property="og:locale:alternate" content="en" />
     <meta property="og:locale:alternate" content="es" />
-    <meta property="og:locale:alternate" content="zh" />
     <meta property="og:locale:alternate" content="fr" />
     <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="zh" />
 
-    <meta name="twitter:url" content="https://prompterai.space/" />
+    <meta name="twitter:url" content="https://prompterai.space/tr/top.html" />
     <link rel="canonical" href="https://prompterai.space/tr/top.html" />
-    <link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
+<link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/top.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/top.html" hreflang="tr" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="alternate" href="https://prompterai.space/zh/top.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -59,14 +63,14 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-4xl mx-auto relative mt-16">
       <div class="absolute top-4 left-4">
         <a
           id="back-link"
-          href="tr/"
+          href="index.html"
           class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
           title="Back"
           aria-label="Back"
@@ -81,51 +85,56 @@
       <div
         class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg"
       >
-        <h1 class="text-2xl font-bold mb-4 text-center">En İyi Sıralamalar</h1>
+        <h1 class="text-2xl font-bold mb-4 text-center">Top Rankings</h1>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
-            <h2 class="text-lg font-semibold mb-1 text-center">
-              En İyi Oluşturucular
-            </h2>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Creators</h2>
             <p class="text-xs text-blue-200 text-center mb-2">
-              Komutlarındaki toplam beğeni, kaydetme ve paylaşma sayısına göre
-              sıralanır.
+              Ranked by total likes, saves and shares on their prompts.
             </p>
             <div id="creator-list" class="space-y-2"></div>
           </div>
           <div>
             <h2 class="text-lg font-semibold mb-1 text-center">
-              En İyi Koleksiyoncular
+              Top Collectors
             </h2>
             <p class="text-xs text-blue-200 text-center mb-2">
-              Beğendikleri, kaydettikleri ve paylaştıkları komut sayısına göre
-              sıralanır.
+              Ranked by how many prompts they've liked, saved and shared.
             </p>
             <div id="collector-list" class="space-y-2"></div>
           </div>
           <div>
-            <h2 class="text-lg font-semibold mb-1 text-center">
-              En İyi Komutlar
-            </h2>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Prompts</h2>
             <p class="text-xs text-blue-200 text-center mb-2">
-              Her komutun aldığı beğeni, kaydetme ve paylaşma sayılarına göre
-              sıralanır.
+              Ranked by likes, saves and shares each prompt receives.
             </p>
             <div id="prompt-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Supporters</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Ranked by total donations.</p>
+            <div id="supporter-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Longest Pro Members</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Earliest subscribers still active.</p>
+            <div id="pro-list" class="space-y-2"></div>
           </div>
         </div>
       </div>
       <div class="mt-4 text-center">
         <a
-          href="tr/"
+          href="index.html"
           class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
         >
-          geri
+          Back
         </a>
       </div>
     </div>
-    <script type="module" src="/src/top-creators.js?v=67"></script>
-    <script type="module" src="/src/top-collectors.js?v=67"></script>
-    <script type="module" src="/src/top-prompts.js?v=67"></script>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/top-supporters.js?v=69"></script>
+    <script type="module" src="/src/top-pro.js?v=69"></script>
   </body>
 </html>

--- a/tr/user.html
+++ b/tr/user.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="User - Prompter" />
     <meta property="og:description" content="Bir kullanıcının paylaştığı istemleri ve profilini görüntüleyin." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="User - Prompter" />
     <meta name="twitter:description" content="Bir kullanıcının paylaştığı istemleri ve profilini görüntüleyin." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/tr/user.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="tr" />
@@ -41,12 +41,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/user.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/user.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/user.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -58,9 +58,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/user-page.js?v=67"></script>
-    <script nomodule src="dist/user-page.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/user-page.js?v=69"></script>
+    <script nomodule src="dist/user-page.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -75,7 +75,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="/icons/logo.svg?v=67" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>

--- a/user.html
+++ b/user.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="./" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="User - Prompter" />
     <meta property="og:description" content="View a user's shared prompts and profile." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="User - Prompter" />
     <meta name="twitter:description" content="View a user's shared prompts and profile." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/user.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="en" />
@@ -41,12 +41,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/user.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/user.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/user.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -58,9 +58,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/user-page.js?v=67"></script>
-    <script nomodule src="dist/user-page.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/user-page.js?v=69"></script>
+    <script nomodule src="dist/user-page.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -75,7 +75,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="/icons/logo.svg?v=67" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>

--- a/zh/404.html
+++ b/zh/404.html
@@ -12,8 +12,8 @@
     </script>
     -->
     <title>404 - Page Not Found</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -23,13 +23,13 @@
     <meta name="robots" content="noindex,follow" />
     <meta property="og:title" content="404 - Page Not Found" />
     <meta property="og:description" content="需要互联网连接的创意AI提示生成器." />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="404 - Page Not Found" />
     <meta name="twitter:description" content="需要互联网连接的创意AI提示生成器." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/404.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/404.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/404.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/404.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -61,7 +61,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body
     class="bg-black text-white min-h-screen flex flex-col items-center justify-center p-4"

--- a/zh/blog.html
+++ b/zh/blog.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Space - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Space - Prompter" />
     <meta property="og:description" content="关于 Prompter 的文章和更新。" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Space - Prompter" />
     <meta name="twitter:description" content="关于 Prompter 的文章和更新。" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/blog.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -36,12 +36,12 @@
     <meta property="og:locale:alternate" content="tr" />
 
     <meta name="twitter:url" content="https://prompterai.space/zh/blog.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/zh/blog.html" />
 <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/blog.html" hreflang="en" />
@@ -63,7 +63,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -90,7 +90,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/zh/dm.html
+++ b/zh/dm.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Direct Messages - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="需要互联网连接的创意AI提示生成器." />
+    <meta name="keywords" content="AI提示, 提示生成器, 创意提示, AI提示器, 提示制作器" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Direct Messages - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Direct Messages - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/zh/dm.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/zh/dm.html" />
+    <link rel="canonical" href="https://prompterai.space/zh/dm.html" />
+<link rel="alternate" href="https://prompterai.space/dm.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/dm.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/dm.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/dm.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/dm.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/dm.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/dm.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/dm.js?v=69"></script>
+    <script nomodule src="dist/dm.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div id="app-container" class="w-full">
+      <header class="flex items-center justify-between w-full mt-4 mb-6">
+        <div class="flex items-center gap-2">
+          <a id="back-link" href="index.html" class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Back">
+            <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+          </a>
+          <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+          <div class="ml-1">
+            <h1 class="text-xl sm:text-2xl font-bold leading-tight">Prompter</h1>
+            <p class="text-sm text-blue-200 sm:text-base">Direct Messages</p>
+          </div>
+        </div>
+      </header>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <button id="create-conv" class="mb-2 bg-white/20 hover:bg-white/30 p-1.5 rounded-md focus:outline-none focus:ring-2 focus:ring-white/50 w-full">New Conversation</button>
+          <ul id="conv-list" class="space-y-2"></ul>
+        </div>
+        <div class="flex-1">
+          <div id="messages" class="space-y-2 mb-2 h-80 overflow-y-auto border border-white/20 p-2 rounded-md bg-white/10"></div>
+          <form id="message-form" class="flex gap-2" data-conv-id="">
+            <input id="message-input" type="text" class="flex-1 p-1 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50" placeholder="Type a message" />
+            <button type="submit" class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50">Send</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -29,8 +29,8 @@
     />
     <title>PROMPTER</title>
     <base href="../" />
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -51,7 +51,7 @@
     <meta
       property="og:description" content="需要互联网连接的创意AI提示生成器."
     />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter标志" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -59,7 +59,7 @@
     <meta
       name="twitter:description" content="需要互联网连接的创意AI提示生成器."
     />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -108,10 +108,10 @@
       }
     </script>
     <script>localStorage.setItem('language', 'zh');</script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -123,7 +123,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <noscript>
@@ -359,7 +359,7 @@
       <!-- Header -->
       <div class="text-center mb-3 pt-4">
         <img
-          src="/icons/logo.svg?v=67"
+          src="/icons/logo.svg?v=69"
           alt="Prompter标志"
           class="mx-auto mb-4 w-16 h-16"
           id="app-logo"
@@ -542,17 +542,17 @@
           aria-label="WhatsApp Group"
         >
           <img
-            src="icons/whatsapp.svg?v=67"
+            src="icons/whatsapp.svg?v=69"
             class="w-6 h-6"
             alt="WhatsApp标志"
           />
         </a>
       </div>
     </div>
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/main.js?v=67"></script>
-    <script nomodule src="/dist/main.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/main.js?v=69"></script>
+    <script nomodule src="/dist/main.js?v=69"></script>
     <script type="module">
       import { app, firebaseReady } from '/src/firebase.js';
       import { onAuth } from '/src/auth.js';
@@ -574,7 +574,8 @@
         });
       };
 
-      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init); else init();
+      if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+      else init();
     </script>
   </body>
 </html>

--- a/zh/intro.html
+++ b/zh/intro.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Introduction - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Introduction - Prompter" />
     <meta property="og:description" content="如何使用 Prompter 的介绍。" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Introduction - Prompter" />
     <meta name="twitter:description" content="如何使用 Prompter 的介绍。" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/intro.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="tr" />
 
     <meta name="twitter:url" content="https://prompterai.space/zh/intro.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/zh/intro.html" />
 <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/intro.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/intro.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/intro.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/intro.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
     <h1 class="text-2xl font-bold mb-4">Welcome to Prompter</h1>

--- a/zh/login.html
+++ b/zh/login.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Login</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -36,13 +36,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Login" />
     <meta property="og:description" content="登录到提示器以保存您喜欢的提示。" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Login" />
     <meta name="twitter:description" content="登录到提示器以保存您喜欢的提示。" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/login.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -61,12 +61,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/login.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/login.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/login.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -78,8 +78,8 @@
         }
       })();
     </script>
-    <script type="module" src="/src/auth.js?v=67"></script>
-    <script nomodule src="dist/auth.js?v=67"></script>
+    <script type="module" src="/src/auth.js?v=69"></script>
+    <script nomodule src="dist/auth.js?v=69"></script>
     <script type="module">
       import { login, register, onAuth } from '/src/auth.js';
       import { setUserProfile, getUserByName } from '/src/user.js';
@@ -177,7 +177,7 @@
         else init();
       });
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="max-w-md mx-auto relative mt-16">

--- a/zh/privacy.html
+++ b/zh/privacy.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Legal - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Legal - Prompter" />
     <meta property="og:description" content="Prompter 的隐私信息和政策。" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Legal - Prompter" />
     <meta name="twitter:description" content="Prompter 的隐私信息和政策。" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/privacy.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -40,9 +40,9 @@
       }
     </script>
     -->
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/zh/privacy.html" />
 <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/privacy.html" hreflang="en" />
@@ -61,7 +61,7 @@
     <meta property="og:locale:alternate" content="tr" />
 
     <meta name="twitter:url" content="https://prompterai.space/zh/privacy.html" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Legal</h1>

--- a/zh/pro.html
+++ b/zh/pro.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Prompter Pro</title>
+    <base href="../" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="需要互联网连接的创意AI提示生成器." />
+    <meta name="keywords" content="AI提示, 提示生成器, 创意提示, AI提示器, 提示制作器" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Prompter Pro" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Prompter Pro" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/zh/pro.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/zh/pro.html" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <!--
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+    -->
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/zh/pro.html" />
+<link rel="alternate" href="https://prompterai.space/pro.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/pro.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/pro.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/pro.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/pro.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/pro.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/pro.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-md mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+
+    <div class="max-w-md mx-auto bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg">
+      <h1 class="text-2xl font-bold mb-4 text-center">Prompter Pro</h1>
+      <p class="mb-2 text-center">
+        Tüm özelliklerin kilidini yalnızca <strong>79 TL / 1.99 USD</strong>
+        karşılığında açın.
+      </p>
+      <ul class="list-disc list-inside space-y-1 mb-4">
+        <li>Yeni özelliklere erken erişim</li>
+        <li>Gelişmiş modeller ile prompt üretimi</li>
+        <li>Sınırsız prompt üretimi, kaydetme ve paylaşma</li>
+        <li>Premium promptlara erişim</li>
+        <li>Prompter WhatsApp kanalına üyelik</li>
+        <li>Günlük yapay zeka bülteni</li>
+        <li>Prompter’ın geleceği hakkında oy kullanma</li>
+        <li>Prompter fikri ve gelişimine destek</li>
+        <li>Prompter ekosistemine sınırsız erişim (şimdiki+gelecek eklentiler dahil)</li>
+      </ul>
+        <div class="flex gap-2 mb-4">
+          <input
+            type="text"
+            placeholder="İndirim kodu"
+            class="flex-grow p-2 rounded-md bg-black/30 border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          />
+          <button
+          class="bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+          >
+            Uygula
+          </button>
+        </div>
+      <div class="flex gap-2 justify-center">
+        <button
+          id="payment-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          abone ol
+        </button>
+        <button
+          id="support-link"
+          type="button"
+          class="w-full bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          destek ol
+        </button>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          geri
+        </a>
+      </div>
+      </div>
+
+      <div class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg max-w-md mx-auto mt-4">
+        <h2 class="text-lg font-semibold mb-2 text-center">IBAN ile ödeme</h2>
+        <ul class="space-y-2 text-sm break-all">
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">IBAN:</span>
+            <span id="iban-text" class="ml-1">TR060082900009491666598560</span>
+            <button
+              id="iban-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="IBAN kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Alıcı adı:</span>
+            <span id="recipient-text" class="ml-1">Muratcan Gençtürk</span>
+            <button
+              id="recipient-copy"
+              class="p-1.5 rounded-md bg-white/20 hover:bg-white/30 focus:outline-none"
+              aria-label="Alıcı adı kopyala"
+            >
+              <i data-lucide="clipboard-copy" class="w-4 h-4" aria-hidden="true"></i>
+            </button>
+          </li>
+          <li class="flex items-center gap-1">
+            <span class="font-semibold">Açıklama:</span>
+            <span class="ml-1">Bu bölüme sadece Prompter'a kayıtlı e-mail adresinizi yazınız.</span>
+          </li>
+        </ul>
+      </div>
+
+        <script>
+        document.getElementById('payment-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompter', '_blank');
+        });
+        document.getElementById('support-link')?.addEventListener('click', () => {
+          window.open('https://turkplay.gumroad.com/l/prompterai', '_blank');
+        });
+        document.getElementById('iban-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('TR060082900009491666598560');
+        });
+        document.getElementById('recipient-copy')?.addEventListener('click', () => {
+          navigator.clipboard.writeText('Muratcan Gençtürk');
+        });
+      </script>
+  </div>
+  </body>
+</html>

--- a/zh/profile.html
+++ b/zh/profile.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Profil - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Profil - Prompter" />
     <meta property="og:description" content="管理您的帐户详细信息和保存的提示" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Profil - Prompter" />
     <meta name="twitter:description" content="管理您的帐户详细信息和保存的提示" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/profile.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -36,10 +36,10 @@
     <meta property="og:locale:alternate" content="tr" />
 
     <meta name="twitter:url" content="https://prompterai.space/zh/profile.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/zh/profile.html" />
 <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/profile.html" hreflang="en" />
@@ -48,8 +48,8 @@
     <link rel="alternate" href="https://prompterai.space/hi/profile.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/profile.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/profile.html" hreflang="zh" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -70,9 +70,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/profile.js?v=67"></script>
-    <script nomodule src="dist/profile.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/profile.js?v=69"></script>
+    <script nomodule src="dist/profile.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -96,7 +96,7 @@
           </a>
           <img
             id="app-logo"
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />

--- a/zh/social.html
+++ b/zh/social.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Prompter Social</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -19,13 +19,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Prompter Social" />
     <meta property="og:description" content="与其他 Prompter 用户联系的链接。" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Prompter Social" />
     <meta name="twitter:description" content="与其他 Prompter 用户联系的链接。" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/social.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -36,11 +36,11 @@
     <meta property="og:locale:alternate" content="tr" />
 
     <meta name="twitter:url" content="https://prompterai.space/zh/social.html" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
     <!--
     <script>
       if ('serviceWorker' in navigator) {
@@ -48,7 +48,7 @@
       }
     </script>
     -->
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
 <link rel="canonical" href="https://prompterai.space/zh/social.html" />
 <link rel="alternate" href="https://prompterai.space/social.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/social.html" hreflang="en" />
@@ -70,7 +70,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="loading-screen">
@@ -93,7 +93,7 @@
             >
           </a>
           <img
-            src="/icons/logo.svg?v=67"
+            src="/icons/logo.svg?v=69"
             alt="Prompter logo"
             class="w-12 h-12 sm:w-14 sm:h-14"
           />
@@ -136,7 +136,7 @@
       import { linkify } from '/src/linkify.js';
       import { sanitizeHTML, setSanitizedHTML } from '/src/sanitize.js';
       import { timeAgo } from '/src/timeago.js';
-      import { categories } from '/src/prompts.js?v=67';
+      import { categories } from '/src/prompts.js?v=69';
       import { BASE_URL } from '/src/config.js';
       import {
         getUserProfile,

--- a/zh/terms.html
+++ b/zh/terms.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Terms - Prompter</title>
-    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=67" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=69" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Terms - Prompter" />
     <meta property="og:description" content="Prompter 的使用条款。" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Terms - Prompter" />
     <meta name="twitter:description" content="Prompter 的使用条款。" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/terms.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -33,9 +33,9 @@
     <meta property="og:locale:alternate" content="tr" />
 
     <meta name="twitter:url" content="https://prompterai.space/zh/terms.html" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <link rel="canonical" href="https://prompterai.space/zh/terms.html" />
 <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/terms.html" hreflang="en" />
@@ -44,7 +44,7 @@
     <link rel="alternate" href="https://prompterai.space/hi/terms.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/terms.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/terms.html" hreflang="zh" />
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="bg-black text-white min-h-screen p-4">
       <h1 class="text-2xl font-bold mb-4">Terms of Use</h1>

--- a/zh/top-collectors.html
+++ b/zh/top-collectors.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Collectors - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="需要互联网连接的创意AI提示生成器." />
+    <meta name="keywords" content="AI提示, 提示生成器, 创意提示, AI提示器, 提示制作器" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Collectors - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Collectors - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/zh/top-collectors.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/zh/top-collectors.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script nomodule src="dist/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/zh/top-collectors.html" />
+<link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-collectors.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-collectors.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-collectors.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-collectors.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-collectors.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-collectors.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompt Collectors</h1>
+      <div id="collector-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/zh/top-creators.html
+++ b/zh/top-creators.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Creators - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="需要互联网连接的创意AI提示生成器." />
+    <meta name="keywords" content="AI提示, 提示生成器, 创意提示, AI提示器, 提示制作器" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Creators - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Creators - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/zh/top-creators.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/zh/top-creators.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script nomodule src="dist/top-creators.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/zh/top-creators.html" />
+<link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-creators.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-creators.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-creators.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-creators.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-creators.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-creators.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Creators</h1>
+      <div id="creator-list" class="space-y-2"></div>
+    </div>
+  </body>
+</html>

--- a/zh/top-prompts.html
+++ b/zh/top-prompts.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Prompts - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="需要互联网连接的创意AI提示生成器." />
+    <meta name="keywords" content="AI提示, 提示生成器, 创意提示, AI提示器, 提示制作器" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Prompts - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Prompts - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/zh/top-prompts.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/zh/top-prompts.html" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${version ? `?${version}` : ''}`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script nomodule src="dist/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
+    <link rel="canonical" href="https://prompterai.space/zh/top-prompts.html" />
+<link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top-prompts.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top-prompts.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top-prompts.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top-prompts.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top-prompts.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top-prompts.html" hreflang="zh" />
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
+        </a>
+      </div>
+      <h1 class="text-2xl font-bold mb-4 text-center">Top Prompts</h1>
+      <div id="prompt-list" class="space-y-4"></div>
+    </div>
+  </body>
+</html>

--- a/zh/top.html
+++ b/zh/top.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <title>Top Lists - Prompter</title>
+    <base href="../" />
+    <link rel="manifest" href="manifest.json?v=69" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="description" content="需要互联网连接的创意AI提示生成器." />
+    <meta name="keywords" content="AI提示, 提示生成器, 创意提示, AI提示器, 提示制作器" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:title" content="Top Lists - Prompter" />
+    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:image:alt" content="Prompter logo" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Top Lists - Prompter" />
+    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:url" content="https://prompterai.space/zh/top.html" />
+    <meta property="og:site_name" content="Prompter" />
+    <meta property="og:locale" content="zh" />
+<meta property="og:locale:alternate" content="en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="fr" />
+    <meta property="og:locale:alternate" content="hi" />
+    <meta property="og:locale:alternate" content="tr" />
+
+    <meta name="twitter:url" content="https://prompterai.space/zh/top.html" />
+    <link rel="canonical" href="https://prompterai.space/zh/top.html" />
+<link rel="alternate" href="https://prompterai.space/top.html" hreflang="x-default" />
+    <link rel="alternate" href="https://prompterai.space/top.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/es/top.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/top.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/top.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/tr/top.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/zh/top.html" hreflang="zh" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <script>
+      (function () {
+        const linkEl = document.getElementById('theme-css');
+        if (!linkEl) return;
+        const version = linkEl.getAttribute('href').split('?')[1];
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          linkEl.href = `css/theme-${savedTheme}.css${
+            version ? `?${version}` : ''
+          }`;
+        }
+      })();
+    </script>
+    <script type="module" src="/src/version.js?v=69"></script>
+  </head>
+  <body class="min-h-screen p-4">
+    <div class="max-w-4xl mx-auto relative mt-16">
+      <div class="absolute top-4 left-4">
+        <a
+          id="back-link"
+          href="index.html"
+          class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 text-white"
+          title="Back"
+          aria-label="Back"
+        >
+          <span
+            class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+            aria-hidden="true"
+            >&larr;</span
+          >
+        </a>
+      </div>
+      <div
+        class="bg-white/10 backdrop-blur-md rounded-2xl p-4 border border-white/20 shadow-lg"
+      >
+        <h1 class="text-2xl font-bold mb-4 text-center">Top Rankings</h1>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Creators</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by total likes, saves and shares on their prompts.
+            </p>
+            <div id="creator-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">
+              Top Collectors
+            </h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by how many prompts they've liked, saved and shared.
+            </p>
+            <div id="collector-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Prompts</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">
+              Ranked by likes, saves and shares each prompt receives.
+            </p>
+            <div id="prompt-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Top Supporters</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Ranked by total donations.</p>
+            <div id="supporter-list" class="space-y-2"></div>
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold mb-1 text-center">Longest Pro Members</h2>
+            <p class="text-xs text-blue-200 text-center mb-2">Earliest subscribers still active.</p>
+            <div id="pro-list" class="space-y-2"></div>
+          </div>
+        </div>
+      </div>
+      <div class="mt-4 text-center">
+        <a
+          href="index.html"
+          class="inline-block bg-gradient-to-r from-cyan-500 to-purple-500 hover:from-cyan-600 hover:to-purple-600 font-bold py-2 px-4 rounded-lg transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500 focus:ring-offset-purple-900"
+        >
+          Back
+        </a>
+      </div>
+    </div>
+    <script type="module" src="/src/top-creators.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=69"></script>
+    <script type="module" src="/src/top-supporters.js?v=69"></script>
+    <script type="module" src="/src/top-pro.js?v=69"></script>
+  </body>
+</html>

--- a/zh/user.html
+++ b/zh/user.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>User - Prompter</title>
     <base href="../" />
-    <link rel="manifest" href="manifest.json?v=67" />
+    <link rel="manifest" href="manifest.json?v=69" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -16,13 +16,13 @@
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="User - Prompter" />
     <meta property="og:description" content="查看用户分享的提示和个人资料。" />
-    <meta property="og:image" content="/icons/logo.svg?v=67" />
+    <meta property="og:image" content="/icons/logo.svg?v=69" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="User - Prompter" />
     <meta name="twitter:description" content="查看用户分享的提示和个人资料。" />
-    <meta name="twitter:image" content="/icons/logo.svg?v=67" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
     <meta property="og:url" content="https://prompterai.space/zh/user.html" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="zh" />
@@ -41,12 +41,12 @@
     <link rel="alternate" href="https://prompterai.space/hi/user.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/user.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/user.html" hreflang="zh" />
-    <link rel="stylesheet" href="css/tailwind.css?v=67" />
-    <script type="module" src="/src/lucide-loader.js?v=67"></script>
-    <link rel="stylesheet" href="css/app.css?v=67" />
-    <script type="module" src="/src/init-app.js?v=67"></script>
-    <script nomodule src="/dist/init-app.js?v=67"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=67" />
+    <link rel="stylesheet" href="css/tailwind.css?v=69" />
+    <script type="module" src="/src/lucide-loader.js?v=69"></script>
+    <link rel="stylesheet" href="css/app.css?v=69" />
+    <script type="module" src="/src/init-app.js?v=69"></script>
+    <script nomodule src="/dist/init-app.js?v=69"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -58,9 +58,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/user-page.js?v=67"></script>
-    <script nomodule src="dist/user-page.js?v=67"></script>
-    <script type="module" src="/src/version.js?v=67"></script>
+    <script type="module" src="/src/user-page.js?v=69"></script>
+    <script nomodule src="dist/user-page.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=69"></script>
   </head>
   <body class="min-h-screen p-4">
     <div id="app-container" class="w-full">
@@ -75,7 +75,7 @@
             >
               <span class="w-6 h-6 inline-flex items-center justify-center text-3xl" aria-hidden="true">&larr;</span>
             </a>
-            <img src="/icons/logo.svg?v=67" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
+            <img src="/icons/logo.svg?v=69" alt="Prompter logo" class="w-12 h-12 sm:w-14 sm:h-14" />
             <div class="ml-1">
               <h1 id="user-name" class="text-xl sm:text-2xl font-bold leading-tight"></h1>
               <p class="text-sm text-blue-200 sm:text-base">Profile</p>


### PR DESCRIPTION
## Summary
- add templates for DM and Top pages
- include canonical and alternate link placeholders
- rebuild localized pages so each language references its counterparts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68601464cf98832fa03b44a51b43f45d