### PR TITLE
Ensure site always fetches latest version

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -29,6 +29,17 @@ export const startVersionCheck = async () => {
       location.reload();
     }
   }, 5 * 60 * 1000);
+  window.addEventListener('online', async () => {
+    const newVersion = await fetchManifestVersion();
+    if (
+      newVersion &&
+      currentManifestVersion &&
+      newVersion !== currentManifestVersion
+    ) {
+      clearServiceWorkersAndCaches();
+      location.reload();
+    }
+  });
 };
 
 export const clearServiceWorkersAndCaches = () => {


### PR DESCRIPTION
## Summary
- always fetch network resources first in the service worker
- reload when the browser goes online and a new manifest version is detected

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862ca7aa4ac832f9a3d3abd6cf574f7