### PR TITLE
Upgrade DOMPurify to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "prompter",
       "version": "1.0.0",
       "dependencies": {
-        "dompurify": "^2.4.4"
+        "dompurify": "^3.2.6"
       },
       "devDependencies": {
         "@babel/cli": "^7.27.2",
@@ -2597,6 +2597,13 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -3460,10 +3467,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.4.tgz",
-      "integrity": "sha512-1e2SpqHiRx4DPvmRuXU5J0di3iQACwJM+mFGE2HAkkK7Tbnfk9WcghcAmyWc9CRrjyRRUpmuhPUH6LphQQR3EQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/domutils": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "jsdom": "^24.0.0"
   },
   "dependencies": {
-    "dompurify": "^2.4.4"
+    "dompurify": "^3.2.6"
   }
 }

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@2.4.4/dist/purify.es.js';
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.es.js';
 export const sanitizeHTML = (html) => DOMPurify.sanitize(html);
 export const setSanitizedHTML = (el, html) => {
   el.innerHTML = DOMPurify.sanitize(html);


### PR DESCRIPTION
## Summary
- bump dompurify to 3.x
- load DOMPurify 3.2.6 from CDN in sanitize helper
- update lockfile

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68606b549cb0832fa388d890ec6b9f04