### PR TITLE
Fix Firebase initialization and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The JSON file should follow this structure:
 Enable that sign‑in method in your Firebase console and add your domain (for example `localhost`) to the list of authorized domains.
 Serve the app using a simple HTTP server such as `python3 -m http.server` so Firebase initializes correctly.
 Synchronization of saved prompts with Firebase requires a logged-in session. When not authenticated, prompts are only stored locally.
-Firestore caching is enabled via `enableIndexedDbPersistence`. Persistence errors are ignored so the app works even when offline caching cannot be activated.
+Firestore caching is enabled using `initializeFirestore` with `persistentLocalCache`. Persistence errors are ignored so the app works even when offline caching cannot be activated.
 
 ### Versioning
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -2,7 +2,8 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.1/firebas
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js';
 import {
   getFirestore,
-  enableIndexedDbPersistence,
+  initializeFirestore,
+  persistentLocalCache,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { pendingAuthCallbacks } from './auth.js';
 
@@ -55,8 +56,8 @@ export const firebaseReady = new Promise((resolve) => {
 export function initFirebase(config) {
   app = initializeApp(config);
   auth = getAuth(app);
+  initializeFirestore(app, { cache: persistentLocalCache() });
   db = getFirestore(app);
-  enableIndexedDbPersistence(db).catch(() => {});
   pendingAuthCallbacks.forEach((cb) => onAuthStateChanged(auth, cb));
   pendingAuthCallbacks.length = 0;
   readyResolve();

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.es.js';
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.min.js?module';
 export const sanitizeHTML = (html) => DOMPurify.sanitize(html);
 export const setSanitizedHTML = (el, html) => {
   el.innerHTML = DOMPurify.sanitize(html);

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,6 @@ const CACHE_NAME = `prompter-${CACHE_VERSION}`;
 const ASSETS = [
   '/',
   '404.html',
-  'blog',
   'blog.html',
   'css/app.css?v=73',
   'css/tailwind.css?v=73',
@@ -73,10 +72,8 @@ const ASSETS = [
   'login.html',
   'manifest.json?v=73',
   'privacy.html',
-  'pro',
   'pro.html',
   'profile.html',
-  'social',
   'social.html',
   'space.html',
   'src/auth.js?v=73',
@@ -140,7 +137,10 @@ const ASSETS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSETS))
+      .catch(() => {})
   );
   self.skipWaiting();
 });


### PR DESCRIPTION
## Summary
- update DOMPurify import path
- use `initializeFirestore` with `persistentLocalCache`
- document new Firestore caching method in README
- drop missing assets from service worker and handle caching errors

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68610e47bbe8832fa09026f80f1dfb5a