### PR TITLE
Add canonical and hreflang to Elon Musk Simulator page

### DIFF
--- a/elonmusksimulator-main/index.html
+++ b/elonmusksimulator-main/index.html
@@ -15,8 +15,14 @@
     <meta name="twitter:image" content="elon_musk_cartoon.png?v=69">
     <link rel="stylesheet" href="style.css?v=69">
     <link rel="manifest" href="manifest.json?v=69">
+    <link rel="canonical" href="https://prompterai.space/elonmusksimulator-main/index.html" />
     <link rel="alternate" href="https://prompterai.space/elonmusksimulator-main/index.html" hreflang="x-default" />
     <link rel="alternate" href="https://prompterai.space/elonmusksimulator-main/index.html" hreflang="en" />
+    <link rel="alternate" href="https://prompterai.space/tr/elonmusksimulator-main/index.html" hreflang="tr" />
+    <link rel="alternate" href="https://prompterai.space/es/elonmusksimulator-main/index.html" hreflang="es" />
+    <link rel="alternate" href="https://prompterai.space/fr/elonmusksimulator-main/index.html" hreflang="fr" />
+    <link rel="alternate" href="https://prompterai.space/hi/elonmusksimulator-main/index.html" hreflang="hi" />
+    <link rel="alternate" href="https://prompterai.space/zh/elonmusksimulator-main/index.html" hreflang="zh" />
 </head>
 <body>
     <a href="../index.html" class="back-button" title="Back" aria-label="Back">


### PR DESCRIPTION
## Summary
- add canonical link to `elonmusksimulator-main/index.html`
- include alternate hreflang links for all supported languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686033393e3c832f9e7adabf6e0731d7