### PR TITLE
Fix DOM replacement logic in edit functions

### DIFF
--- a/dist/profile.js
+++ b/dist/profile.js
@@ -614,7 +614,7 @@ var _renderSavedPrompts = function renderSavedPrompts(prompts) {
       textarea.className = 'w-full p-2 rounded-md bg-black/30';
       textarea.value = pEl.textContent;
       if (!textWrap.isConnected || !pEl.isConnected || !textWrap.contains(pEl)) return;
-      textWrap.replaceChild(textarea, pEl);
+      if (pEl.parentNode) pEl.parentNode.replaceChild(textarea, pEl);
       var editRow = document.createElement('div');
       editRow.className = 'flex items-center gap-2 mt-2';
       var saveEdit = document.createElement('button');
@@ -630,7 +630,7 @@ var _renderSavedPrompts = function renderSavedPrompts(prompts) {
       // refresh icons for the new buttons
       (_window$lucide = window.lucide) === null || _window$lucide === void 0 || _window$lucide.createIcons();
       cancelEdit.addEventListener('click', function () {
-        if (textWrap.contains(textarea)) textWrap.replaceChild(pEl, textarea);
+        if (textarea.parentNode) textarea.parentNode.replaceChild(pEl, textarea);
         if (item.contains(editRow)) item.replaceChild(actions, editRow);
         editing = false;
       });
@@ -909,7 +909,7 @@ var _renderSharedPrompts = /*#__PURE__*/function () {
                     textarea.className = 'w-full p-2 rounded-md bg-black/30';
                     textarea.value = p.text;
                     if (!textWrap.isConnected || !text.isConnected || !textWrap.contains(text)) return;
-                    textWrap.replaceChild(textarea, text);
+                    if (text.parentNode) text.parentNode.replaceChild(textarea, text);
                     var editRow = document.createElement('div');
                     editRow.className = 'flex items-center gap-2 mt-2';
                     var saveEdit = document.createElement('button');
@@ -925,7 +925,7 @@ var _renderSharedPrompts = /*#__PURE__*/function () {
                     // refresh icons for the new buttons
                     (_window$lucide4 = window.lucide) === null || _window$lucide4 === void 0 || _window$lucide4.createIcons();
                     cancelEdit.addEventListener('click', function () {
-                      if (textWrap.contains(textarea)) textWrap.replaceChild(text, textarea);
+                      if (textarea.parentNode) textarea.parentNode.replaceChild(text, textarea);
                       if (item.contains(editRow)) item.replaceChild(likeRow, editRow);
                       editing = false;
                     });

--- a/social.html
+++ b/social.html
@@ -597,7 +597,7 @@
           const textarea = document.createElement('textarea');
           textarea.className = 'w-full p-2 rounded-md bg-black/30';
           textarea.value = p.text;
-          if (textWrap.contains(text)) textWrap.replaceChild(textarea, text);
+          if (text.parentNode) text.parentNode.replaceChild(textarea, text);
 
           const editRow = document.createElement('div');
           editRow.className = 'flex items-center gap-2 mt-2';
@@ -618,8 +618,8 @@
           window.lucide?.createIcons();
 
           cancelEdit.addEventListener('click', () => {
-            if (textWrap.contains(textarea))
-              textWrap.replaceChild(text, textarea);
+            if (textarea.parentNode)
+              textarea.parentNode.replaceChild(text, textarea);
             if (card.contains(editRow)) card.replaceChild(likeRow, editRow);
             editing = false;
           });

--- a/src/profile.js
+++ b/src/profile.js
@@ -606,7 +606,7 @@ const renderSavedPrompts = (prompts) => {
       textarea.value = pEl.textContent;
       if (!textWrap.isConnected || !pEl.isConnected || !textWrap.contains(pEl))
         return;
-      textWrap.replaceChild(textarea, pEl);
+      if (pEl.parentNode) pEl.parentNode.replaceChild(textarea, pEl);
 
       const editRow = document.createElement('div');
       editRow.className = 'flex items-center gap-2 mt-2';
@@ -628,7 +628,7 @@ const renderSavedPrompts = (prompts) => {
       window.lucide?.createIcons();
 
       cancelEdit.addEventListener('click', () => {
-        if (textWrap.contains(textarea)) textWrap.replaceChild(pEl, textarea);
+        if (textarea.parentNode) textarea.parentNode.replaceChild(pEl, textarea);
         if (item.contains(editRow)) item.replaceChild(actions, editRow);
         editing = false;
       });
@@ -930,7 +930,7 @@ const renderSharedPrompts = async (prompts) => {
       textarea.value = p.text;
       if (!textWrap.isConnected || !text.isConnected || !textWrap.contains(text))
         return;
-      textWrap.replaceChild(textarea, text);
+      if (text.parentNode) text.parentNode.replaceChild(textarea, text);
 
       const editRow = document.createElement('div');
       editRow.className = 'flex items-center gap-2 mt-2';
@@ -953,7 +953,7 @@ const renderSharedPrompts = async (prompts) => {
       window.lucide?.createIcons();
 
       cancelEdit.addEventListener('click', () => {
-        if (textWrap.contains(textarea)) textWrap.replaceChild(text, textarea);
+        if (textarea.parentNode) textarea.parentNode.replaceChild(text, textarea);
         if (item.contains(editRow)) item.replaceChild(likeRow, editRow);
         editing = false;
       });


### PR DESCRIPTION
## Summary
- correctly replace prompt textareas in saved/shared prompts
- update compiled assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862dff88600832f80c3123886e1f75d