### PR TITLE
Add Node tests for prompts and users

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write \"**/*.{js,json,md,css,html}\"",
     "prepare": "husky install",
     "pretest": "node scripts/check-node-modules.js",
-    "test": "npm run lint && npm run lint:prompts && node test/security.test.js",
+    "test": "npm run lint && npm run lint:prompts && node test/security.test.js && node test/prompt.test.mjs && node test/user.test.mjs",
     "lint:prompts": "node scripts/check-prompts.js",
     "build": "node scripts/build-pages.js && node scripts/build-prompts.js && node scripts/update-meta.js",
     "build:es5": "babel src --out-dir dist --presets=@babel/preset-env",

--- a/test/loadModule.js
+++ b/test/loadModule.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+async function loadModule(srcRelative) {
+  const srcPath = path.resolve(__dirname, '..', srcRelative);
+  let code = fs.readFileSync(srcPath, 'utf8');
+  const repl = {
+    'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js':
+      'file://' + path.resolve(__dirname, 'mocks/firestore.js').replace(/\\/g, '/'),
+    './firebase.js':
+      'file://' + path.resolve(__dirname, 'mocks/firebase.js').replace(/\\/g, '/'),
+    './notifications.js':
+      'file://' + path.resolve(__dirname, 'mocks/notifications.js').replace(/\\/g, '/'),
+  };
+  for (const [orig, rep] of Object.entries(repl)) {
+    code = code.replace(orig, rep);
+  }
+  const tmp = path.join(os.tmpdir(), 'tmp_' + path.basename(srcRelative));
+  fs.writeFileSync(tmp, code);
+  return import('file://' + tmp + '?v=' + Date.now());
+}
+
+module.exports = { loadModule };

--- a/test/mocks/firebase.js
+++ b/test/mocks/firebase.js
@@ -1,0 +1,2 @@
+export const db = {};
+export const withRetry = async (fn) => fn();

--- a/test/mocks/firestore.js
+++ b/test/mocks/firestore.js
@@ -1,0 +1,127 @@
+let counter = 1;
+const state = {};
+export const calls = {
+  addDoc: [],
+  setDoc: [],
+  updateDoc: [],
+  deleteDoc: [],
+  getDoc: [],
+  getDocs: [],
+  query: [],
+  doc: [],
+  collection: [],
+};
+export const reset = () => {
+  counter = 1;
+  for (const k in calls) calls[k].length = 0;
+  for (const k in state) delete state[k];
+};
+export function collection(db, path) {
+  calls.collection.push(path);
+  return { _path: path };
+}
+export function doc(db, ...segments) {
+  const p = segments.join('/');
+  calls.doc.push(p);
+  return { _path: p };
+}
+export function serverTimestamp() {
+  return Date.now();
+}
+export function increment(n) {
+  return { __op: 'increment', n };
+}
+export function arrayUnion(...vals) {
+  return { __op: 'arrayUnion', values: vals.flat() };
+}
+export function arrayRemove(...vals) {
+  return { __op: 'arrayRemove', values: vals.flat() };
+}
+export function where(field, op, value) {
+  return { type: 'where', field, op, value };
+}
+export function orderBy(field, dir) {
+  return { type: 'orderBy', field, dir };
+}
+export function limit(n) {
+  return { type: 'limit', n };
+}
+export function query(colRef, ...clauses) {
+  const q = { colRef, clauses };
+  calls.query.push(q);
+  return q;
+}
+function applyOps(doc, data) {
+  const out = { ...doc };
+  for (const [k, v] of Object.entries(data)) {
+    if (v && v.__op === 'increment') {
+      out[k] = (out[k] || 0) + v.n;
+    } else if (v && v.__op === 'arrayUnion') {
+      const set = new Set(out[k] || []);
+      v.values.forEach((val) => set.add(val));
+      out[k] = Array.from(set);
+    } else if (v && v.__op === 'arrayRemove') {
+      out[k] = (out[k] || []).filter((x) => !v.values.includes(x));
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+export async function addDoc(colRef, data) {
+  const id = `doc${counter++}`;
+  const path = `${colRef._path}/${id}`;
+  state[path] = { ...data };
+  calls.addDoc.push({ colRef, data });
+  return { id, path };
+}
+export async function setDoc(docRef, data, opts = {}) {
+  const existing = state[docRef._path] || {};
+  state[docRef._path] = opts.merge ? { ...existing, ...data } : { ...data };
+  calls.setDoc.push({ docRef, data, opts });
+}
+export async function updateDoc(docRef, data) {
+  const existing = state[docRef._path] || {};
+  state[docRef._path] = applyOps(existing, data);
+  calls.updateDoc.push({ docRef, data });
+}
+export async function deleteDoc(docRef) {
+  delete state[docRef._path];
+  calls.deleteDoc.push({ docRef });
+}
+export async function getDoc(docRef) {
+  calls.getDoc.push({ docRef });
+  const data = state[docRef._path];
+  return {
+    exists: () => data !== undefined,
+    data: () => data,
+  };
+}
+export async function getDocs(q) {
+  calls.getDocs.push({ q });
+  const isCollection = Object.prototype.hasOwnProperty.call(q, '_path');
+  const colPath = isCollection ? q._path : q.colRef._path;
+  const clauses = isCollection ? [] : q.clauses;
+  const docs = [];
+  for (const [path, doc] of Object.entries(state)) {
+    if (!path.startsWith(colPath + '/')) continue;
+    let match = true;
+    for (const clause of clauses) {
+      if (clause.type === 'where') {
+        if (clause.op === '==') {
+          if (doc[clause.field] !== clause.value) match = false;
+        }
+      }
+    }
+    if (match) {
+      docs.push({
+        id: path.split('/').pop(),
+        ref: { _path: path },
+        data: () => doc,
+        get: (field) => doc[field],
+      });
+    }
+  }
+  return { empty: docs.length === 0, docs };
+}
+export const _state = state;

--- a/test/mocks/notifications.js
+++ b/test/mocks/notifications.js
@@ -1,0 +1,7 @@
+export const calls = [];
+export const sendNotification = (...args) => {
+  calls.push(args);
+};
+export const reset = () => {
+  calls.length = 0;
+};

--- a/test/prompt.test.mjs
+++ b/test/prompt.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'assert';
+import runTest from './runTest.js';
+import { reset as resetFs, _state, calls as fsCalls } from './mocks/firestore.js';
+import { reset as resetNotif, calls as notifCalls } from './mocks/notifications.js';
+import { loadModule } from './loadModule.js';
+
+await runTest('savePrompt adds new document when none exists', async () => {
+  resetFs();
+  resetNotif();
+  const { savePrompt } = await loadModule('src/prompt.js');
+  await savePrompt('hello', 'u1');
+  const prompt = Object.values(_state).find((d) => d.text === 'hello');
+  assert(prompt);
+  assert.strictEqual(prompt.userId, 'u1');
+  assert.strictEqual(prompt.shareCount, 1);
+});
+
+await runTest('savePrompt updates existing prompt', async () => {
+  resetFs();
+  resetNotif();
+  const { collection, addDoc, doc: docFn } = await import('./mocks/firestore.js');
+  const ref = await addDoc(collection(null, 'prompts'), { text: 'hi', userId: 'u2', shareCount: 1, sharedBy: [] });
+  const { savePrompt } = await loadModule('src/prompt.js');
+  await savePrompt('hi', 'u2', 'cat');
+  const updated = _state[ref.path];
+  assert.strictEqual(updated.shareCount, 2);
+  assert.deepStrictEqual(updated.sharedBy, ['u2']);
+  assert.strictEqual(fsCalls.updateDoc.length, 1);
+});
+
+await runTest('likePrompt notifies owner when liked by others', async () => {
+  resetFs();
+  resetNotif();
+  const { collection, addDoc } = await import('./mocks/firestore.js');
+  const { sendNotification } = await import('./mocks/notifications.js');
+  const docRef = await addDoc(collection(null, 'prompts'), { userId: 'owner1', likes: 0, likedBy: [] });
+  const { likePrompt } = await loadModule('src/prompt.js');
+  await likePrompt(docRef.id, 'user2');
+  const updated = _state[docRef.path];
+  assert.strictEqual(updated.likes, 1);
+  assert.deepStrictEqual(updated.likedBy, ['user2']);
+  assert.strictEqual(notifCalls.length, 1);
+  assert.deepStrictEqual(notifCalls[0], ['owner1', { type: 'like', promptId: docRef.id, from: 'user2' }]);
+});
+
+await runTest('addComment stores comment and notifies owner', async () => {
+  resetFs();
+  resetNotif();
+  const { collection, addDoc } = await import('./mocks/firestore.js');
+  const promptRef = await addDoc(collection(null, 'prompts'), { userId: 'owner2', commentCount: 0 });
+  const { addComment } = await loadModule('src/prompt.js');
+  await addComment(promptRef.id, 'user3', 'nice');
+  const commentPath = `prompts/${promptRef.id}/comments`;
+  const comment = Object.entries(_state).find(([p]) => p.startsWith(commentPath));
+  assert(comment, 'comment created');
+  const updatedPrompt = _state[promptRef.path];
+  assert.strictEqual(updatedPrompt.commentCount, 1);
+  assert.strictEqual(notifCalls.length, 1);
+  assert.deepStrictEqual(notifCalls[0], ['owner2', { type: 'comment', promptId: promptRef.id, from: 'user3' }]);
+});

--- a/test/runTest.js
+++ b/test/runTest.js
@@ -1,0 +1,10 @@
+module.exports = async function runTest(name, fn) {
+  try {
+    await fn();
+    console.log(`\u2713 ${name}`);
+  } catch (err) {
+    console.error(`\u2717 ${name}`);
+    console.error(err);
+    process.exitCode = 1;
+  }
+};

--- a/test/user.test.mjs
+++ b/test/user.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import runTest from './runTest.js';
+import { reset as resetFs, _state } from './mocks/firestore.js';
+import { loadModule } from './loadModule.js';
+
+await runTest('setUserProfile stores profile info', async () => {
+  resetFs();
+  const { setUserProfile, getUserProfile } = await loadModule('src/user.js');
+  await setUserProfile('u1', { name: 'Alice', email: 'a@example.com', bio: 'hi' });
+  const profile = await getUserProfile('u1');
+  assert.strictEqual(profile.name, 'Alice');
+  assert.strictEqual(profile.email, 'a@example.com');
+  assert.strictEqual(profile.bio, 'hi');
+});
+
+await runTest('follow and unfollow user', async () => {
+  resetFs();
+  const { followUser, unfollowUser, isFollowing, getFollowerIds, getFollowingIds } = await loadModule('src/user.js');
+  await followUser('u1', 'u2');
+  assert.strictEqual(await isFollowing('u1', 'u2'), true);
+  assert.deepStrictEqual(await getFollowingIds('u1'), ['u2']);
+  assert.deepStrictEqual(await getFollowerIds('u2'), ['u1']);
+  await unfollowUser('u1', 'u2');
+  assert.strictEqual(await isFollowing('u1', 'u2'), false);
+});


### PR DESCRIPTION
## Summary
- create utilities to load ESM modules with stubbed dependencies
- add Firestore and Firebase mocks for unit testing
- test prompt functions `savePrompt`, `likePrompt`, and `addComment`
- test user profile and follow helpers
- run new test suites via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860678b2c70832f809779b61fa70b88