### PR TITLE
Fix Firebase config path

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,7 +12,7 @@ export async function loadFirebaseConfig(retries = 3) {
   }
   while (retries > 0) {
     try {
-      const res = await fetch('/firebase.config.json');
+      const res = await fetch('firebase.config.json');
       if (!res.ok) throw new Error('Firebase configuration not found');
       const cfg = await res.json();
       window.firebaseConfig = cfg;


### PR DESCRIPTION
## Summary
- load firebase.config.json relative to base path so the site can be served from subdirectories

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68610814308c832fb758953c39aa994a