### PR TITLE
Fix profile editing and caching

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -139,8 +139,8 @@
     </script>
     <script type="module" src="/src/version.js?v=74"></script>
     <link rel="preload" href="translations/ui/es.json?v=74" as="fetch" />
-    <link rel="preload" href="/src/init-app.js?v=74" as="script" />
-    <link rel="preload" href="/src/main.js?v=74" as="script" />
+    <link rel="preload" href="/src/init-app.js?v=74" as="script" crossorigin="anonymous" />
+    <link rel="preload" href="/src/main.js?v=74" as="script" crossorigin="anonymous" />
   </head>
   <body class="min-h-screen p-4">
     <noscript>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -12,6 +12,15 @@
       "collectionGroup": "prompts",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "sharedBy", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "prompts",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "shared", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]

--- a/fr/index.html
+++ b/fr/index.html
@@ -139,8 +139,8 @@
     </script>
     <script type="module" src="/src/version.js?v=74"></script>
     <link rel="preload" href="translations/ui/fr.json?v=74" as="fetch" />
-    <link rel="preload" href="/src/init-app.js?v=74" as="script" />
-    <link rel="preload" href="/src/main.js?v=74" as="script" />
+    <link rel="preload" href="/src/init-app.js?v=74" as="script" crossorigin="anonymous" />
+    <link rel="preload" href="/src/main.js?v=74" as="script" crossorigin="anonymous" />
   </head>
   <body class="min-h-screen p-4">
     <noscript>

--- a/hi/index.html
+++ b/hi/index.html
@@ -139,8 +139,8 @@
     </script>
     <script type="module" src="/src/version.js?v=74"></script>
     <link rel="preload" href="translations/ui/hi.json?v=74" as="fetch" />
-    <link rel="preload" href="/src/init-app.js?v=74" as="script" />
-    <link rel="preload" href="/src/main.js?v=74" as="script" />
+    <link rel="preload" href="/src/init-app.js?v=74" as="script" crossorigin="anonymous" />
+    <link rel="preload" href="/src/main.js?v=74" as="script" crossorigin="anonymous" />
   </head>
   <body class="min-h-screen p-4">
     <noscript>

--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@
     </script>
     <script type="module" src="/src/version.js?v=74"></script>
     <link rel="preload" href="translations/ui/en.json?v=74" as="fetch" />
-    <link rel="preload" href="/src/init-app.js?v=74" as="script" />
-    <link rel="preload" href="/src/main.js?v=74" as="script" />
+    <link rel="preload" href="/src/init-app.js?v=74" as="script" crossorigin="anonymous" />
+    <link rel="preload" href="/src/main.js?v=74" as="script" crossorigin="anonymous" />
   </head>
   <body class="min-h-screen p-4">
     <noscript>

--- a/src/profile.js
+++ b/src/profile.js
@@ -899,8 +899,6 @@ const renderSharedPrompts = async (prompts) => {
       'p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-white/50';
     editBtn.innerHTML =
       '<i data-lucide="pencil" class="w-4 h-4" aria-hidden="true"></i>';
-    // clicking the prompt text also starts editing
-    text.addEventListener('click', startEdit);
 
     const shareBtn = document.createElement('button');
     shareBtn.className =
@@ -974,6 +972,8 @@ const renderSharedPrompts = async (prompts) => {
         }
       });
     };
+
+    text.addEventListener('click', startEdit);
 
     editBtn.addEventListener('click', startEdit);
 

--- a/src/version.js
+++ b/src/version.js
@@ -25,23 +25,8 @@ export const startVersionCheck = async () => {
       currentManifestVersion &&
       newVersion !== currentManifestVersion
     ) {
-      if (!document.getElementById('update-banner')) {
-        const banner = document.createElement('div');
-        banner.id = 'update-banner';
-        banner.textContent = 'A new version is available.';
-        banner.style.cssText =
-          'background:#fef08a;color:#000;padding:8px;text-align:center;font-size:14px;position:sticky;top:0;z-index:1000;';
-        const btn = document.createElement('button');
-        btn.textContent = 'Refresh';
-        btn.style.cssText =
-          'margin-left:8px;text-decoration:underline;font-weight:bold;background:transparent;border:none;cursor:pointer;color:inherit;';
-        btn.addEventListener('click', () => {
-          clearServiceWorkersAndCaches();
-          location.reload();
-        });
-        banner.appendChild(btn);
-        document.body.prepend(banner);
-      }
+      clearServiceWorkersAndCaches();
+      location.reload();
     }
   }, 5 * 60 * 1000);
 };

--- a/sw.js
+++ b/sw.js
@@ -174,6 +174,11 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
+  const url = new URL(event.request.url);
+  if (url.origin !== location.origin) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(
       (cached) =>

--- a/tr/index.html
+++ b/tr/index.html
@@ -139,8 +139,8 @@
     </script>
     <script type="module" src="/src/version.js?v=74"></script>
     <link rel="preload" href="translations/ui/tr.json?v=74" as="fetch" />
-    <link rel="preload" href="/src/init-app.js?v=74" as="script" />
-    <link rel="preload" href="/src/main.js?v=74" as="script" />
+    <link rel="preload" href="/src/init-app.js?v=74" as="script" crossorigin="anonymous" />
+    <link rel="preload" href="/src/main.js?v=74" as="script" crossorigin="anonymous" />
   </head>
   <body class="min-h-screen p-4">
     <noscript>

--- a/zh/index.html
+++ b/zh/index.html
@@ -139,8 +139,8 @@
     </script>
     <script type="module" src="/src/version.js?v=74"></script>
     <link rel="preload" href="translations/ui/zh.json?v=74" as="fetch" />
-    <link rel="preload" href="/src/init-app.js?v=74" as="script" />
-    <link rel="preload" href="/src/main.js?v=74" as="script" />
+    <link rel="preload" href="/src/init-app.js?v=74" as="script" crossorigin="anonymous" />
+    <link rel="preload" href="/src/main.js?v=74" as="script" crossorigin="anonymous" />
   </head>
   <body class="min-h-screen p-4">
     <noscript>


### PR DESCRIPTION
## Summary
- fix reference error when editing prompts on profile page
- avoid caching cross-origin requests in service worker
- reload automatically when a new version is available
- ensure preload credentials match by setting `crossorigin` on links
- add Firestore index for shared prompts

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861649b6414832f93eb992d35cc48b4