### PR TITLE
Fix blog initialization

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -620,15 +620,20 @@
         prompterFilter?.addEventListener(evt, startListener);
       });
 
-      document.addEventListener('DOMContentLoaded', () => {
-        const run = () => {
-          loadCache();
-          onAuth(startListener);
-          startListener();
-        };
+      const run = () => {
+        loadCache();
+        onAuth(startListener);
+        startListener();
+      };
+      if (document.readyState !== 'loading') {
         if (window.firebaseInitPromise) window.firebaseInitPromise.then(run);
         else run();
-      });
+      } else {
+        document.addEventListener('DOMContentLoaded', () => {
+          if (window.firebaseInitPromise) window.firebaseInitPromise.then(run);
+          else run();
+        });
+      }
     </script>
   </body>
 </html>

--- a/test/blog-devtools.js
+++ b/test/blog-devtools.js
@@ -1,0 +1,36 @@
+const puppeteer = require('puppeteer');
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--ignore-certificate-errors'],
+  });
+  const page = await browser.newPage();
+  const errors = [];
+  page.on('pageerror', err => {
+    errors.push('Page error: ' + err.message);
+  });
+  const requests = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      errors.push('Console error: ' + msg.text());
+    }
+  });
+  page.on('requestfailed', req => {
+    errors.push('Request failed: ' + req.url() + ' ' + req.failure().errorText);
+  });
+  page.on('requestfinished', req => {
+    requests.push(req.url());
+  });
+  await page.goto('http://localhost:8000/blog.html', {waitUntil: 'networkidle0'});
+  await new Promise(r => setTimeout(r, 3000));
+  console.log('loaded');
+  ['http://localhost:8000/src/blog.js',
+   'http://localhost:8000/src/init-app.js',
+   'http://localhost:8000/firebase.config.json'].forEach(url => {
+    if (!requests.some(r => r.startsWith(url))) {
+      errors.push('Missing request: ' + url);
+    }
+  });
+  errors.forEach(e => console.log(e));
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- ensure initialization runs even when DOMContentLoaded already fired
- add puppeteer-based devtools script to capture missing network requests

## Testing
- `node test/blog-devtools.js > /tmp/blog-test.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_686798a1937c832fafe08eb56e32d4a5