### PR TITLE
Add back link to social pages

### DIFF
--- a/es/social.html
+++ b/es/social.html
@@ -77,6 +77,19 @@
     >
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
+          <a
+            id="back-link"
+            href="/"
+            class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Back"
+            aria-label="Back"
+          >
+            <span
+              class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+              aria-hidden="true"
+              >&larr;</span
+            >
+          </a>
           <img
             src="/icons/logo.svg?v=92"
             alt="Prompter logo"

--- a/fr/social.html
+++ b/fr/social.html
@@ -77,6 +77,19 @@
     >
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
+          <a
+            id="back-link"
+            href="/"
+            class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Back"
+            aria-label="Back"
+          >
+            <span
+              class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+              aria-hidden="true"
+              >&larr;</span
+            >
+          </a>
           <img
             src="/icons/logo.svg?v=92"
             alt="Prompter logo"

--- a/hi/social.html
+++ b/hi/social.html
@@ -77,6 +77,19 @@
     >
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
+          <a
+            id="back-link"
+            href="/"
+            class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Back"
+            aria-label="Back"
+          >
+            <span
+              class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+              aria-hidden="true"
+              >&larr;</span
+            >
+          </a>
           <img
             src="/icons/logo.svg?v=92"
             alt="Prompter logo"

--- a/social.html
+++ b/social.html
@@ -77,6 +77,19 @@
     >
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
+          <a
+            id="back-link"
+            href="/"
+            class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Back"
+            aria-label="Back"
+          >
+            <span
+              class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+              aria-hidden="true"
+              >&larr;</span
+            >
+          </a>
           <img
             src="/icons/logo.svg?v=92"
             alt="Prompter logo"

--- a/tr/social.html
+++ b/tr/social.html
@@ -77,6 +77,19 @@
     >
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
+          <a
+            id="back-link"
+            href="/"
+            class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Back"
+            aria-label="Back"
+          >
+            <span
+              class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+              aria-hidden="true"
+              >&larr;</span
+            >
+          </a>
           <img
             src="/icons/logo.svg?v=92"
             alt="Prompter logo"

--- a/zh/social.html
+++ b/zh/social.html
@@ -77,6 +77,19 @@
     >
       <header class="flex items-center justify-between w-full mt-4 mb-6">
         <div class="flex items-center gap-2">
+          <a
+            id="back-link"
+            href="/"
+            class="p-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50"
+            title="Back"
+            aria-label="Back"
+          >
+            <span
+              class="w-6 h-6 inline-flex items-center justify-center text-3xl"
+              aria-hidden="true"
+              >&larr;</span
+            >
+          </a>
           <img
             src="/icons/logo.svg?v=92"
             alt="Prompter logo"


### PR DESCRIPTION
## Summary
- add a back button before the logo in all `social.html` pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d9869df28832f97a3d7a0a9607c80