### PR TITLE
Fix DOMPurify URL

### DIFF
--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.es.mjs';
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.6/+esm';
 export const sanitizeHTML = (html) => DOMPurify.sanitize(html);
 export const setSanitizedHTML = (el, html) => {
   el.innerHTML = DOMPurify.sanitize(html);


### PR DESCRIPTION
## Summary
- update DOMPurify URL to jsDelivr +esm build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686111d72598832f84edb05a96c427e7