### PR TITLE
Add preconnect hints

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -9,6 +9,8 @@
     />
     <title>Space - Prompter</title>
     <base href="./" />
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
     <link rel="manifest" href="manifest.json?v=80" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
     />
     <title>Prompter - AI Prompt Generator</title>
     <base href="./" />
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=80" />
     <link rel="manifest" href="manifest.json?v=80" />
     <meta name="theme-color" content="#000000" />

--- a/social.html
+++ b/social.html
@@ -9,6 +9,8 @@
     />
     <title>Prompter Social</title>
     <base href="./" />
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
     <link rel="manifest" href="manifest.json?v=80" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/templates/blog.template.html
+++ b/templates/blog.template.html
@@ -9,6 +9,8 @@
     />
     <title>Space - Prompter</title>
     <base href="{{BASE_HREF}}" />
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
     <link rel="manifest" href="manifest.json?v=80" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/templates/index.template.html
+++ b/templates/index.template.html
@@ -27,6 +27,8 @@
     />
     <title>Prompter - AI Prompt Generator</title>
     <base href="{{BASE_HREF}}" />
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
     <link rel="icon" type="image/svg+xml" href="/icons/logo.svg?v=80" />
     <link rel="manifest" href="manifest.json?v=80" />
     <meta name="theme-color" content="#000000" />

--- a/templates/social.template.html
+++ b/templates/social.template.html
@@ -9,6 +9,8 @@
     />
     <title>Prompter Social</title>
     <base href="{{BASE_HREF}}" />
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
     <link rel="manifest" href="manifest.json?v=80" />
     <meta name="theme-color" content="#000000" />
     <meta


### PR DESCRIPTION
## Summary
- optimize initial connection to external hosts
- insert preconnect hints for unpkg.com and gstatic.com in templates
- keep generated HTML in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865172769f4832fb2e866566576a60a