### PR TITLE
Fix Firebase and offline caching warnings

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,8 +1,8 @@
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js';
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js';
 import {
-  getFirestore,
-  enableIndexedDbPersistence,
+  initializeFirestore,
+  persistentLocalCache,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { pendingAuthCallbacks } from './auth.js';
 
@@ -55,8 +55,9 @@ export const firebaseReady = new Promise((resolve) => {
 export function initFirebase(config) {
   app = initializeApp(config);
   auth = getAuth(app);
-  db = getFirestore(app);
-  enableIndexedDbPersistence(db).catch(() => {});
+  db = initializeFirestore(app, {
+    cache: persistentLocalCache(),
+  });
   pendingAuthCallbacks.forEach((cb) => onAuthStateChanged(auth, cb));
   pendingAuthCallbacks.length = 0;
   readyResolve();

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.es.js';
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.es.mjs';
 export const sanitizeHTML = (html) => DOMPurify.sanitize(html);
 export const setSanitizedHTML = (el, html) => {
   el.innerHTML = DOMPurify.sanitize(html);

--- a/sw.js
+++ b/sw.js
@@ -140,7 +140,9 @@ const ASSETS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.allSettled(ASSETS.map((a) => cache.add(a)))
+    )
   );
   self.skipWaiting();
 });


### PR DESCRIPTION
## Summary
- load DOMPurify from the correct module path
- use the new Firestore `persistentLocalCache`
- ignore failures when pre-caching resources

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68610e47bbe8832fa09026f80f1dfb5a