### PR TITLE
Improve index error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,10 +245,10 @@ firebase deploy --only firestore:indexes
 ```
 
 Use a valid Firebase token when running the command above. Missing indexes will
-lead to empty results on the Social page until they are created.
-Firestore may take several minutes to build the indexes after deployment. During
-this period queries on the Social page can throw `failed-precondition` errors and
-show "Failed to load prompts."
+lead to "Could not load prompts" errors and empty results on the Social page
+until they are created. Firestore may take several minutes to build the indexes
+after deployment. During this period queries on the Social page can throw
+`failed-precondition` errors and show "Could not load prompts."
 
 If you encounter `Cannot read properties of undefined (reading 'onAuthStateChanged')` on the Social page, your Firebase configuration is missing. Create a `firebase.config.json` file (using `firebase.config.example.json` as a template) or set `window.firebaseConfig` before loading the scripts.
 

--- a/src/profile.js
+++ b/src/profile.js
@@ -434,6 +434,9 @@ const sharePrompt = (prompt, baseUrl) => {
 const LOAD_ERROR_MESSAGE =
   'Could not load prompts. Please check your connection.';
 
+const INDEX_ERROR_MESSAGE =
+  'Missing Firestore indexes. See README \u201cUpdating Firestore Indexes\u201d.';
+
 const showLoadError = (listId, retryFn) => {
   const list = document.getElementById(listId);
   if (!list) return;
@@ -498,6 +501,9 @@ const loadPromptsForUser = async (user) => {
     },
     (err) => {
       console.error('Failed to load prompts:', err);
+      if (err.code === 'failed-precondition') {
+        alert(INDEX_ERROR_MESSAGE);
+      }
       showSharedLoadError(() => loadPromptsForUser(user));
     },
   );
@@ -513,6 +519,9 @@ const loadPromptsForUser = async (user) => {
     renderSavedPrompts(appState.savedPrompts);
   } catch (err) {
     console.error('Failed to load prompts:', err);
+    if (err.code === 'failed-precondition') {
+      alert(INDEX_ERROR_MESSAGE);
+    }
     showSavedLoadError(() => loadPromptsForUser(user));
   }
 };


### PR DESCRIPTION
## Summary
- document that missing Firestore indexes cause `Could not load prompts` errors
- warn on `failed-precondition` in profile code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b88d8820832fbdde4d67600cc486