### PR TITLE
Handle missing Firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Enable that sign‑in method in your Firebase console and add your domain (for e
 Serve the app using a simple HTTP server such as `python3 -m http.server` so Firebase initializes correctly.
 Synchronization of saved prompts with Firebase requires a logged-in session. When not authenticated, prompts are only stored locally.
 Firestore caching is enabled using `initializeFirestore` with `persistentLocalCache({ tabManager: persistentMultipleTabManager() })`. Persistence errors are ignored so the app works even when offline caching cannot be activated.
+If `firebase.config.json` cannot be fetched, a red banner reading "Missing Firebase configuration" appears at the top of the page and the Social and Profile pages skip their initialization.
 
 ### Versioning
 
@@ -269,7 +270,7 @@ The entry in `firestore.indexes.json` looks like:
 }
 ```
 
-If you encounter `Cannot read properties of undefined (reading 'onAuthStateChanged')` on the Social page, your Firebase configuration is missing. Create a `firebase.config.json` file (using `firebase.config.example.json` as a template) or set `window.firebaseConfig` before loading the scripts.
+If you encounter `Cannot read properties of undefined (reading 'onAuthStateChanged')` on the Social page, your Firebase configuration is missing. Create a `firebase.config.json` file (using `firebase.config.example.json` as a template) or set `window.firebaseConfig` before loading the scripts. When the file cannot be loaded, a "Missing Firebase configuration" banner is shown.
 
 ## CLI and script credentials
 

--- a/es/social.html
+++ b/es/social.html
@@ -983,7 +983,8 @@
       }
 
       document.addEventListener('DOMContentLoaded', () => {
-        if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+        if (window.firebaseInitPromise)
+          window.firebaseInitPromise.then(init).catch(() => {});
         else init();
       });
     </script>

--- a/fr/social.html
+++ b/fr/social.html
@@ -983,7 +983,8 @@
       }
 
       document.addEventListener('DOMContentLoaded', () => {
-        if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+        if (window.firebaseInitPromise)
+          window.firebaseInitPromise.then(init).catch(() => {});
         else init();
       });
     </script>

--- a/hi/social.html
+++ b/hi/social.html
@@ -983,7 +983,8 @@
       }
 
       document.addEventListener('DOMContentLoaded', () => {
-        if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+        if (window.firebaseInitPromise)
+          window.firebaseInitPromise.then(init).catch(() => {});
         else init();
       });
     </script>

--- a/social.html
+++ b/social.html
@@ -983,7 +983,8 @@
       }
 
       document.addEventListener('DOMContentLoaded', () => {
-        if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+        if (window.firebaseInitPromise)
+          window.firebaseInitPromise.then(init).catch(() => {});
         else init();
       });
     </script>

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -23,6 +23,24 @@ export async function loadFirebaseConfig(retries = 3) {
       retries -= 1;
       if (!retries) {
         console.error('Failed to load Firebase config:', err);
+        const showBanner = () => {
+          if (document.getElementById('firebase-config-error')) return;
+          const banner = document.createElement('div');
+          banner.id = 'firebase-config-error';
+          banner.textContent = 'Missing Firebase configuration.';
+          banner.style.background = '#dc2626';
+          banner.style.color = '#fff';
+          banner.style.padding = '8px';
+          banner.style.textAlign = 'center';
+          banner.style.position = 'fixed';
+          banner.style.top = '0';
+          banner.style.left = '0';
+          banner.style.right = '0';
+          banner.style.zIndex = '1000';
+          document.body.prepend(banner);
+        };
+        if (document.body) showBanner();
+        else document.addEventListener('DOMContentLoaded', showBanner, { once: true });
         return null;
       }
       await new Promise((r) => setTimeout(r, 1000));

--- a/src/init-app.js
+++ b/src/init-app.js
@@ -8,6 +8,7 @@ export let analytics;
 
 export const firebaseInitPromise = loadFirebaseConfig()
   .then((config) => {
+    if (!config) throw new Error('Missing Firebase config');
     initFirebase(config);
     analytics = getAnalytics(app);
     return new Promise((resolve) => {
@@ -30,6 +31,7 @@ export const firebaseInitPromise = loadFirebaseConfig()
   })
   .catch((err) => {
     console.error('Failed to initialize Firebase:', err);
+    throw err;
   });
 
 window.firebaseInitPromise = firebaseInitPromise;

--- a/src/profile.js
+++ b/src/profile.js
@@ -1518,6 +1518,7 @@ const init = () => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+  if (window.firebaseInitPromise)
+    window.firebaseInitPromise.then(init).catch(() => {});
   else init();
 });

--- a/tr/social.html
+++ b/tr/social.html
@@ -983,7 +983,8 @@
       }
 
       document.addEventListener('DOMContentLoaded', () => {
-        if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+        if (window.firebaseInitPromise)
+          window.firebaseInitPromise.then(init).catch(() => {});
         else init();
       });
     </script>

--- a/zh/social.html
+++ b/zh/social.html
@@ -983,7 +983,8 @@
       }
 
       document.addEventListener('DOMContentLoaded', () => {
-        if (window.firebaseInitPromise) window.firebaseInitPromise.then(init);
+        if (window.firebaseInitPromise)
+          window.firebaseInitPromise.then(init).catch(() => {});
         else init();
       });
     </script>


### PR DESCRIPTION
## Summary
- show an error banner when firebase configuration cannot be loaded
- reject firebase init promise on missing config
- skip init on profile and social pages if firebase init fails
- document new behaviour in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d930e516c832fbd329f0c69a608fe