### PR TITLE
Handle punctuation after URLs

### DIFF
--- a/src/linkify.js
+++ b/src/linkify.js
@@ -1,9 +1,9 @@
 import { sanitizeHTML } from './sanitize.js';
 export function linkify(text) {
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-  const html = text.replace(urlRegex, (url) => {
+  const urlRegex = /(https?:\/\/[^\s]+?)([).]+)?(?=\s|$)/g;
+  const html = text.replace(urlRegex, (match, url, punctuation = '') => {
     const safeUrl = url.replace(/"/g, '&quot;');
-    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="underline">${url}</a>`;
+    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="underline">${url}</a>${punctuation}`;
   });
   return sanitizeHTML(html);
 }

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -8,10 +8,10 @@ const DOMPurify = createDOMPurify(window);
 const sanitizeHTML = (html) => DOMPurify.sanitize(html);
 
 function linkify(text) {
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-  const html = text.replace(urlRegex, (url) => {
+  const urlRegex = /(https?:\/\/[^\s]+?)([).]+)?(?=\s|$)/g;
+  const html = text.replace(urlRegex, (match, url, punctuation = '') => {
     const safeUrl = url.replace(/"/g, '&quot;');
-    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="underline">${url}</a>`;
+    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="underline">${url}</a>${punctuation}`;
   });
   return sanitizeHTML(html);
 }
@@ -49,4 +49,10 @@ runTest('linkify adds rel="noopener noreferrer" to links', () => {
   const text = 'visit https://example.com';
   const result = linkify(text);
   assert(/rel="noopener noreferrer"/.test(result));
+});
+
+runTest('linkify excludes trailing punctuation from URLs', () => {
+  const text = 'visit https://example.com).';
+  const result = linkify(text);
+  assert(/https:\/\/example\.com<\/a>\)\./.test(result));
 });


### PR DESCRIPTION
## Summary
- update `linkify` regex to avoid trailing punctuation
- test `linkify` with closing parentheses and period

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68605d328f68832f9c142c9c9584bd4f