### PR TITLE
Add localStorage caching for posts

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -544,6 +544,18 @@
       let followingIds = [];
       let prompterUser = null;
       let loadedPosts = [];
+      const BLOG_CACHE_KEY = 'blogCache';
+      const loadCachedPosts = () => {
+        try {
+          const cached = localStorage.getItem(BLOG_CACHE_KEY);
+          if (cached) {
+            loadedPosts = JSON.parse(cached);
+            filterAndRender();
+          }
+        } catch (err) {
+          console.warn('Failed to parse blog cache:', err);
+        }
+      };
       let unsubscribe = null;
 
       const refreshFollowing = async () => {
@@ -629,6 +641,11 @@
         unsubscribe = onSnapshot(q, (snap) => {
           loadedPosts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
           filterAndRender();
+          try {
+            localStorage.setItem(BLOG_CACHE_KEY, JSON.stringify(loadedPosts));
+          } catch (err) {
+            console.warn('Failed to store blog cache:', err);
+          }
         });
       };
 
@@ -639,6 +656,7 @@
 
       document.addEventListener('DOMContentLoaded', () => {
         const run = () => {
+          loadCachedPosts();
           onAuth(startListener);
           startListener();
         };

--- a/social.html
+++ b/social.html
@@ -904,6 +904,18 @@
       }
 
       let loadedPrompts = null;
+      const SOCIAL_CACHE_KEY = 'socialCache';
+      const loadCachedPrompts = () => {
+        try {
+          const cached = localStorage.getItem(SOCIAL_CACHE_KEY);
+          if (cached) {
+            loadedPrompts = JSON.parse(cached);
+            filterAndRender();
+          }
+        } catch (err) {
+          console.warn('Failed to parse social cache:', err);
+        }
+      };
 
       function filterAndRender() {
         if (loadedPrompts === null) return;
@@ -951,6 +963,11 @@
             if (loading.parentElement) loading.remove();
             let prompts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
             loadedPrompts = prompts;
+            try {
+              localStorage.setItem(SOCIAL_CACHE_KEY, JSON.stringify(prompts));
+            } catch (err) {
+              console.warn('Failed to store social cache:', err);
+            }
             if (prompts.length === 0) {
               list.innerHTML = '';
               const msg = document.createElement('p');
@@ -982,6 +999,7 @@
         onAuth((u) => {
           if (u) updateLastSocialVisit(u.uid, Date.now());
         });
+        loadCachedPrompts();
         promptSearch?.addEventListener('input', debouncedFilter);
         onAuth((u) => startListener(u));
       }

--- a/src/blog.js
+++ b/src/blog.js
@@ -41,13 +41,28 @@ export const createPost = async (
 };
 
 export const getAllPosts = async () => {
+  const cacheKey = 'blogCache';
+  try {
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+  } catch {
+    /* ignore */
+  }
   const q = query(
     collection(db, 'blogPosts'),
     where('shared', '==', true),
     orderBy('createdAt', 'desc')
   );
   const snap = await withRetry(() => getDocs(q));
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  const posts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  try {
+    localStorage.setItem(cacheKey, JSON.stringify(posts));
+  } catch {
+    /* ignore */
+  }
+  return posts;
 };
 
 export const likePost = async (postId, userId) => {

--- a/src/profile.js
+++ b/src/profile.js
@@ -450,10 +450,25 @@ const showSharedLoadError = (retryFn) => showLoadError('shared-list', retryFn);
 
 const loadPromptsForUser = async (user) => {
   if (!user) return;
+  const cacheKey = `profileCache_${user.uid}`;
+  try {
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      sharedPromptsData = JSON.parse(cached);
+      renderSharedPrompts(sharedPromptsData);
+    }
+  } catch (err) {
+    console.warn('Failed to parse profile cache:', err);
+  }
   try {
     const prompts = await getUserPrompts(user.uid);
     sharedPromptsData = prompts;
     renderSharedPrompts(sharedPromptsData);
+    try {
+      localStorage.setItem(cacheKey, JSON.stringify(prompts));
+    } catch (err) {
+      console.warn('Failed to store profile cache:', err);
+    }
   } catch (err) {
     console.error('Failed to load prompts:', err);
     showSharedLoadError(() => loadPromptsForUser(user));


### PR DESCRIPTION
## Summary
- implement profile cache so shared prompts show when offline
- read/write social prompt cache for faster load
- cache blog posts locally and load them on startup
- add caching to `getAllPosts` API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686121500700832f9792067afadc132c