### PR TITLE
Fix firebase config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ disabled.
 
 Prompter uses Firebase Email/Password authentication. Provide your Firebase
 credentials in a `firebase.config.json` file that can be fetched relative to the
-deployed base URL (for example `https://example.com/app/firebase.config.json`)
+deployed base URL (for example `./firebase.config.json` when served from `https://example.com/app/`)
 or expose them via `window.firebaseConfig` before the scripts load.
 The JSON file should follow this structure:
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,7 +12,7 @@ export async function loadFirebaseConfig(retries = 3) {
   }
   while (retries > 0) {
     try {
-      const res = await fetch('firebase.config.json');
+      const res = await fetch('./firebase.config.json');
       if (!res.ok) throw new Error('Firebase configuration not found');
       const cfg = await res.json();
       window.firebaseConfig = cfg;


### PR DESCRIPTION
## Summary
- use a relative path when fetching `firebase.config.json`
- document the relative path for the Firebase config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68610cd3fa34832f859d1200c6b5ebb5