### PR TITLE
Fix edit NotFoundError

### DIFF
--- a/social.html
+++ b/social.html
@@ -597,7 +597,8 @@
           const textarea = document.createElement('textarea');
           textarea.className = 'w-full p-2 rounded-md bg-black/30';
           textarea.value = p.text;
-          if (textWrap.contains(text)) textWrap.replaceChild(textarea, text);
+          if (!textWrap.contains(text)) return;
+          textWrap.replaceChild(textarea, text);
 
           const editRow = document.createElement('div');
           editRow.className = 'flex items-center gap-2 mt-2';
@@ -614,7 +615,8 @@
           editRow.appendChild(saveEdit);
           editRow.appendChild(cancelEdit);
 
-          if (card.contains(likeRow)) card.replaceChild(editRow, likeRow);
+          if (!card.contains(likeRow)) return;
+          card.replaceChild(editRow, likeRow);
           window.lucide?.createIcons();
 
           cancelEdit.addEventListener('click', () => {

--- a/src/profile.js
+++ b/src/profile.js
@@ -603,6 +603,7 @@ const renderSavedPrompts = (prompts) => {
       const textarea = document.createElement('textarea');
       textarea.className = 'w-full p-2 rounded-md bg-black/30';
       textarea.value = pEl.textContent;
+      if (!textWrap.contains(pEl)) return;
       textWrap.replaceChild(textarea, pEl);
 
       const editRow = document.createElement('div');
@@ -619,7 +620,8 @@ const renderSavedPrompts = (prompts) => {
         '<i data-lucide="x" class="w-4 h-4" aria-hidden="true"></i>';
       editRow.appendChild(saveEdit);
       editRow.appendChild(cancelEdit);
-      if (item.contains(actions)) item.replaceChild(editRow, actions);
+      if (!item.contains(actions)) return;
+      item.replaceChild(editRow, actions);
       // refresh icons for the new buttons
       window.lucide?.createIcons();
 
@@ -934,6 +936,7 @@ const renderSharedPrompts = async (prompts) => {
       const textarea = document.createElement('textarea');
       textarea.className = 'w-full p-2 rounded-md bg-black/30';
       textarea.value = p.text;
+      if (!textWrap.contains(text)) return;
       textWrap.replaceChild(textarea, text);
 
       const editRow = document.createElement('div');
@@ -951,7 +954,8 @@ const renderSharedPrompts = async (prompts) => {
       editRow.appendChild(saveEdit);
       editRow.appendChild(cancelEdit);
 
-      if (item.contains(likeRow)) item.replaceChild(editRow, likeRow);
+      if (!item.contains(likeRow)) return;
+      item.replaceChild(editRow, likeRow);
       // refresh icons for the new buttons
       window.lucide?.createIcons();
 


### PR DESCRIPTION
## Summary
- prevent `NotFoundError` when editing prompts by verifying DOM nodes before calling `replaceChild` in `social.html`
- add the same checks in `src/profile.js`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68617fa34d6c832fbf47d6ddd35c4bfb