### PR TITLE
Ensure linkify anchors include rel attribute

### DIFF
--- a/src/linkify.js
+++ b/src/linkify.js
@@ -3,7 +3,7 @@ export function linkify(text) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
   const html = text.replace(urlRegex, (url) => {
     const safeUrl = url.replace(/"/g, '&quot;');
-    return `<a href="${safeUrl}" target="_blank" class="underline">${url}</a>`;
+    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="underline">${url}</a>`;
   });
   return sanitizeHTML(html);
 }

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -11,7 +11,7 @@ function linkify(text) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
   const html = text.replace(urlRegex, (url) => {
     const safeUrl = url.replace(/"/g, '&quot;');
-    return `<a href="${safeUrl}" target="_blank" class="underline">${url}</a>`;
+    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="underline">${url}</a>`;
   });
   return sanitizeHTML(html);
 }
@@ -43,4 +43,10 @@ runTest('linkify sanitizes malicious strings', () => {
   const malicious = 'visit https://example.com <img src=x onerror=alert(1)>';
   const clean = linkify(malicious);
   assert(!/onerror/i.test(clean) && !/script/i.test(clean));
+});
+
+runTest('linkify adds rel="noopener noreferrer" to links', () => {
+  const text = 'visit https://example.com';
+  const result = linkify(text);
+  assert(/rel="noopener noreferrer"/.test(result));
 });


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to generated links
- update security tests to check for the rel attribute

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686043a94ec0832fadf4678bd0f53c4d