### PR TITLE
Add BlogPosting schema to blog pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -50,6 +50,19 @@
     <link rel="alternate" href="https://prompterai.space/hi/blog.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/blog.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/blog.html" hreflang="zh" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Space - Prompter",
+        "description": "Articles and updates about Prompter.",
+        "author": {
+          "@type": "Organization",
+          "name": "Prompter"
+        },
+        "datePublished": "2023-01-01"
+      }
+    </script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');

--- a/es/blog.html
+++ b/es/blog.html
@@ -50,6 +50,19 @@
     <link rel="alternate" href="https://prompterai.space/hi/blog.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/blog.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/blog.html" hreflang="zh" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Space - Prompter",
+        "description": "Artículos y novedades sobre Prompter.",
+        "author": {
+          "@type": "Organization",
+          "name": "Prompter"
+        },
+        "datePublished": "2023-01-01"
+      }
+    </script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');

--- a/fr/blog.html
+++ b/fr/blog.html
@@ -50,6 +50,19 @@
     <link rel="alternate" href="https://prompterai.space/hi/blog.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/blog.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/blog.html" hreflang="zh" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Space - Prompter",
+        "description": "Articles et actualités sur Prompter.",
+        "author": {
+          "@type": "Organization",
+          "name": "Prompter"
+        },
+        "datePublished": "2023-01-01"
+      }
+    </script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');

--- a/hi/blog.html
+++ b/hi/blog.html
@@ -50,6 +50,19 @@
     <link rel="alternate" href="https://prompterai.space/hi/blog.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/blog.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/blog.html" hreflang="zh" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Space - Prompter",
+        "description": "Prompter से संबंधित लेख और अपडेट।",
+        "author": {
+          "@type": "Organization",
+          "name": "Prompter"
+        },
+        "datePublished": "2023-01-01"
+      }
+    </script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');

--- a/templates/blog.template.html
+++ b/templates/blog.template.html
@@ -51,6 +51,19 @@
         "url": "{{CANONICAL_URL}}"
       }
     </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Space - Prompter",
+        "description": "{{DESCRIPTION}}",
+        "author": {
+          "@type": "Organization",
+          "name": "Prompter"
+        },
+        "datePublished": "2023-01-01"
+      }
+    </script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');

--- a/tr/blog.html
+++ b/tr/blog.html
@@ -50,6 +50,19 @@
     <link rel="alternate" href="https://prompterai.space/hi/blog.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/blog.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/blog.html" hreflang="zh" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Space - Prompter",
+        "description": "Prompter hakkında makaleler ve güncellemeler.",
+        "author": {
+          "@type": "Organization",
+          "name": "Prompter"
+        },
+        "datePublished": "2023-01-01"
+      }
+    </script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');

--- a/zh/blog.html
+++ b/zh/blog.html
@@ -50,6 +50,19 @@
     <link rel="alternate" href="https://prompterai.space/hi/blog.html" hreflang="hi" />
     <link rel="alternate" href="https://prompterai.space/tr/blog.html" hreflang="tr" />
     <link rel="alternate" href="https://prompterai.space/zh/blog.html" hreflang="zh" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Space - Prompter",
+        "description": "关于 Prompter 的文章和更新。",
+        "author": {
+          "@type": "Organization",
+          "name": "Prompter"
+        },
+        "datePublished": "2023-01-01"
+      }
+    </script>
     <script>
       (function () {
         const linkEl = document.getElementById('theme-css');


### PR DESCRIPTION
## Summary
- add BlogPosting JSON-LD block to `blog.template.html`
- include same schema in all localized `blog.html` pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68604673768c832fb12e9bf6a556902d