### PR TITLE
Update Firestore initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The JSON file should follow this structure:
 Enable that sign‑in method in your Firebase console and add your domain (for example `localhost`) to the list of authorized domains.
 Serve the app using a simple HTTP server such as `python3 -m http.server` so Firebase initializes correctly.
 Synchronization of saved prompts with Firebase requires a logged-in session. When not authenticated, prompts are only stored locally.
-Firestore caching is enabled using `initializeFirestore` with `persistentLocalCache`. Persistence errors are ignored so the app works even when offline caching cannot be activated.
+Firestore caching is enabled using `initializeFirestore` with `persistentLocalCache({ tabManager: persistentMultipleTabManager() })`. Persistence errors are ignored so the app works even when offline caching cannot be activated.
 
 ### Versioning
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -4,6 +4,7 @@ import {
 
   initializeFirestore,
   persistentLocalCache,
+  persistentMultipleTabManager,
 } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js';
 import { pendingAuthCallbacks } from './auth.js';
 
@@ -57,7 +58,9 @@ export function initFirebase(config) {
   app = initializeApp(config);
   auth = getAuth(app);
   db = initializeFirestore(app, {
-    cache: persistentLocalCache(),
+    localCache: persistentLocalCache({
+      tabManager: persistentMultipleTabManager(),
+    }),
   });
   pendingAuthCallbacks.forEach((cb) => onAuthStateChanged(auth, cb));
   pendingAuthCallbacks.length = 0;


### PR DESCRIPTION
## Summary
- switch Firestore to use `persistentMultipleTabManager`
- mention new initialization method in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861151ffc74832f819997e49723fe05