### PR TITLE
Add HTML alt checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Prompter web application",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . && node scripts/check-alt.js",
     "format": "prettier --write \"**/*.{js,json,md,css,html}\"",
     "prepare": "husky install",
     "pretest": "node scripts/check-node-modules.js",

--- a/scripts/check-alt.js
+++ b/scripts/check-alt.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const rootDir = path.join(__dirname, '..');
+
+function getHtmlFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') return [];
+      return getHtmlFiles(res);
+    }
+    return entry.isFile() && entry.name.endsWith('.html') ? [res] : [];
+  });
+}
+
+let hasErrors = false;
+for (const file of getHtmlFiles(rootDir)) {
+  const html = fs.readFileSync(file, 'utf8');
+  const dom = new JSDOM(html);
+  const missing = [...dom.window.document.querySelectorAll('img:not([alt])')];
+  if (missing.length) {
+    missing.forEach((img) => {
+      console.error(
+        `${path.relative(rootDir, file)} missing alt: ${img.outerHTML}`
+      );
+    });
+    hasErrors = true;
+  }
+}
+
+if (hasErrors) {
+  process.exitCode = 1;
+} else {
+  console.log('All images have alt attributes.');
+}


### PR DESCRIPTION
## Summary
- add `scripts/check-alt.js` to find `<img>` tags without alt text
- run the check as part of `npm run lint`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686513d687e0832fbe2a6b1fa4e9ca2d