### PR TITLE
Toggle full sentence prompts per category

### DIFF
--- a/dist/prompts.js
+++ b/dist/prompts.js
@@ -300,7 +300,7 @@ var loadFullSentences = exports.loadFullSentences = /*#__PURE__*/function () {
 }();
 var generatePrompt = exports.generatePrompt = /*#__PURE__*/function () {
   var _ref3 = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee3() {
-    var selectedCatId, isRandom, sentences, prompt, availableCategories, categoryData, promptParts, newPrompt;
+    var toggleKey, useFullSentence, selectedCatId, isRandom, sentences, prompt, availableCategories, categoryData, promptParts, newPrompt;
     return _regenerator().w(function (_context3) {
       while (1) switch (_context3.n) {
         case 0:
@@ -311,13 +311,11 @@ var generatePrompt = exports.generatePrompt = /*#__PURE__*/function () {
           throw new Error('offline');
         case 1:
           _state.appState.isGenerating = true;
+          toggleKey = _state.appState.selectedCategory;
+          useFullSentence = !!_state.appState.useFullSentenceNext[toggleKey];
           selectedCatId = _state.appState.selectedCategory;
           isRandom = selectedCatId === 'random';
-          if (!isRandom) {
-            _context3.n = 4;
-            break;
-          }
-          if (!_state.appState.useFullSentenceNext) {
+          if (!useFullSentence) {
             _context3.n = 3;
             break;
           }
@@ -328,29 +326,29 @@ var generatePrompt = exports.generatePrompt = /*#__PURE__*/function () {
           prompt = getRandomElement(sentences);
           _state.appState.generatedPrompt = prompt;
           _state.appState.isGenerating = false;
-          _state.appState.useFullSentenceNext = false;
+          _state.appState.useFullSentenceNext[toggleKey] = !useFullSentence;
           return _context3.a(2, {
             prompt: prompt,
-            categoryId: 'random'
+            categoryId: isRandom ? 'random' : selectedCatId
           });
         case 3:
-          availableCategories = categories.filter(function (c) {
-            return c.id !== 'random';
-          });
-          selectedCatId = availableCategories[Math.floor(Math.random() * availableCategories.length)].id;
-          _state.appState.useFullSentenceNext = true;
-        case 4:
-          _context3.n = 5;
+          if (isRandom) {
+            availableCategories = categories.filter(function (c) {
+              return c.id !== 'random';
+            });
+            selectedCatId = availableCategories[Math.floor(Math.random() * availableCategories.length)].id;
+          }
+          _context3.n = 4;
           return loadCategory(_state.appState.language, selectedCatId);
-        case 5:
+        case 4:
           categoryData = _context3.v;
           if (!(!categoryData || !categoryData.parts || !Array.isArray(categoryData.parts))) {
-            _context3.n = 6;
+            _context3.n = 5;
             break;
           }
           _state.appState.isGenerating = false;
           throw new Error('Invalid category data');
-        case 6:
+        case 5:
           promptParts = categoryData.parts.map(function (partArray, idx) {
             if (!_state.appState.partHistory[idx]) {
               _state.appState.partHistory[idx] = [];
@@ -365,6 +363,7 @@ var generatePrompt = exports.generatePrompt = /*#__PURE__*/function () {
           newPrompt = categoryData.structure ? categoryData.structure(promptParts) : promptParts.join(' ');
           _state.appState.generatedPrompt = newPrompt;
           _state.appState.isGenerating = false;
+          _state.appState.useFullSentenceNext[toggleKey] = !useFullSentence;
           return _context3.a(2, {
             prompt: newPrompt,
             categoryId: isRandom ? 'random' : selectedCatId

--- a/dist/state.js
+++ b/dist/state.js
@@ -19,7 +19,9 @@ var readLocal = function readLocal(key, fallback) {
 var appState = exports.appState = {
   generatedPrompt: '',
   selectedCategory: 'random',
-  useFullSentenceNext: false,
+  // tracks whether each category should use a full sentence prompt next
+  // { [categoryId]: boolean }
+  useFullSentenceNext: {},
   isGenerating: false,
   copySuccess: false,
   language: 'en',

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -256,24 +256,26 @@ export const generatePrompt = async () => {
     throw new Error('offline');
   }
   appState.isGenerating = true;
+  const toggleKey = appState.selectedCategory;
+  const useFullSentence = !!appState.useFullSentenceNext[toggleKey];
   let selectedCatId = appState.selectedCategory;
   const isRandom = selectedCatId === 'random';
 
+  if (useFullSentence) {
+    const sentences = await loadFullSentences(appState.language);
+    const prompt = getRandomElement(sentences);
+    appState.generatedPrompt = prompt;
+    appState.isGenerating = false;
+    appState.useFullSentenceNext[toggleKey] = !useFullSentence;
+    return { prompt, categoryId: isRandom ? 'random' : selectedCatId };
+  }
+
   if (isRandom) {
-    if (appState.useFullSentenceNext) {
-      const sentences = await loadFullSentences(appState.language);
-      const prompt = getRandomElement(sentences);
-      appState.generatedPrompt = prompt;
-      appState.isGenerating = false;
-      appState.useFullSentenceNext = false;
-      return { prompt, categoryId: 'random' };
-    }
     const availableCategories = categories.filter((c) => c.id !== 'random');
     selectedCatId =
       availableCategories[
         Math.floor(Math.random() * availableCategories.length)
       ].id;
-    appState.useFullSentenceNext = true;
   }
 
   const categoryData = await loadCategory(appState.language, selectedCatId);
@@ -304,5 +306,6 @@ export const generatePrompt = async () => {
 
   appState.generatedPrompt = newPrompt;
   appState.isGenerating = false;
+  appState.useFullSentenceNext[toggleKey] = !useFullSentence;
   return { prompt: newPrompt, categoryId: isRandom ? 'random' : selectedCatId };
 };

--- a/src/state.js
+++ b/src/state.js
@@ -12,7 +12,9 @@ const readLocal = (key, fallback) => {
 export const appState = {
   generatedPrompt: '',
   selectedCategory: 'random',
-  useFullSentenceNext: false,
+  // tracks whether each category should use a full sentence prompt next
+  // { [categoryId]: boolean }
+  useFullSentenceNext: {},
   isGenerating: false,
   copySuccess: false,
   language: 'en',


### PR DESCRIPTION
## Summary
- track full sentence mode per category
- alternate full sentence prompts for each category
- rebuild distribution files

## Testing
- `npm test`
- `node test/toggle_test.mjs` (manual verification of alternating behavior)

------
https://chatgpt.com/codex/tasks/task_e_68650feb4fa4832fbcc79551dff25ca5