### PR TITLE
Add metadata translations for top pages

### DIFF
--- a/templates/top-collectors.template.html
+++ b/templates/top-collectors.template.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Collectors - Prompter</title>
     <base href="{{BASE_HREF}}" />
-    <link rel="manifest" href="manifest.json?v=69" />
+    <link rel="manifest" href="manifest.json?v=70" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -15,26 +15,26 @@
     <meta name="keywords" content="{{KEYWORDS}}" />
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Collectors - Prompter" />
-    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:description" content="{{DESCRIPTION}}" />
+    <meta property="og:image" content="/icons/logo.svg?v=70" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Collectors - Prompter" />
-    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta name="twitter:description" content="{{DESCRIPTION}}" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=70" />
     <meta property="og:url" content="{{CANONICAL_URL}}" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="{{LANG}}" />
 {{OG_ALTERNATES}}
 
     <meta name="twitter:url" content="{{CANONICAL_URL}}" />
-    <link rel="stylesheet" href="css/tailwind.css?v=69" />
-    <script type="module" src="/src/lucide-loader.js?v=69"></script>
-    <link rel="stylesheet" href="css/app.css?v=69" />
-    <script type="module" src="/src/init-app.js?v=69"></script>
-    <script nomodule src="/dist/init-app.js?v=69"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <link rel="stylesheet" href="css/tailwind.css?v=70" />
+    <script type="module" src="/src/lucide-loader.js?v=70"></script>
+    <link rel="stylesheet" href="css/app.css?v=70" />
+    <script type="module" src="/src/init-app.js?v=70"></script>
+    <script nomodule src="/dist/init-app.js?v=70"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=70" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -46,9 +46,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-collectors.js?v=69"></script>
-    <script nomodule src="dist/top-collectors.js?v=69"></script>
-    <script type="module" src="/src/version.js?v=69"></script>
+    <script type="module" src="/src/top-collectors.js?v=70"></script>
+    <script nomodule src="dist/top-collectors.js?v=70"></script>
+    <script type="module" src="/src/version.js?v=70"></script>
     <link rel="canonical" href="{{CANONICAL_URL}}" />
 {{ALTERNATE_LINKS}}
   </head>

--- a/templates/top-creators.template.html
+++ b/templates/top-creators.template.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Creators - Prompter</title>
     <base href="{{BASE_HREF}}" />
-    <link rel="manifest" href="manifest.json?v=69" />
+    <link rel="manifest" href="manifest.json?v=70" />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
@@ -15,26 +15,26 @@
     <meta name="keywords" content="{{KEYWORDS}}" />
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Creators - Prompter" />
-    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:description" content="{{DESCRIPTION}}" />
+    <meta property="og:image" content="/icons/logo.svg?v=70" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Creators - Prompter" />
-    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta name="twitter:description" content="{{DESCRIPTION}}" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=70" />
     <meta property="og:url" content="{{CANONICAL_URL}}" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="{{LANG}}" />
 {{OG_ALTERNATES}}
 
     <meta name="twitter:url" content="{{CANONICAL_URL}}" />
-    <link rel="stylesheet" href="css/tailwind.css?v=69" />
-    <script type="module" src="/src/lucide-loader.js?v=69"></script>
-    <link rel="stylesheet" href="css/app.css?v=69" />
-    <script type="module" src="/src/init-app.js?v=69"></script>
-    <script nomodule src="/dist/init-app.js?v=69"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <link rel="stylesheet" href="css/tailwind.css?v=70" />
+    <script type="module" src="/src/lucide-loader.js?v=70"></script>
+    <link rel="stylesheet" href="css/app.css?v=70" />
+    <script type="module" src="/src/init-app.js?v=70"></script>
+    <script nomodule src="/dist/init-app.js?v=70"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=70" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -46,9 +46,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-creators.js?v=69"></script>
-    <script nomodule src="dist/top-creators.js?v=69"></script>
-    <script type="module" src="/src/version.js?v=69"></script>
+    <script type="module" src="/src/top-creators.js?v=70"></script>
+    <script nomodule src="dist/top-creators.js?v=70"></script>
+    <script type="module" src="/src/version.js?v=70"></script>
     <link rel="canonical" href="{{CANONICAL_URL}}" />
 {{ALTERNATE_LINKS}}
   </head>

--- a/templates/top-prompts.template.html
+++ b/templates/top-prompts.template.html
@@ -9,7 +9,7 @@
     />
     <title>Top Prompts - Prompter</title>
     <base href="{{BASE_HREF}}" />
-    <link rel="manifest" href="manifest.json?v=69" />
+    <link rel="manifest" href="manifest.json?v=70" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -21,32 +21,26 @@
     <meta name="keywords" content="{{KEYWORDS}}" />
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Prompts - Prompter" />
-    <meta
-      property="og:description"
-      content="Creative AI prompt generator that requires an internet connection."
-    />
-    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:description" content="{{DESCRIPTION}}" />
+    <meta property="og:image" content="/icons/logo.svg?v=70" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Prompts - Prompter" />
-    <meta
-      name="twitter:description"
-      content="Creative AI prompt generator that requires an internet connection."
-    />
-    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta name="twitter:description" content="{{DESCRIPTION}}" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=70" />
     <meta property="og:url" content="{{CANONICAL_URL}}" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="{{LANG}}" />
     {{OG_ALTERNATES}}
 
     <meta name="twitter:url" content="{{CANONICAL_URL}}" />
-    <link rel="stylesheet" href="css/tailwind.css?v=69" />
-    <script type="module" src="/src/lucide-loader.js?v=69"></script>
-    <link rel="stylesheet" href="css/app.css?v=69" />
-    <script type="module" src="/src/init-app.js?v=69"></script>
-    <script nomodule src="/dist/init-app.js?v=69"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <link rel="stylesheet" href="css/tailwind.css?v=70" />
+    <script type="module" src="/src/lucide-loader.js?v=70"></script>
+    <link rel="stylesheet" href="css/app.css?v=70" />
+    <script type="module" src="/src/init-app.js?v=70"></script>
+    <script nomodule src="/dist/init-app.js?v=70"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=70" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -60,9 +54,9 @@
         }
       })();
     </script>
-    <script type="module" src="/src/top-prompts.js?v=69"></script>
-    <script nomodule src="dist/top-prompts.js?v=69"></script>
-    <script type="module" src="/src/version.js?v=69"></script>
+    <script type="module" src="/src/top-prompts.js?v=70"></script>
+    <script nomodule src="dist/top-prompts.js?v=70"></script>
+    <script type="module" src="/src/version.js?v=70"></script>
     <link rel="canonical" href="{{CANONICAL_URL}}" />
     {{ALTERNATE_LINKS}}
     <script type="application/ld+json">

--- a/templates/top.template.html
+++ b/templates/top.template.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>Top Lists - Prompter</title>
     <base href="{{BASE_HREF}}" />
-    <link rel="manifest" href="manifest.json?v=69" />
+    <link rel="manifest" href="manifest.json?v=70" />
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Cache-Control"
@@ -18,14 +18,14 @@
     <meta name="keywords" content="{{KEYWORDS}}" />
     <meta name="robots" content="index,follow" />
     <meta property="og:title" content="Top Lists - Prompter" />
-    <meta property="og:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta property="og:image" content="/icons/logo.svg?v=69" />
+    <meta property="og:description" content="{{DESCRIPTION}}" />
+    <meta property="og:image" content="/icons/logo.svg?v=70" />
     <meta property="og:image:alt" content="Prompter logo" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Top Lists - Prompter" />
-    <meta name="twitter:description" content="Creative AI prompt generator that requires an internet connection." />
-    <meta name="twitter:image" content="/icons/logo.svg?v=69" />
+    <meta name="twitter:description" content="{{DESCRIPTION}}" />
+    <meta name="twitter:image" content="/icons/logo.svg?v=70" />
     <meta property="og:url" content="{{CANONICAL_URL}}" />
     <meta property="og:site_name" content="Prompter" />
     <meta property="og:locale" content="{{LANG}}" />
@@ -34,12 +34,12 @@
     <meta name="twitter:url" content="{{CANONICAL_URL}}" />
     <link rel="canonical" href="{{CANONICAL_URL}}" />
 {{ALTERNATE_LINKS}}
-    <link rel="stylesheet" href="css/tailwind.css?v=69" />
-    <script type="module" src="/src/lucide-loader.js?v=69"></script>
-    <link rel="stylesheet" href="css/app.css?v=69" />
-    <script type="module" src="/src/init-app.js?v=69"></script>
-    <script nomodule src="/dist/init-app.js?v=69"></script>
-    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=69" />
+    <link rel="stylesheet" href="css/tailwind.css?v=70" />
+    <script type="module" src="/src/lucide-loader.js?v=70"></script>
+    <link rel="stylesheet" href="css/app.css?v=70" />
+    <script type="module" src="/src/init-app.js?v=70"></script>
+    <script nomodule src="/dist/init-app.js?v=70"></script>
+    <link id="theme-css" rel="stylesheet" href="css/theme-dark.css?v=70" />
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');
@@ -53,7 +53,7 @@
         }
       })();
     </script>
-    <script type="module" src="/src/version.js?v=69"></script>
+    <script type="module" src="/src/version.js?v=70"></script>
   </head>
   <body class="min-h-screen p-4">
     <div class="max-w-4xl mx-auto relative mt-16">
@@ -121,10 +121,10 @@
         </a>
       </div>
     </div>
-    <script type="module" src="/src/top-creators.js?v=69"></script>
-    <script type="module" src="/src/top-collectors.js?v=69"></script>
-    <script type="module" src="/src/top-prompts.js?v=69"></script>
-    <script type="module" src="/src/top-supporters.js?v=69"></script>
-    <script type="module" src="/src/top-pro.js?v=69"></script>
+    <script type="module" src="/src/top-creators.js?v=70"></script>
+    <script type="module" src="/src/top-collectors.js?v=70"></script>
+    <script type="module" src="/src/top-prompts.js?v=70"></script>
+    <script type="module" src="/src/top-supporters.js?v=70"></script>
+    <script type="module" src="/src/top-pro.js?v=70"></script>
   </body>
 </html>

--- a/translations/en.json
+++ b/translations/en.json
@@ -21,5 +21,13 @@
   "user_description": "View a user's shared prompts and profile.",
   "user_keywords": "user profile, shared prompts",
   "prompter_logo_alt": "Prompter logo",
-  "whatsapp_logo_alt": "WhatsApp logo"
+  "whatsapp_logo_alt": "WhatsApp logo",
+  "top_description": "Explore top users, prompts and supporters.",
+  "top_keywords": "top prompts, top users, prompter rankings",
+  "top_prompts_description": "Most popular prompts ranked by likes and saves.",
+  "top_prompts_keywords": "top prompts, most popular prompts, prompt rankings",
+  "top_creators_description": "Leading prompt creators ranked by engagement.",
+  "top_creators_keywords": "top creators, prompt creators, ranking",
+  "top_collectors_description": "Power users ranked by prompts collected.",
+  "top_collectors_keywords": "top collectors, prompter users, ranking"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -21,5 +21,13 @@
   "user_description": "Ver los prompts y el perfil compartidos de un usuario.",
   "user_keywords": "perfil de usuario, prompts compartidos",
   "prompter_logo_alt": "Logo de Prompter",
-  "whatsapp_logo_alt": "Logo de WhatsApp"
+  "whatsapp_logo_alt": "Logo de WhatsApp",
+  "top_description": "Explora los mejores usuarios, prompts y seguidores.",
+  "top_keywords": "top prompts, mejores usuarios, rankings prompter",
+  "top_prompts_description": "Prompts más populares clasificados por me gusta y guardados.",
+  "top_prompts_keywords": "mejores prompts, más populares, ranking de prompts",
+  "top_creators_description": "Principales creadores de prompts según la participación.",
+  "top_creators_keywords": "top creadores, creadores de prompts, ranking",
+  "top_collectors_description": "Usuarios destacados clasificados por prompts recopilados.",
+  "top_collectors_keywords": "top coleccionistas, usuarios de prompter, ranking"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -21,5 +21,13 @@
   "user_description": "Voir les invites partagées et le profil d'un utilisateur.",
   "user_keywords": "profil utilisateur, invites partagées",
   "prompter_logo_alt": "Logo de Prompter",
-  "whatsapp_logo_alt": "Logo WhatsApp"
+  "whatsapp_logo_alt": "Logo WhatsApp",
+  "top_description": "Découvrez les meilleurs utilisateurs, prompts et supporters.",
+  "top_keywords": "top prompts, meilleurs utilisateurs, classement prompter",
+  "top_prompts_description": "Prompts les plus populaires classés par mentions J'aime et sauvegardes.",
+  "top_prompts_keywords": "meilleurs prompts, plus populaires, classement prompts",
+  "top_creators_description": "Créateurs de prompts en tête selon l'engagement.",
+  "top_creators_keywords": "top créateurs, créateurs de prompts, classement",
+  "top_collectors_description": "Utilisateurs actifs classés par prompts collectés.",
+  "top_collectors_keywords": "top collectionneurs, utilisateurs prompter, classement"
 }

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -21,5 +21,13 @@
   "user_description": "किसी उपयोगकर्ता के साझा किए गए प्रॉम्प्ट और प्रोफ़ाइल देखें।",
   "user_keywords": "उपयोगकर्ता प्रोफ़ाइल, साझा प्रॉम्प्ट",
   "prompter_logo_alt": "Prompter लोगो",
-  "whatsapp_logo_alt": "WhatsApp लोगो"
+  "whatsapp_logo_alt": "WhatsApp लोगो",
+  "top_description": "शीर्ष उपयोगकर्ता, प्रॉम्प्ट और समर्थकों को देखें.",
+  "top_keywords": "शीर्ष प्रॉम्प्ट, शीर्ष उपयोगकर्ता, prompter रैंकिंग",
+  "top_prompts_description": "सबसे धैन और सेव के अनुसार प्रॉम्प्ट.",
+  "top_prompts_keywords": "शीर्ष प्रॉम्प्ट, सबसे लोकप्रिय, प्रॉम्प्ट रैंकिंग",
+  "top_creators_description": "सबसे अधिक सहभागिता वाले प्रॉम्प्ट निर्माता.",
+  "top_creators_keywords": "शीर्ष निर्माता, प्रॉम्प्ट निर्माता, रैंकिंग",
+  "top_collectors_description": "संग्रहित प्रॉम्प्ट की संख्या पर आधारित उपयोगकर्ता.",
+  "top_collectors_keywords": "शीर्ष कलेक्टर, prompter उपयोगकर्ता, रैंकिंग"
 }

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -21,5 +21,13 @@
   "user_description": "Bir kullanıcının paylaştığı istemleri ve profilini görüntüleyin.",
   "user_keywords": "kullanıcı profili, paylaşılan istemler",
   "prompter_logo_alt": "Prompter logosu",
-  "whatsapp_logo_alt": "WhatsApp logosu"
+  "whatsapp_logo_alt": "WhatsApp logosu",
+  "top_description": "En iyi kullanıcıları, istemleri ve destekçileri keşfedin.",
+  "top_keywords": "en iyi istemler, en iyi kullanıcılar, prompter sıralamaları",
+  "top_prompts_description": "Beğeni ve kaydetmeye göre sıralanan en popüler istemler.",
+  "top_prompts_keywords": "en iyi istemler, en popüler, istem sıralaması",
+  "top_creators_description": "Etkileşime göre sıralanan önde gelen istem oluşturucular.",
+  "top_creators_keywords": "en iyi oluşturucular, istem oluşturucu, sıralama",
+  "top_collectors_description": "Toplanan istem sayısına göre sıralanan kullanıcılar.",
+  "top_collectors_keywords": "en iyi koleksiyoncular, prompter kullanıcıları, sıralama"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -21,5 +21,13 @@
   "user_description": "查看用户分享的提示和个人资料。",
   "user_keywords": "用户个人资料, 分享的提示",
   "prompter_logo_alt": "Prompter标志",
-  "whatsapp_logo_alt": "WhatsApp标志"
+  "whatsapp_logo_alt": "WhatsApp标志",
+  "top_description": "探索最受欢迎的用户、提示和支持者。",
+  "top_keywords": "热门提示, 顶级用户, prompter 排行",
+  "top_prompts_description": "按点赞和收藏排序的最受欢迎提示。",
+  "top_prompts_keywords": "热门提示, 最受欢迎, 提示排名",
+  "top_creators_description": "按互动量排名的顶级提示创作者。",
+  "top_creators_keywords": "顶级创作者, 提示创作者, 排行",
+  "top_collectors_description": "按收藏提示数量排名的用户。",
+  "top_collectors_keywords": "顶级收藏者, prompter 用户, 排行"
 }


### PR DESCRIPTION
## Summary
- translate descriptions and keywords for top pages across locales
- inject these strings into top-related templates

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686044a86800832f9aced63bf94982b2