### PR TITLE
Use configurable ad link

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,5 @@
 export const BASE_URL = 'https://prompterai.space';
+
+// Optional advertisement link opened when selecting the random category
+// Defaults to `null` so no new window is opened unless configured
+export const AD_LINK = null;

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,6 +1,6 @@
 import { appState, THEMES } from './state.js';
 import { categories, ICON_FALLBACKS, generatePrompt } from './prompts.js';
-import { BASE_URL } from './config.js';
+import { BASE_URL, AD_LINK } from './config.js';
 
 const LANGUAGE_PAGES = {
   en: 'index.html',
@@ -996,8 +996,8 @@ const setupEventListeners = () => {
           .querySelectorAll('.category-button')
           .forEach((btn) => btn.classList.remove('selected'));
         button.classList.add('selected');
-        if (category.id === 'random') {
-          window.open('https://otieu.com/4/9497116', '_blank');
+        if (category.id === 'random' && AD_LINK) {
+          window.open(AD_LINK, '_blank');
         }
       });
     }


### PR DESCRIPTION
## Summary
- add `AD_LINK` to the configuration
- only open the configured ad link

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686047aff7f0832fb8034f802673aabf